### PR TITLE
Adding documentation for API to get activities by paymentRequestID

### DIFF
--- a/src/api/payment-requests/payment-activities.md
+++ b/src/api/payment-requests/payment-activities.md
@@ -59,7 +59,7 @@ Payment Activities are created when a Payment Request has been **created**, **pa
 
 ## Operations
 
-### List Payment Activities **EXPERIMENTAL**
+### List Payment Activities For Merchant **EXPERIMENTAL**
 
 List payment activities for a merchant. Results are [paginated][] and ordered by
 descending activity created date.
@@ -88,6 +88,64 @@ descending activity created date.
 {% json %}
 {
   "nextPageKey": "PaymentRequest#E9eXsErwA444qFDoZt5iLA|Activity#000000000000001|614161c4c4d3020073bd4ce8|2021-09-15T03:00:21.156Z",
+  "items": [
+    {
+      "type": "refund",
+      "value": { "currency": "NZD", "amount": "600" },
+      "assetType": "centrapay.nzd.main",
+      "paymentRequestId": "MhocUmpxxmgdHjr7DgKoKw",
+      "merchantName": "Centrapay Café",
+      "merchantId": "5ee0c486308f590260d9a07f",
+      "merchantAccountId": "C4QnjXvj8At6SMsEN4LRi9",
+      "merchantConfigId": "5ee168e8597be5002af7b454",
+      "createdAt": "2021-06-12T01:17:00.000Z",
+      "createdBy": "da75ad90-9a5b-4df0-8374-f48b3a8fbfcc",
+      "createdBy": "crn::user:0af834c8-1110-11ec-9072-3e22fb52e878",
+      "paymentRequestCreatedBy": "crn::user:0af834c8-1110-11ec-9072-3e22fb52e878"
+    },
+    {
+      "type": "payment",
+      "value": { "currency": "NZD", "amount": "6190" },
+      "assetType": "centrapay.nzd.main",
+      "paymentRequestId": "MhocUmpxxmgdHjr7DgKoKw",
+      "merchantName": "Centrapay Café",
+      "merchantId": "5ee0c486308f590260d9a07f",
+      "merchantAccountId": "C4QnjXvj8At6SMsEN4LRi9",
+      "merchantConfigId": "5ee168e8597be5002af7b454",
+      "createdAt": "2021-06-12T01:16:00.000Z",
+      "createdBy": "crn::user:da75ad90-9a5b-4df0-8374-f48b3a8fbfcc",
+      "paymentRequestCreatedBy": "crn::user:0af834c8-1110-11ec-9072-3e22fb52e878"
+    },
+    {
+      "type": "request",
+      "value": { "currency": "NZD", "amount": "6190" },
+      "paymentRequestId": "MhocUmpxxmgdHjr7DgKoKw",
+      "merchantName": "Centrapay Café",
+      "merchantId": "5ee0c486308f590260d9a07f",
+      "merchantAccountId": "C4QnjXvj8At6SMsEN4LRi9",
+      "merchantConfigId": "5ee168e8597be5002af7b454",
+      "createdAt": "2021-06-12T01:15:46.000Z",
+      "createdBy": "crn::user:0af834c8-1110-11ec-9072-3e22fb52e878",
+      "paymentRequestCreatedBy": "crn::user:0af834c8-1110-11ec-9072-3e22fb52e878"
+    }
+  ]
+}
+{% endjson %}
+
+### List Payment Activities For Payment Request **EXPERIMENTAL**
+
+List payment activities for a payment request. Results are ordered by
+descending activity created date.
+
+{% reqspec %}
+  GET '/api/payment-requests/{paymentRequestId}/activities'
+  auth 'jwt'
+  path_param 'paymentRequestId', 'MhocUmpxxmgdHjr7DgKoKw'
+{% endreqspec %}
+
+{% h4 Example response payload %}
+{% json %}
+{
   "items": [
     {
       "type": "refund",


### PR DESCRIPTION
For payment request view story we must be able to get the activities of a payment request.
This is needed to show the activity feed on the sale and the refund screens.