### PR TITLE
Add note to list assets and get assets that only active assets are returned

### DIFF
--- a/src/api/assets/assets.md
+++ b/src/api/assets/assets.md
@@ -161,7 +161,7 @@ Tokens have the following fields along with the base asset fields.
 
 ### List Assets for Account
 
-Returns a [paginated][] list of Assets for an account.
+Returns a [paginated][] list of Assets for an account. This will only return active assets.
 
 {% reqspec %}
   GET '/api/accounts/{accountId}/assets'


### PR DESCRIPTION
As part of updating asset pk and sk it was found that only active assets are returned by GET /api/accounts/{accountId}/assets and GET /api/assets/{assetId} apis. Updated documentation to reflect this.