### PR TITLE
Update balance to availableBalance for asset APIs

### DIFF
--- a/src/api/assets/assets.md
+++ b/src/api/assets/assets.md
@@ -40,16 +40,17 @@ specific to its category.
 
 {% h4 Required Fields %}
 
-| Field       | Type               | Description                                           |
-|:------------|:-------------------|:------------------------------------------------------|
-| id          | String             | The Asset's unique identifier.                        |
-| accountId   | String             | The Asset's owning Centrapay Account id.              |
-| category    | String             | Asset category ("Money", "Giftcard", or "Token").     |
-| type        | String             | [Asset Type][] id used by payment option asset types. |
-| liveness    | String             | Either "main" (live payments allowed) or "test".      |
-| description | String             | Displayable asset description.                        |
-| createdAt   | {% dt Timestamp %} | Date when the asset was created or issued.            |
-| status      | String             | "active" if the asset can be used for payments.       |
+| Field             | Type               | Description                                                            |
+|:------------------|:-------------------|:-----------------------------------------------------------------------|
+| id                | String             | The Asset's unique identifier.                                         |
+| accountId         | String             | The Asset's owning Centrapay Account id.                               |
+| category          | String             | Asset category ("Money", "Giftcard", or "Token").                      |
+| type              | String             | [Asset Type][] id used by payment option asset types.                  |
+| liveness          | String             | Either "main" (live payments allowed) or "test".                       |
+| description       | String             | Displayable asset description.                                         |
+| createdAt         | {% dt Timestamp %} | Date when the asset was created or issued.                             |
+| status            | String             | "active" if the asset can be used for payments.                        |
+| availableBalance  | {% dt BigNumber %} | The balance of the asset that is available for transfers or purchases. |
 
 
 <a name="money">
@@ -153,6 +154,7 @@ Tokens have the following fields along with the base asset fields.
   "productCode": "23403",
   "initialBalance": "6000",
   "balance": "6000",
+  "availableBalance": "6000",
   "balanceUpdatedAt": "2021-01-01T00:00:00.000Z",
   "expiresAt": "2020-12-31T00:00:00.000Z",
   "createdAt": "2020-05-01T12:30:00.000Z"
@@ -185,6 +187,7 @@ Returns a [paginated][] list of Assets for an account. This will only return act
       "productCode": "23403",
       "initialBalance": "6000",
       "balance": "6000",
+      "availableBalance": "6000",
       "balanceUpdatedAt": "2021-01-01T00:00:00.000Z",
       "expiresAt": "2020-12-31T00:00:00.000Z",
       "createdAt": "2020-05-01T12:30:00.000Z"

--- a/src/api/assets/external-assets.md
+++ b/src/api/assets/external-assets.md
@@ -71,6 +71,7 @@ Load an asset from a supported third-party issuer. Asset details will be obtaine
   "currency": "NZD",
   "initialBalance": "7000",
   "balance": "6000",
+  "availableBalance": "6000",
   "balanceUpdatedAt": "2020-06-10T15:30:00.000Z",
   "expiresAt": "2020-12-31T00:00:00.000Z",
   "createdAt": "2020-05-01T12:30:00.000Z"

--- a/src/api/assets/wallets.md
+++ b/src/api/assets/wallets.md
@@ -68,7 +68,8 @@ send money from this Wallet.
   "createdAt": "2021-01-01T00:00:00.000Z",
   "status": "active",
   "currency": "NZD",
-  "balance": "0"
+  "balance": "0",
+  "availableBalance": "6000"
 }
 {% endjson %}
 
@@ -86,6 +87,7 @@ send money from this Wallet.
   "status": "active",
   "currency": "NZD",
   "balance": "0",
+  "availableBalance": "6000",
   "settlement": true
 }
 {% endjson %}
@@ -113,14 +115,16 @@ send money from this Wallet.
     "accountId": "Te2uDM7xhDLWGVJU3nzwnh",
     "ledgerId": "centrapay.nzd.main",
     "currency": "NZD",
-    "balance": "2000"
+    "balance": "2000",
+    "availableBalance": "6000"
   },
   {
     "id": "NQ1yeromwnWPD2hY41L2yS",
     "accountId": "Te2uDM7xhDLWGVJU3nzwnh",
     "ledgerId": "centrapay.nzd.test",
     "currency": "NZD",
-    "balance": "20"
+    "balance": "20",
+    "availableBalance": "6000"
   }
 ]
 {% endjson %}


### PR DESCRIPTION
https://www.notion.so/centrapay/65a900a58a64424e85e3ccbaad674f51?v=f3704058540e48bc8c3680e61c76b2e3&p=755fdcd9420b44f2a5001d6a5d7728ee
Based on this story it seems like we are going to be returning available balance in all of our asset API's. I updated the docs to reflect that but will wait on confirmation before making the changes.