### PR TITLE
Fix payment request in page links

### DIFF
--- a/src/api/payment-requests/payment-requests.md
+++ b/src/api/payment-requests/payment-requests.md
@@ -775,3 +775,4 @@ descending activity created date.
 [GS1 Global Product Classification]: https://www.gs1.org/standards/gpc
 [Legacy Payment API]: {% link api/payment-requests/legacy-payment-requests.md %}#requests-pay
 [Account]: {% link api/accounts/accounts.md %}
+[Payment Request]: #payment-request


### PR DESCRIPTION
This fixes the in page links on the payment request page that are broken after the payment activities info was copied over. 