### PR TITLE
Third Party Consumer Can Cancel Request

### DIFF
--- a/src/api/payment-requests/payment-requests.md
+++ b/src/api/payment-requests/payment-requests.md
@@ -214,13 +214,13 @@ Payment Activities are created when a Payment Request has been **created**, **pa
 
 {% h4 Activity Types %}
 
-|     Name     |                    Description                     |
-| ------------ | -------------------------------------------------- |
-| request      | [Payment Request][] was created.                   |
-| payment      | [Payment Request][] was paid.                      |
-| refund       | Funds were returned to the shopper.                |
-| cancellation | [Payment Request][] was cancelled by the merchant. |
-| expiry       | [Payment Request][] wasn't paid before time out.   |
+|     Name     |                            Description                             |
+| ------------ | ------------------------------------------------------------------ |
+| request      | [Payment Request][] was created.                                   |
+| payment      | [Payment Request][] was paid.                                      |
+| refund       | Funds were returned to the shopper.                                |
+| cancellation | [Payment Request][] was cancelled by the merchant or the shopper.  |
+| expiry       | [Payment Request][] wasn't paid before time out.                   |
 
 ## Operations
 
@@ -776,3 +776,4 @@ descending activity created date.
 [Legacy Payment API]: {% link api/payment-requests/legacy-payment-requests.md %}#requests-pay
 [Account]: {% link api/accounts/accounts.md %}
 [Payment Request]: #payment-request
+[paginated]: {% link api/pagination.md %}


### PR DESCRIPTION
A payment request can now be cancelled not only by the merchant but also by the consumer if they are using a third party application.
Also fixed a bug where the pagination link was not showing up properly on the list payment activities documentation.