### PR TITLE
Updating 'farmlands-external-asset' batch type to 'farmlands'

### DIFF
--- a/src/api/batch/batches.md
+++ b/src/api/batch/batches.md
@@ -108,7 +108,7 @@ Initialize loading of entities from a batch file.
   auth 'api-key'
   example {
     body ({
-      type: 'farmlands-external-asset',
+      type: 'farmlands',
       url: 'https://azurebuckets.com/1234',
       accountId: 'C4QnjXvj8At6SMsEN4LRi9'
     })
@@ -130,7 +130,7 @@ Initialize loading of entities from a batch file.
 {
 	id: "AVH5uG4gRLYK6YR8JyrViN",
 	status: "created",
-	type: "farmlands-external-asset",
+	type: "farmlands",
 	count: "0",
 	errorCount: "0",
 	errors: []
@@ -151,7 +151,7 @@ Initialize loading of entities from a batch file.
 {
 	"id": "AVH5uG4gRLYK6YR8JyrViN",
 	"status": "complete",
-	"type": "farmlands-external-asset",
+	"type": "farmlands",
 	"count": "160000",
 	"errorCount": "1",
 	"errors": [

--- a/src/api/batch/farmlands.md
+++ b/src/api/batch/farmlands.md
@@ -5,7 +5,7 @@ parent: Batches
 grand_parent: Api Reference
 has_children: false
 nav_exclude: true
-permalink: /api/batch-types/farmlands-external-asset
+permalink: /api/batch-types/farmlands
 description: |
   Load Farmlands Card data
 ---
@@ -14,9 +14,9 @@ description: |
 
 Loads Farmlands Card data into Centrapay as external assets.
 
-| Type Name   | farmlands-external-asset |
-| File Format | JSON                     |
-| File Schema | Array of [Account]       |
+| Type Name   | farmlands          |
+| File Format | JSON               |
+| File Schema | Array of [Account] |
 
 ## Contents
 {:.no_toc .text-delta}


### PR DESCRIPTION
We are making the farmlands batch type more generic.
Currently we only require a single batch type for farmlands. We can always add more specific types in the future if the need arises.