### PR TITLE
Add region on account model

### DIFF
--- a/src/api/accounts/accounts.md
+++ b/src/api/accounts/accounts.md
@@ -37,7 +37,8 @@ individual account.
 | id         | String             | The unique identifier.                                      |
 | type       | String             | Account type, must be either 'org' or 'individual'.         |
 | name       | String             | The display name of the Account.                            |
-| test       | Boolean            | A flag which is only present if the account is for testing. |
+| region     | String             | The region that the Account will operate in.                |
+| test       | Boolean            | A flag which is only present if the Account is for testing. |
 | createdAt  | {% dt Timestamp %} | When the Account was created.                               |
 | modifiedAt | {% dt Timestamp %} | When the Account was updated.                               |
 | createdBy  | {% dt CRN %}       | The User or API Key that created the Account.               |
@@ -60,10 +61,11 @@ individual account.
 
 {% h4 Required Fields %}
 
-| Field |  Type  |                    Description                     |
-| :---- | :----- | :------------------------------------------------- |
-| name  | String | The name of the account                            |
-| type  | String | Account type, must be either 'org' or 'individual' |
+| Field  |  Type  |                               Description                                |
+| :----- | :----- | :----------------------------------------------------------------------- |
+| name   | String | The name of the account.                                                 |
+| type   | String | Account type, must be either "org" or "individual".                      |
+| region | String | The region that the account will operate in. Can be "NZ", "AU", or "US". |
 
 
 {% h4 Optional Fields %}

--- a/src/api/merchants/merchants.md
+++ b/src/api/merchants/merchants.md
@@ -29,16 +29,16 @@ which define the payment methods available for a Payment Request.
 
 {% h4 Mandatory Fields %}
 
-|   Field   |        Type        |                  Description                   |
-| :-------- | :----------------- | :--------------------------------------------- |
-| id        | String             | Merchant's unique identifier.                  |
-| accountId | String             | Id of Merchant's owning Centrapay account.     |
-| name      | String             | Merchant name.                                 |
-| country   | String             | Merchant [ISO 3166]{:.external} country code.  |
-| createdAt | {% dt Timestamp %} | When the Merchant was created.                 |
-| createdBy | {% dt CRN %}       | The User or API Key that created the Merchant. |
-| updatedAt | {% dt Timestamp %} | When the Merchant was updated.                 |
-| updatedBy | {% dt CRN %}       | The User or API Key that updated the Merchant. |
+|   Field   |        Type        |                                        Description                                        |
+| :-------- | :----------------- | :---------------------------------------------------------------------------------------- |
+| id        | String             | Merchant's unique identifier.                                                             |
+| accountId | String             | Id of Merchant's owning Centrapay account.                                                |
+| name      | String             | Merchant name.                                                                            |
+| country   | String             | Merchant [ISO 3166]{:.external} country code. Must match the "region" on the [Account][]. |
+| createdAt | {% dt Timestamp %} | When the Merchant was created.                                                            |
+| createdBy | {% dt CRN %}       | The User or API Key that created the Merchant.                                            |
+| updatedAt | {% dt Timestamp %} | When the Merchant was updated.                                                            |
+| updatedBy | {% dt CRN %}       | The User or API Key that updated the Merchant.                                            |
 
 {% h4 Optional Fields %}
 
@@ -268,3 +268,4 @@ Returns a [paginated][] list of Merchants attached to an Account.
 [ISO 3166]: https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2
 [Location]: {% link api/data-types.md %}#Location
 [paginated]: {% link api/pagination.md %}
+[Account]: {% link api/accounts/accounts.md %}


### PR DESCRIPTION
The region on the Account will encapsulate where the account will operate. The merchant's country will match the account's region for now but in the future, regions will be expanded.