### PR TITLE
Update region property to only be org accounts

### DIFF
--- a/src/api/accounts/accounts.md
+++ b/src/api/accounts/accounts.md
@@ -32,18 +32,18 @@ individual account.
 ### Account
 
 
-|     Field     |        Type        |                         Description                         |
-| :------------ | :----------------- | :---------------------------------------------------------- |
-| id            | String             | The unique identifier.                                      |
-| type          | String             | Account type, must be either 'org' or 'individual'.         |
-| name          | String             | The display name of the Account.                            |
-| region        | String             | The region that the Account will operate in.                |
-| test          | Boolean            | A flag which is only present if the Account is for testing. |
-| createdAt     | {% dt Timestamp %} | When the Account was created.                               |
-| modifiedAt    | {% dt Timestamp %} | When the Account was updated.                               |
-| createdBy     | {% dt CRN %}       | The User or API Key that created the Account.               |
-| modifiedBy    | {% dt CRN %}       | The User or API Key that updated the Account.               |
-| subscriptions | Array              | A list of [Subscriptions](#subscription) on the Account.    |
+|     Field     |        Type        |                                  Description                                  |
+| :------------ | :----------------- | :---------------------------------------------------------------------------- |
+| id            | String             | The unique identifier.                                                        |
+| type          | String             | Account type, must be either 'org' or 'individual'.                           |
+| name          | String             | The display name of the Account.                                              |
+| region        | String             | The region that the Account will operate in. Only defined for 'org' Accounts. |
+| test          | Boolean            | A flag which is only present if the Account is for testing.                   |
+| createdAt     | {% dt Timestamp %} | When the Account was created.                                                 |
+| modifiedAt    | {% dt Timestamp %} | When the Account was updated.                                                 |
+| createdBy     | {% dt CRN %}       | The User or API Key that created the Account.                                 |
+| modifiedBy    | {% dt CRN %}       | The User or API Key that updated the Account.                                 |
+| subscriptions | Array              | A list of [Subscriptions](#subscription) on the Account.                      |
 
 ### Subscription
 
@@ -66,19 +66,18 @@ individual account.
 
 {% h4 Required Fields %}
 
-| Field  |  Type  |                               Description                                |
-| :----- | :----- | :----------------------------------------------------------------------- |
-| name   | String | The name of the account.                                                 |
-| type   | String | Account type, must be either "org" or "individual".                      |
-| region | String | The region that the account will operate in. Can be "NZ", "AU", or "US". |
-
+| Field |  Type  |                     Description                     |
+| :---- | :----- | :-------------------------------------------------- |
+| name  | String | The name of the Account.                            |
+| type  | String | Account type, must be either "org" or "individual". |
 
 {% h4 Optional Fields %}
 
-| Field |  Type   |                      Description                       |
-| :---- | :------ | :----------------------------------------------------- |
-| owner | String  | Id of user to add as member with "account-owner" role. |
-| test  | Boolean | A flag indicating if the account is for testing.       |
+| Field  |  Type   |                                                                 Description                                                                  |
+| :----- | :------ | :------------------------------------------------------------------------------------------------------------------------------------------- |
+| owner  | String  | Id of user to add as member with "account-owner" role.                                                                                       |
+| test   | Boolean | A flag indicating if the Account is for testing.                                                                                             |
+| region | String  | The region that the Account will operate in. Required for 'org' Accounts, not allowed for 'individual' Accounts. Can be "NZ", "AU", or "US". |
 
 
 {% h4 Example response payload %}


### PR DESCRIPTION
The modelling has changed so that individual accounts will not have regions. This is because individual users of Centrapay be in any region, and can move between regions.