### PR TITLE
Quick Pay -> Quick Pay on Poll

### DIFF
--- a/src/api/payment-requests/payment-requests.md
+++ b/src/api/payment-requests/payment-requests.md
@@ -358,7 +358,6 @@ Payment Activities are created when a Payment Request has been **created**, **pa
 | 400    | {% break _ CHECKSUM_FAILED %}              | Luhn checksum digit doesn't pass.                                                                         |
 | 403    | {% break _ PATRON_CODE_INVALID %}          | Patron Code doesn't exist or has expired.                                                                 |
 | 403    | {% break _ NO_AVAILABLE_PAYMENT_OPTIONS %} | The currency is not supported by any of the [Asset Types][] that the [Merchant][] is configured with.     |
-| 403    | {% break _ INSUFFICIENT_ASSET_VALUE %}     | The patron does not have enough funds to quick pay the payment request.                                   |
 
 ### Get a Payment Request
 

--- a/src/guides/payment-flows.md
+++ b/src/guides/payment-flows.md
@@ -80,8 +80,8 @@ approval before this goes through.
 
 ### Quick Pay
 
-Quick pay is used to pay the payment request immediately after it's created, without requiring patron approval.
-Quick pay can only be triggered using the patron-presented flows, and the patron barcode must be linked to an
+Quick Pay is used to pay the payment request after it is polled for the first time, without requiring patron approval.
+Quick Pay can only be triggered using the patron-presented flows, and the patron barcode must be linked to an
 asset type that allows quick pay. See [Asset Types][] for the list of asset types that support Quick Pay.
 
 [Payment Requests]: {% link api/payment-requests/payment-requests.md %}


### PR DESCRIPTION
Updated Quick Pay documentation to be Quick Pay on Poll. Instead of Quick Paying on creation of the payment request, we now Quick Pay the first time a payment request is polled