### PR TITLE
Deprecating appName

### DIFF
--- a/src/api/patron-codes.md
+++ b/src/api/patron-codes.md
@@ -82,9 +82,6 @@ The Centrapay Prefix may present any of the following prefixes:
 }
 {% endjson %}
 
-The `appName` field represents information about the app that generated the code.
-It is used to apply discounts or restrict payment options for the payment request created.
-
 You can find payment request information attached to a Patron Code by [polling for the Payment
 Request][polling] using the transacting APIs.
 

--- a/src/api/patron-codes.md
+++ b/src/api/patron-codes.md
@@ -19,7 +19,7 @@ A Patron Code is an alternative to presenting a QR code where that option isn't 
 
 ### Patron Code **EXPERIMENTAL**
 
-{% h4 Required Fields %}
+{% h4 Fields %}
 
 | Field       | Type               | Description                                          |
 |:------------|:-------------------|:-----------------------------------------------------|
@@ -27,7 +27,7 @@ A Patron Code is an alternative to presenting a QR code where that option isn't 
 | barcode     | String             | ✩ Field to display in barcode format.                |
 | createdAt   | {% dt Timestamp %} | Date when the Patron Code was created.               |
 | expiresAt   | {% dt Timestamp %} | Date when the Patron Code will expire.               |
-| appName     | String             | The app used to create the Patron Code.              |
+| appName     | String {% opt %}   | Deprecated. The app used to create the Patron Code.  |
 | accountId   | String             | The account id of the creator of the patron code     |
 
 ✩ Barcode is a 16 digit number. The first 6 digits are a Centrapay defined prefix, then a 9 digit
@@ -82,7 +82,7 @@ The Centrapay Prefix may present any of the following prefixes:
 }
 {% endjson %}
 
-The `appName` field in the Patron Code represents information about the app that generated the code.
+The `appName` field in the Patron Code is deprecated. The field represents information about the app that generated the code.
 It is used to apply discounts or restrict payment options for the payment request created.
 
 You can find payment request information attached to a Patron Code by [polling for the Payment

--- a/src/api/patron-codes.md
+++ b/src/api/patron-codes.md
@@ -82,7 +82,7 @@ The Centrapay Prefix may present any of the following prefixes:
 }
 {% endjson %}
 
-The `appName` field in the Patron Code is deprecated. The field represents information about the app that generated the code.
+The `appName` field represents information about the app that generated the code.
 It is used to apply discounts or restrict payment options for the payment request created.
 
 You can find payment request information attached to a Patron Code by [polling for the Payment

--- a/src/api/patron-codes.md
+++ b/src/api/patron-codes.md
@@ -26,7 +26,6 @@ A Patron Code is an alternative to presenting a QR code where that option isn't 
 | id        | String             | The Patron Code's unique identifier.                   |
 | barcode   | String             | ✩ Field to display in barcode format.                  |
 | createdAt | {% dt Timestamp %} | Date when the Patron Code was created.                 |
-| createdBy | {% dt CRN %}       | Identifier for the account that created the barcode.   |
 | expiresAt | {% dt Timestamp %} | Date when the Patron Code will expire.                 |
 | appName   | String {% opt %}   | The app used to create the Patron Code. **DEPRECATED** |
 | accountId | String             | The account id of the creator of the patron code.      |

--- a/src/api/patron-codes.md
+++ b/src/api/patron-codes.md
@@ -21,14 +21,15 @@ A Patron Code is an alternative to presenting a QR code where that option isn't 
 
 {% h4 Fields %}
 
-| Field       | Type               | Description                                          |
-|:------------|:-------------------|:-----------------------------------------------------|
-| id          | String             | The Patron Code's unique identifier.                 |
-| barcode     | String             | ✩ Field to display in barcode format.                |
-| createdAt   | {% dt Timestamp %} | Date when the Patron Code was created.               |
-| expiresAt   | {% dt Timestamp %} | Date when the Patron Code will expire.               |
-| appName     | String {% opt %}   | Deprecated. The app used to create the Patron Code.  |
-| accountId   | String             | The account id of the creator of the patron code     |
+|   Field   |        Type        |                      Description                       |
+| :-------- | :----------------- | :----------------------------------------------------- |
+| id        | String             | The Patron Code's unique identifier.                   |
+| barcode   | String             | ✩ Field to display in barcode format.                  |
+| createdAt | {% dt Timestamp %} | Date when the Patron Code was created.                 |
+| createdBy | {% dt CRN %}       | Identifier for the account that created the barcode.   |
+| expiresAt | {% dt Timestamp %} | Date when the Patron Code will expire.                 |
+| appName   | String {% opt %}   | The app used to create the Patron Code. **DEPRECATED** |
+| accountId | String             | The account id of the creator of the patron code.      |
 
 ✩ Barcode is a 16 digit number. The first 6 digits are a Centrapay defined prefix, then a 9 digit
 code, then a luhn checksum digit.


### PR DESCRIPTION
The changes in https://bitbucket.org/centrapay/rhea/commits/cdc577dbeb37841812d3171855ce478dadaece93 have made appName an optional field when creating a patron code. This PR documents that change.