### PR TITLE
Payment Requests don't have a refunded status

### DIFF
--- a/src/api/payment-requests/payment-requests.md
+++ b/src/api/payment-requests/payment-requests.md
@@ -55,7 +55,7 @@ version (documented on this page) and the "legacy" version (documented at
 | merchantId         | String             | The id of the [Merchant][] the Payment Request is on behalf of.                                                 |
 | merchantName       | String             | The name of the Merchant the Payment Request is on behalf of.                                                   |
 | configId           | String             | The [Merchant Config][] id used to configure the payment options.                                               |
-| status             | String             | "new", "paid", "cancelled", "expired", "refunded".                                                              |
+| status             | String             | "new", "paid", "cancelled", or "expired".                                                                       |
 | liveness           | String             | Indicates liveness of assets that are accepted, determined by the payment options. Values are "main" or "test". |
 | createdAt          | {% dt Timestamp %} | When the payment request was created.                                                                           |
 | updatedAt          | {% dt Timestamp %} | When the payment request was updated.                                                                           |


### PR DESCRIPTION
Came down to this commit:

> Added refunded status to V2 payment request docs
> Adding a refunded status here in advance to force integrators to support it

But this doesn't match our thinking. We're trying to reduce the number of statuses that integrators need to worry about, and refunded is no longer on the map.