### PR TITLE
Fix broken links

### DIFF
--- a/src/api/payment-requests/payment-requests.md
+++ b/src/api/payment-requests/payment-requests.md
@@ -77,12 +77,12 @@ version (documented on this page) and the "legacy" version (documented at
 | terminalId           | String  | The software or logical id of the payment terminal.                                                                                                                      |
 | deviceId             | String  | The hardware id or serial number of the payment terminal.                                                                                                                |
 | operatorId           | String  | POS operator Id.                                                                                                                                                         |
-| createdByAccountId   | String  | Id of the [Centrapay Account]() creating the Payment Request.                                                                                                            |
-| createdByAccountName | String  | Name of the [Centrapay Account]() creating the Payment Request.                                                                                                          |
+| createdByAccountId   | String  | Id of the [Centrapay Account][] creating the Payment Request.                                                                                                            |
+| createdByAccountName | String  | Name of the [Centrapay Account][] creating the Payment Request.                                                                                                          |
 | conditionsEnabled    | Boolean | Flag to indicate that a merchant is able to accept [Payment Conditions](#payment-condition).        |
-| patronNotPresent     | Boolean | Flag to indicate the patron is not physically present. This may affect payment conditions or available [Payment Options]().                                              |
+| patronNotPresent     | Boolean | Flag to indicate the patron is not physically present. This may affect payment conditions or available [Payment Options][].                                              |
 | cancellationReason   | String  | The reason that the payment request was cancelled. See [Cancellation Reasons](#cancellation-reasons) for possible values.                                                |
-| preAuth              | Boolean | Flag to indicate the if the request is a pre authorization for supported [Asset Types]().                                                                            |
+| preAuth              | Boolean | Flag to indicate the if the request is a pre authorization for supported [Asset Types][].                                                                            |
 
 
 ### Payment Option
@@ -375,11 +375,11 @@ Payment Activities are created when a Payment Request has been **created**, **pa
 | terminalId           | String {% opt %}  | The software or logical id of the payment terminal.                                                                                                                      |
 | deviceId             | String {% opt %}  | The hardware id or serial number of the payment terminal.                                                                                                                |
 | operatorId           | String {% opt %}  | The POS operator Id.                                                                                                                                                     |
-| createdByAccountId   | String {% opt %}  | The id of the [Centrapay Account]() creating the Payment Request.                                                                                                        |
-| createdByAccountName | String {% opt %}  | The name of the [Centrapay Account]() creating the Payment Request.                                                                                                      |
-| conditionsEnabled    | Boolean {% opt %} | Flag to opt into accepting [Asset Types]() which require conditions to be met. If not set, assets which require conditions will not be payment options.                  |
-| patronNotPresent     | Boolean {% opt %} | Flag to indicate the patron is not physically present. This may affect payment conditions or available [Payment Options]().                                              |
-| preAuth              | Boolean {% opt %} | Flag to indicate if the Payment Request is a pre authorization for supported [Asset Types](). If set barcode must be provided.                                         |
+| createdByAccountId   | String {% opt %}  | The id of the [Centrapay Account][] creating the Payment Request.                                                                                                        |
+| createdByAccountName | String {% opt %}  | The name of the [Centrapay Account][] creating the Payment Request.                                                                                                      |
+| conditionsEnabled    | Boolean {% opt %} | Flag to opt into accepting [Asset Types][] which require conditions to be met. If not set, assets which require conditions will not be payment options.                  |
+| patronNotPresent     | Boolean {% opt %} | Flag to indicate the patron is not physically present. This may affect payment conditions or available [Payment Options][].                                              |
+| preAuth              | Boolean {% opt %} | Flag to indicate if the Payment Request is a pre authorization for supported [Asset Types][]. If set barcode must be provided.                                         |
 
 {% h4 Example response payload %}
 

--- a/src/api/status-codes.md
+++ b/src/api/status-codes.md
@@ -129,14 +129,14 @@ Centrapay API rate limits have been exceeded.
 
  * Check the `Retry-After` HTTP response header for the number of seconds
    before the next request will be accepted.
- * Contact [integrations@centrapay.com]() to increase your limits.
+ * Contact [integrations@centrapay.com](mailto:integrations@centrapay.com) to increase your limits.
 
 
 ## 5xx Server Error
 
 If you get a 500 level error, something has gone wrong on our end. Retrying
 should solve the issue. Usually a Centrapay Engineer will investigate but
-bug reports are also welcome at [integrations@centrapay.com]().
+bug reports are also welcome at [integrations@centrapay.com](mailto:integrations@centrapay.com).
 
 
 [Auth]: {% link api/auth.md %}

--- a/src/guides/giftcard-distribution.md
+++ b/src/guides/giftcard-distribution.md
@@ -21,7 +21,7 @@ another Centrapay user's phone number via SMS.
 You can load Giftcards by calling our [External Assets] endpoint. You will need to use the giftcard
 number for the `externalId` field. The `pin`, the `issuer` and the `type` need to be on hand too.
 
-If your asset type is not included on the list, contact [integrations@centrapay.com]().
+If your asset type is not included on the list, contact [integrations@centrapay.com](mailto:integrations@centrapay.com).
 
 ## Sending Assets
 

--- a/src/index.md
+++ b/src/index.md
@@ -17,7 +17,7 @@ Checkout our [Guides][] for hints on where to begin or see the
 [API Reference][] for a deeper dive.
 
 For more help getting setup, contact us via email at
-[integrations@centrapay.com]().
+[integrations@centrapay.com](mailto:integrations@centrapay.com).
 
 [Guides]: {% link guides/introduction.md %}
 [API Reference]: {% link api/introduction.md %}


### PR DESCRIPTION
Came across broken links, fixed them where I could

We should lint for this, matching on `]()` should throw an error.