### PR TITLE
Document 24 hr limit on Payment Request expirySeconds

### DIFF
--- a/src/api/payment-requests/legacy-payment-requests.md
+++ b/src/api/payment-requests/legacy-payment-requests.md
@@ -56,15 +56,15 @@ See [Asset Types][] for the list of possible `asset` values for each Asset Type.
 
 {% h4 Optional Parameters %}
 
-| Parameter            | Description                                                                        |
-|:---------------------|:-----------------------------------------------------------------------------------|
-| description          | Description of the payment                                                         |
-| externalReference    | Unique merchant reference for the payment request                                  |
-| notifyUrl            | The URL that will receive **POST** requests from the webhook                       |
-| paymentExpirySeconds | The amount of seconds until a request expires, must be an integer greater than 0   |
-| terminalId           | The payment system terminal Id. Required for NZ Epay integration.                  |
-| deviceId             | Physical payment system device Id                                                  |
-| patronCode           | Associate this payment request with an active Patron Code. |
+|      Parameter       |                                                   Description                                                   |
+| :------------------- | :-------------------------------------------------------------------------------------------------------------- |
+| description          | Description of the payment                                                                                      |
+| externalReference    | Unique merchant reference for the payment request                                                               |
+| notifyUrl            | The URL that will receive **POST** requests from the webhook                                                    |
+| paymentExpirySeconds | The amount of seconds until a request expires, must be an integer greater than 0 and less than 86400 (24 hours) |
+| terminalId           | The payment system terminal Id. Required for NZ Epay integration.                                               |
+| deviceId             | Physical payment system device Id                                                                               |
+| patronCode           | Associate this payment request with an active Patron Code.                                                      |
 
 {% h4 Error Responses %}
 

--- a/src/api/payment-requests/payment-requests.md
+++ b/src/api/payment-requests/payment-requests.md
@@ -366,7 +366,7 @@ Payment Activities are created when a Payment Request has been **created**, **pa
 | configId             | String            | The [Merchant Config][] id used to configure the payment options.                                                                                                        |
 | value                | {% dt Monetary %} | The canonical value of the payment request. Must be positive.                                                                                                            |
 | barcode              | String {% opt %}  | The patron's barcode to identify the account to attach the payment request to                                                                                            |
-| expirySeconds        | String {% opt %}  | How long the payment request will be payable for.                                                                                                                        |
+| expirySeconds        | String {% opt %}  | How long the payment request will be payable for. Maximum value: 86400 (24 hours).                                                                                       |
 | lineItems            | Array {% opt %}   | **Experimental** The [Line Items](#line-item) being paid for.                                                                                                            |
 | purchaseOrderRef     | String {% opt %}  | A reference to a purchase order for this payment request.                                                                                                                |
 | invoiceRef           | String {% opt %}  | A reference to an invoice for this payment request.                                                                                                                      |
@@ -379,7 +379,7 @@ Payment Activities are created when a Payment Request has been **created**, **pa
 | createdByAccountName | String {% opt %}  | The name of the [Centrapay Account][] creating the Payment Request.                                                                                                      |
 | conditionsEnabled    | Boolean {% opt %} | Flag to opt into accepting [Asset Types][] which require conditions to be met. If not set, assets which require conditions will not be payment options.                  |
 | patronNotPresent     | Boolean {% opt %} | Flag to indicate the patron is not physically present. This may affect payment conditions or available [Payment Options][].                                              |
-| preAuth              | Boolean {% opt %} | Flag to indicate if the Payment Request is a Pre Auth for supported [Asset Types][]. If set barcode must be provided.                                         |
+| preAuth              | Boolean {% opt %} | Flag to indicate if the Payment Request is a Pre Auth for supported [Asset Types][]. If set barcode must be provided.                                                    |
 
 {% h4 Example response payload %}
 


### PR DESCRIPTION
One of the decisions made in the [Deprecate Cancel in Favour of Void ADR](https://www.notion.so/centrapay/Deprecate-Cancel-in-Favour-of-Void-57f8819fb9d54a269dcb8c8fe787884b) was that the Payment Request timeout window will be limited to 24 hours.

This change was implemented in [this PR](https://bitbucket.org/centrapay/kari/pull-requests/1337).