### PR TITLE
Rename status codes page to http status codes

### DIFF
--- a/src/api/http-status-codes.md
+++ b/src/api/http-status-codes.md
@@ -2,8 +2,8 @@
 layout: default
 nav_order: 3
 parent: API Reference
-title: Status Codes
-permalink: /api/status-codes
+title: HTTP Status Codes
+permalink: /api/http-status-codes
 ---
 
 # HTTP Status Codes


### PR DESCRIPTION
The title of this page is too similar to Scanned codes which may cause confusion.