### PR TITLE
Change nuxt build directory to not include underscore

### DIFF
--- a/new-docs/nuxt.config.js
+++ b/new-docs/nuxt.config.js
@@ -2,6 +2,9 @@ import { defineNuxtConfig } from 'nuxt';
 
 export default defineNuxtConfig({
   css: ['~/assets/css/tailwind.css'],
+  app: {
+    buildAssetsDir: '/nuxt/'
+  },
   build: {
     postcss: {
       postcssOptions: {


### PR DESCRIPTION
GitHub pages ignores directories starting with underscore.

Test plan:
- Navigate to `docs.centrapay.com/v2/` - see that the network calls to retrieve the javascript and CSS files return 200.