### PR TITLE
Make line item price explicit

### DIFF
--- a/legacy/src/api/payment-requests/payment-requests.md
+++ b/legacy/src/api/payment-requests/payment-requests.md
@@ -149,7 +149,7 @@ line items may be represented as a separate line item with a negative amount.
 | name  | String             | The product description.                                                                                               |
 | sku   | String             | The product (stock keeping unit) code.                                                                                 |
 | qty   | {% dt BigNumber %} | The product quantity (eg. item count, weight, volume etc).                                                             |
-| price | {% dt BigNumber %} | The combined price of each individual product in cents (eg. price = individual product price * qty - discounts + tax). |
+| price | {% dt BigNumber %} | The total price in cents for the line item (eg. price = product price * qty - discounts + tax). |
 
 {% h4 Optional Fields %}
 

--- a/legacy/src/api/payment-requests/payment-requests.md
+++ b/legacy/src/api/payment-requests/payment-requests.md
@@ -144,13 +144,12 @@ line items may be represented as a separate line item with a negative amount.
 
 {% h4 Mandatory Fields %}
 
-| Field |        Type        |                              Description                              |
-| ----- | ------------------ | --------------------------------------------------------------------- |
-| name  | String             | The product description.                                              |
-| sku   | String             | The product (stock keeping unit) code.                                |
-| qty   | {% dt BigNumber %} | The product quantity (eg. item count, weight, volume etc).            |
-| price | {% dt BigNumber %} | The final price in cents (eg. product price * qty - discounts + tax). |
-
+| Field |        Type        |                                                      Description                                                       |
+| ----- | ------------------ | ---------------------------------------------------------------------------------------------------------------------- |
+| name  | String             | The product description.                                                                                               |
+| sku   | String             | The product (stock keeping unit) code.                                                                                 |
+| qty   | {% dt BigNumber %} | The product quantity (eg. item count, weight, volume etc).                                                             |
+| price | {% dt BigNumber %} | The combined price of each individual product in cents (eg. price = individual product price * qty - discounts + tax). |
 
 {% h4 Optional Fields %}
 


### PR DESCRIPTION
There has been the misunderstanding that line item price represents the price of an individual product. This is incorrect.
Line item price represents the combined price of each individual product.
This PR updates the description of line item price to help make this more clear.