### PR TITLE
Fixed previous and next buttons

### DIFF
--- a/components/Layout.vue
+++ b/components/Layout.vue
@@ -48,7 +48,7 @@
               :href="previousPage._path"
               class="text-base font-semibold text-slate-500 hover:text-slate-600 dark:text-slate-400 dark:hover:text-slate-300"
             >
-              <span aria-hidden="true">&larr;</span> {{ previousPage.text }}
+              <span aria-hidden="true">&larr;</span> {{ previousPage.title }}
             </NuxtLink>
           </dd>
         </div>
@@ -67,7 +67,7 @@
               :href="nextPage._path"
               class="text-base font-semibold text-slate-500 hover:text-slate-600 dark:text-slate-400 dark:hover:text-slate-300"
             >
-              {{ nextPage.text }} <span aria-hidden="true">&rarr;</span>
+              {{ nextPage.title }} <span aria-hidden="true">&rarr;</span>
             </NuxtLink>
           </dd>
         </div>


### PR DESCRIPTION
Was referencing `text` instead of `title` so the name of the next/previous doc wasn't showing up. Looking better now 
<img width="802" alt="image" src="https://user-images.githubusercontent.com/70119888/189552451-1e904ff9-253d-4a4f-8e92-5b480155abe9.png">

**Test Plan:** This won't be accessible in production as the vue-router doesn't know about it, so regression check the landing page and the two links to the old docs