### PR TITLE
Add v2 page that routes to the content pages

### DIFF
--- a/pages/v2.vue
+++ b/pages/v2.vue
@@ -1,0 +1,10 @@
+<template>
+  <div>
+    <NuxtLink
+      to="/introduction/getting-started"
+      class="btn btn-primary"
+    >
+      Go to Content
+    </NuxtLink>
+  </div>
+</template>


### PR DESCRIPTION
In production, we can't route to the content pages, we get the Jekyll 404 instead. This is because we need to route to them via client-side routing in the Nuxt app.

Test plan:
- Go to [docs.centrapay.com/v2](url), you should see:
<img width="3359" alt="image" src="https://user-images.githubusercontent.com/50732795/189553060-18272594-ed79-4b51-9f95-20dd1f5f379a.png">

- Clicking the button should go to [docs.centrapay.com/introduction/getting-started](url) and you should see:
<img width="1432" alt="image" src="https://user-images.githubusercontent.com/50732795/189553102-da2db045-67ef-470b-9486-824a2abe95b2.png">
