### PR TITLE
Add include option to Jekyll config

### DIFF
--- a/legacy/_config.yml
+++ b/legacy/_config.yml
@@ -2,6 +2,7 @@ source: src
 destination: ../_site
 repository: centrapay/centrapay.github.io
 show_downloads: false
+include: [ _*.mjs ]
 title: Centrapay Docs
 kramdown:
   toc_levels: '2,3'


### PR DESCRIPTION
Nuxt generates a file that starts with an underscore. Files that start with an underscore are not read by the Jekyll server.

Test plan:
- Go to [https://docs.centrapay.com/introduction/getting-started/](url), you should see 
<img width="1288" alt="image" src="https://user-images.githubusercontent.com/50732795/189554057-0496d126-b060-4c24-b9c8-6f4aeee02bdd.png">
