### PR TITLE
Copy files from _content nuxt build file to _site

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,7 @@ cd ../
 
 yarn generate
 
+mv .output/public/api/_content _site/api
 rm -r .output/public/api/
 mv .output/public/* _site/
 


### PR DESCRIPTION
This fixes a 404 we get from the deployed site. 
<img width="425" alt="image" src="https://user-images.githubusercontent.com/50732795/189779857-b19920e4-5864-41d3-80e8-786b97c590a9.png">


Test plan:
- Go to [https://docs.centrapay.com/introduction/getting-started/](url), there should be no 404's in the console