### PR TITLE
Add yarnrc file with supported architectures

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,4 @@
+supportedArchitectures:
+  os:
+    - "darwin"
+    - "linux"


### PR DESCRIPTION
ESbuild has a Linux compatible version and a Mac compatible version. yarn install will retrieve the packages that are compatible with the current OS.

Our local environment needs the Mac compatible version of ESbuild, while Docker needs the Linux compatible version. Adding this config will download both versions so that users won't have to reinstall packages when starting in local versus starting in Docker.