### PR TITLE
Revert "Add include option to Jekyll config"

### DIFF
--- a/legacy/_config.yml
+++ b/legacy/_config.yml
@@ -2,7 +2,6 @@ source: src
 destination: ../_site
 repository: centrapay/centrapay.github.io
 show_downloads: false
-include: [ _*.mjs ]
 title: Centrapay Docs
 kramdown:
   toc_levels: '2,3'


### PR DESCRIPTION
Reverts centrapay/centrapay-docs#507

The option didn't work. Instead, we added a `.nojekyll` file to the `gh-pages` repo. Recommended by Github: [https://github.blog/2009-12-29-bypassing-jekyll-on-github-pages/](url)