### PR TITLE
Volume for node modules

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,6 +1,10 @@
 version: "3"
 
 services:
+  app:
+    volumes: [ node-modules:/work/node_modules ]
+  script:
+    volumes: [ node-modules:/work/node_modules ]
   legacy:
     volumes: [ bundle:/usr/local/bundle ]
   ruby-script:
@@ -8,3 +12,4 @@ services:
 
 volumes:
   bundle:
+  node-modules:


### PR DESCRIPTION
yarn install took ages in the docker container because we didnt have a volume setup for them. It is a lot faster now