### PR TITLE
Add Github action for Slack PR notifications

### DIFF
--- a/.github/workflows/pull-request-notification.yml
+++ b/.github/workflows/pull-request-notification.yml
@@ -1,0 +1,34 @@
+# Post a Slack message for every pull request.
+#
+# The Github action context "event" attribute is a pull request webhook event
+# document. See:
+# https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
+# https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#pull_request
+
+name: Pull Request Notification
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'opened'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - run: |
+          curl -X POST "${{ secrets.NEW_PR_SLACK_HOOK_URL }}" \
+          --data "$(
+            scripts/slack-pull-request-msg.js \
+              --repo    "${{ github.event.repository.name }}" \
+              --user    "${{ github.event.pull_request.user.login }}" \
+              --number  "${{ github.event.pull_request.number }}" \
+              --title   "${{ github.event.pull_request.title }}" \
+              --desc    "${{ github.event.pull_request.body }}" \
+              --link    "${{ github.event.pull_request.html_url }}"
+            )"

--- a/scripts/slack-pull-request-msg.js
+++ b/scripts/slack-pull-request-msg.js
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+
+'use strict';
+
+function errorExit(e) {
+  console.error(e);
+  process.exit(1);
+}
+
+let argv = process.argv.slice(2);
+const args = {
+  repo: null,
+  number: null,
+  title: null,
+  description: '',
+  user: null,
+  link: null,
+};
+
+while(argv.length) {
+  const arg = argv.shift();
+  switch (arg) {
+  case '--repo':
+    args.repo = argv.shift();
+    break;
+  case '--number':
+    args.number = argv.shift();
+    break;
+  case '--title':
+    args.title = argv.shift();
+    break;
+  case '--desc':
+    args.description = argv.shift();
+    break;
+  case '--link':
+    args.link = argv.shift();
+    break;
+  case '--user':
+    args.user = argv.shift();
+    break;
+  default:
+    errorExit(`Unexpected arg: "${arg}"`);
+  }
+}
+
+Object.entries(args).forEach(([k,v]) => {
+  if (v === null) {
+    errorExit(`Missing required arg: ${k}`);
+  }
+});
+
+
+/*
+ * https://api.slack.com/messaging/composing/layouts
+ */
+const slackMessage = {
+  blocks: [
+    {
+      text: {
+        text: `New PR for *${args.repo}* by ${args.user}`,
+        type: 'mrkdwn',
+      },
+      type: 'section'
+    },
+    {
+      text: {
+        text: `<${args.link}|#${args.number} ${args.title}>`,
+        type: 'mrkdwn',
+      },
+      type: 'section',
+    },
+  ]
+};
+
+if (args.description.length) {
+  slackMessage.blocks.push({
+    text: {
+      text: args.description,
+      type: 'mrkdwn',
+    },
+    type: 'section',
+  });
+}
+
+process.stdout.write(JSON.stringify(slackMessage));


### PR DESCRIPTION
Out of the box slack github integration does not allow subscribing to just pull request created events (see https://github.com/integrations/slack#customize-your-notifications). This simple script can be duplicated into each github repo to post a message to Slack directly when a PR is opened. 