### PR TITLE
Query Nuxt Content files without trailing slash

### DIFF
--- a/pages/[...slug].vue
+++ b/pages/[...slug].vue
@@ -11,7 +11,8 @@
 
 <script setup>
 const { path } = useRoute();
-const contentDirectory = await queryContent().where({ _path: path }).findOne();
+const contentPath = path.endsWith('/') ? path.slice(0, -1) : path;
+const contentDirectory = await queryContent().where({ _path: contentPath }).findOne();
 const title = contentDirectory.title;
 const tableOfContents = contentDirectory.body.toc.links;
 </script>


### PR DESCRIPTION
Using the queryContent composable with a path containing a trailing slashes returns a 404 because Nuxt Content creates internal paths for Content files without a trailing slash (see
https://content.nuxtjs.org/guide/writing/content-directory#paths).

We need to support routes with trailing slashes because the Nuxt prerendering (SSG) creates a directory containing an index.html file for each content file e.g. test.md -> test/index.html. Github Pages recognises that it is accessing a directory and will always append a trailing slash when a route is accessed.

This behaviour is not configurable so we need to strip any trailing slash from the pathname of the URL before querying Nuxt Content.

Test plan:
- Navigate to route managed by Nuxt Content and confirm that refreshing
  the page works after Github Pages appends a trailing slash