### PR TITLE
Remove update business endpoint

### DIFF
--- a/legacy/src/api/accounts/businesses.md
+++ b/legacy/src/api/accounts/businesses.md
@@ -196,41 +196,5 @@ number. Results are [paginated][] and ordered by relevance.
 }
 {% endjson %}
 
-### Update a Business **EXPERIMENTAL**
-
-{% reqspec %}
-  PUT '/api/businesses/{id}'
-  auth 'api-key'
-  body ({
-    taxNumber: {
-      value: '123-456-789',
-      type: 'nz-gst',
-    }
-  })
-  path_param 'id', 'DKTs3U38hdhfEqwF1JKoT2'
-{% endreqspec %}
-
-{% h4 Example response payload %}
-
-{% json %}
-{
-  "id": "DKTs3U38hdhfEqwF1JKoT2",
-  "accountId": "Jaim1Cu1Q55uooxSens6yk",
-  "accountName": "Centrapay",
-  "nzbn": "9429046246448",
-  "name": "CENTRAPAY LIMITED",
-  "tradingName": "CentraPay",
-  "companyNumber": "6340244",
-  "createdAt": "2020-06-12T01:17:46.499Z",
-  "updatedAt": "2020-06-12T01:17:46.499Z",
-  "createdBy": "crn:WIj211vFs9cNACwBb04vQw:api-key:MyApiKey",
-  "updatedBy": "crn:WIj211vFs9cNACwBb04vQw:api-key:MyApiKey",
-  "taxNumber": {
-    "value": "123-456-789",
-    "type": "nz-gst",
-  }
-}
-{% endjson %}
-
 [Account]: {% link api/accounts/accounts.md %}
 [paginated]: {% link api/pagination.md %}


### PR DESCRIPTION
The update business endpoint has been updated so that it can only be called by global admins.
We should not be publicly documenting a endpoint that can only be called by global admins.
Therefore I am removing the documentation for the update business endpoint.