### PR TITLE
Render section title when loading page

### DIFF
--- a/components/Layout.vue
+++ b/components/Layout.vue
@@ -140,7 +140,7 @@ const contentDirectory = await queryContent().where({ _path: contentPath }).find
 const title = contentDirectory.title;
 const navigation = await fetchContentNavigation();
 const section = navigation.find((s) =>
-  s.children.find((child) => child._path === path)
+  s.children.find((child) => child._path === contentPath)
 );
 const { toc, prev, next } = useContent();
 const showTocDropdown = ref(false);


### PR DESCRIPTION
The section title is not rendering on page load because Github appends a trailing slash to our route (see
https://github.com/centrapay/centrapay-docs/pull/525 for more context).

Stripping the trailing slash from the URL means we can query Nuxt Content's navigation and get a successful match for the current page.

Test plan:
- Confirm section title is rendered when navigating to v2 guide pages
- Confirm section title is rendered when guide pages are refreshed
- Regression: Confirm section title is rendered when using the left-hand nav to switch between guides