### PR TITLE
Add payment activities read permission to merchant terminal role

### DIFF
--- a/legacy/src/api/auth.md
+++ b/legacy/src/api/auth.md
@@ -164,7 +164,7 @@ if there is a flag associated to it then at least one of them must be met.
 | {% break : merchants:update 🗄 %}                |       ✅      |               |                   |                         |         |
 | {% break : patron-codes:create %}                |       ✅      |               |                   |                         |         |
 | {% break : patron-codes:read %}                  |       ✅      |               |         ✅        |                         |    ✅   |
-| {% break : payment-activities:read %}            |       ✅      |               |                   |                         |    ✅   |
+| {% break : payment-activities:read %}            |       ✅      |               |         ✅        |                         |    ✅   |
 | {% break : payment-conditions:approve %}         |       ✅      |               |         ✅        |                         |    ✅   |
 | {% break : payment-requests:cancel 🗄 %}         |       ✅      |               |         ✅        |                         |    ✅   |
 | {% break : payment-requests:create 🗄 %}         |       ✅      |               |         ✅        |                         |    ✅   |


### PR DESCRIPTION
This PR adds the payment activities read permission to the merchant terminal role in line with the permissions updates
