### PR TITLE
Update Centrapay logo and text

### DIFF
--- a/components/Header.vue
+++ b/components/Header.vue
@@ -1,10 +1,15 @@
 <template>
   <header class="w-full p-4 shadow-md sticky top-0 bg-surface-primary z-10">
-    <div class="prose desktop-gutters flex items-center justify-center space-x-2">
-      <icons-centrapay-logo class="w-12 h-12 fill-brand-accent" />
-      <h1 class="hidden md:block type-headline-3">
-        Centrapay Docs
-      </h1>
+    <div class="prose-a:no-underline max-w-7xl mx-auto flex items-center justify-start space-x-2">
+      <NuxtLink
+        to="/"
+        class="flex items-center"
+      >
+        <icons-centrapay-logo class="icon-3xl fill-brand-accent" />
+        <h1 class="hidden md:block type-headline-4 px-1">
+          Centrapay Docs
+        </h1>
+      </NuxtLink>
     </div>
   </header>
 </template>


### PR DESCRIPTION
The logo and text are aligned to top left. The user is able to click both logo and text to return to docs.centrapay.com.

Test plans:

1. Go to docs.centrapay.com 
2. Check the logo and text are aligned on the left side of the page
3. Go to docs.centrapay.com/v2/guides/farmlands-pos-integration
4. Click the logo and text to return to the homepage(docs.centrapay.com)

![image](https://user-images.githubusercontent.com/32785419/209407861-2f587eb4-8ca2-4651-88f1-a045b11fd6ed.png)
