### PR TITLE
🔧 Fix scrolling when a navigation link is clicked

### DIFF
--- a/assets/css/components/index.css
+++ b/assets/css/components/index.css
@@ -2,3 +2,4 @@
 @import "./cards";
 @import "./icons";
 @import "./images";
+@import "./typography";

--- a/assets/css/components/typography.css
+++ b/assets/css/components/typography.css
@@ -1,0 +1,6 @@
+h2,h3 {
+  @apply
+    scroll-mt-32
+    lg:scroll-mt-24
+  ;
+}

--- a/components/Layout.vue
+++ b/components/Layout.vue
@@ -94,3 +94,10 @@ const section = navigation.find((s) =>
 const { toc } = useContent();
 const showTocDropdown = ref(false);
 </script>
+
+<style>
+html {
+  @apply
+    scroll-smooth;
+}
+</style>


### PR DESCRIPTION
This is essentially reverting code that was removed in this PR: https://github.com/centrapay/centrapay-docs/pull/552/files#diff-9cab4b4c181482f944a8d2c7e97b3456c5e4d18c0d54b10ae745ebdfcc719668 Moved margins when headers are scrolled to a css file.

Test plan: Expect to click a navigation link and have smooth scrolling to visible header below nav bar.