### PR TITLE
💅 Align heading typography to design

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="prose max-w-none">
     <Header />
     <NuxtPage />
   </div>

--- a/assets/css/components/index.css
+++ b/assets/css/components/index.css
@@ -2,4 +2,4 @@
 @import "./cards";
 @import "./icons";
 @import "./images";
-@import "./typography";
+@import "./typography.css";

--- a/assets/css/components/typography.css
+++ b/assets/css/components/typography.css
@@ -1,6 +1,13 @@
-h2,h3 {
+h2 {
   @apply
-    scroll-mt-32
-    lg:scroll-mt-24
+    scroll-mt-20
+    lg:scroll-mt-12
+  ;
+}
+
+h3 {
+  @apply
+    scroll-mt-24
+    lg:scroll-mt-16
   ;
 }

--- a/components/Card.vue
+++ b/components/Card.vue
@@ -1,6 +1,6 @@
 <template>
   <NuxtLink
-    class="card w-full p-2 rounded-xl shadow-sm border border-color-outline-transparent cursor-pointer hover:bg-interactive-tertiary-hover hover:shadow-md focus:ring-1 focus:ring-offset-2 focus:ring-focus-ring"
+    class="not-prose card w-full p-2 rounded-xl shadow-sm border border-color-outline-transparent cursor-pointer hover:bg-interactive-tertiary-hover hover:shadow-md focus:ring-1 focus:ring-offset-2 focus:ring-focus-ring"
     :to="props.link"
   >
     <div class="p-2 space-y-2">
@@ -8,7 +8,7 @@
         :is="currentIcon"
         class="w-6 h-6 fill-brand-accent stroke-brand-accent"
       />
-      <h2>
+      <h2 class="type-headline-4">
         {{ props.title }}
       </h2>
       <p>

--- a/components/Header.vue
+++ b/components/Header.vue
@@ -1,14 +1,14 @@
 <template>
-  <header class="w-full p-4 shadow-md sticky top-0 bg-surface-primary z-10">
-    <div class="prose-a:no-underline max-w-7xl mx-auto flex items-center justify-start space-x-2">
+  <header class="not-prose w-full p-4 shadow-md sticky top-0 bg-surface-primary z-10">
+    <div class="max-w-7xl mx-auto flex items-center justify-start space-x-2">
       <NuxtLink
         to="/"
         class="flex items-center"
       >
         <icons-centrapay-logo class="icon-3xl fill-brand-accent" />
-        <h1 class="hidden md:block type-headline-4 px-1">
+        <span class="hidden md:block type-headline-4 px-1">
           Centrapay Docs
-        </h1>
+        </span>
       </NuxtLink>
     </div>
   </header>

--- a/components/Layout.vue
+++ b/components/Layout.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="prose mx-auto max-w-7xl flex flex-col-reverse min-h-full lg:grid lg:grid-cols-5 lg:gap-8 lg:px-8">
+  <div class="mx-auto max-w-7xl flex flex-col-reverse min-h-full lg:grid lg:grid-cols-5 lg:gap-8 lg:px-8">
     <div
       class="min-w-full max-w-2xl flex-auto px-4 py-3 lg:py-16 lg:max-w-prose lg:col-span-4"
     >
@@ -10,7 +10,7 @@
         >
           <p
             v-if="section"
-            class="text-brand-accent"
+            class="text-brand-accent type-overline"
           >
             {{ section.title }}
           </p>
@@ -22,7 +22,7 @@
       </article>
     </div>
     <nav
-      class="sticky top-[4.5rem] flex flex-col w-full px-4 bg-white drop-shadow-sm lg:max-h-page lg:self-start lg:bg-transparent lg:backdrop-blur-none lg:flex-none lg:overflow-y-auto lg:py-16 lg:col-span-1"
+      class="prose-a:no-underline sticky top-[4.5rem] flex flex-col w-full px-4 bg-white drop-shadow-sm lg:max-h-page lg:self-start lg:bg-transparent lg:backdrop-blur-none lg:flex-none lg:overflow-y-auto lg:py-16 lg:col-span-1"
     >
       <button
         class="px-0 py-3 gap-1 flex items-center focus:outline-none focus:ring-0 mb-0 lg:hidden"
@@ -54,7 +54,7 @@
           >
             <a
               :href="`#${heading.id}`"
-              class="active:text-brand-accent no-underline"
+              class="active:text-brand-accent"
               @click="showTocDropdown = false"
             >
               {{ heading.text }}

--- a/content/guides/farmlands-pos-integration.md
+++ b/content/guides/farmlands-pos-integration.md
@@ -45,7 +45,7 @@ If you need a deeper dive into how to request payment using Centrapay’s APIs, 
 <!-- TODO: Link to Patron Not Present page when it is created -->
 - Accepting payments when  [Patron Not Present](https://www.notion.so/Patron-Not-Present-7da502cf99de4bd1af82a3bf8ed05e90)
 
-## Simple Flow
+### Simple Flow
 
 The Simple Flow should be used when:
 
@@ -339,7 +339,7 @@ sequenceDiagram
 
 After each Payment Condition is accepted or declined, the POS must continue to poll the Payment Request until the Payment Request status is paid. Here, the POS can stop polling and display confirmation of the successful payment.
 
-## Pre Auth Flow
+### Pre Auth Flow
 <!-- TODO: Link to Pre Auth page when it is created -->
 The [Pre Auth](https://www.notion.so/Pre-Auth-5d923a9225a949329d3cccf3d7e3a879) flow involves creating an authorization that ensures funds are available and places a hold on them.
 
@@ -714,7 +714,7 @@ Note over POS: ✅ Display release confirmation
 
     - Example API Request [[API Reference](https://docs.centrapay.com/api/payment-requests#release-funds-held-for-a-pre-auth-payment-request-experimental)]
 
-## Patron Not Present Flow
+### Patron Not Present Flow
 <!-- TODO: Link to Patron Not Present page when it is created -->
 The [Patron Not Present](https://www.notion.so/Patron-Not-Present-7da502cf99de4bd1af82a3bf8ed05e90) flow should be used when the Cardholder is not physically present when a Pre Auth payment is authorised. For example, it can be used to support phone-based orders or where the Farmlands barcode is already known.
 

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <main>
-    <div class="prose desktop-gutters px-4 sm:px-6">
-      <div class="my-4">
+    <div class="desktop-gutters px-4 sm:px-6">
+      <div class="not-prose my-4">
         <h1 class="type-headline-3">
           Getting Started
         </h1>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -19,6 +19,22 @@ const tailwindConfig = {
       maxWidth: {
         '8xl': '88rem',
       },
+      typography: {
+        DEFAULT: {
+          css: {
+            h2: {
+              borderTopWidth: '1px',
+              paddingTop: '48px',
+            },
+            h3: {
+              paddingTop: '32px',
+            },
+            'h2 > a, h3 > a': {
+              textDecorationLine: 'none',
+            },
+          },
+        },
+      },
     },
   },
   plugins: [


### PR DESCRIPTION
* Update headings to use Centrapay typography.
* Add prose class at root to remove repetition.

Test plan: Expect Nuxt pages to have:
* Divider above `<h2>` headings
* Links in paragraphs to be underlines
* Headings to not be underlined