### PR TITLE
🐛 FIX: Add divider above prose h2 headings

### DIFF
--- a/components/Prose.vue
+++ b/components/Prose.vue
@@ -3,8 +3,8 @@
     class="
       prose prose-slate max-w-none
       prose-headings:font-display prose-headings:font-normal
+      prose-h2:scroll-mt-16 prose-h2:mt-8 prose-h2:pt-8 prose-h2:border-t
       prose-h3:scroll-mt-20
-      prose-h2:scroll-mt-24
       prose-lead:text-slate-500
       prose-a:no-underline
       prose-pre:bg-transparent prose-pre:my-0


### PR DESCRIPTION
This styling was removed in Pull Request #561.

Test plan: See divider above h2 headings as pictured. Expect clicking table of contents to scroll aligns H2 at top.

<img width="1292" alt="Screenshot 2023-01-13 at 10 16 32 AM" src="https://user-images.githubusercontent.com/64108933/212182984-f2a70fe0-130a-4397-8e22-f54e74116523.png">