### PR TITLE
Push footer to the bottom of the page

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -1,7 +1,7 @@
 <template>
-  <div>
+  <div class="flex flex-col min-h-screen">
     <Header />
     <NuxtPage />
-    <Footer />
+    <Footer class="mt-auto" />
   </div>
 </template>


### PR DESCRIPTION
The footer sits right underneath the content. If there is not much content on the page, this will mean the footer will be sitting in the middle of the page. This change makes it so that the footer is always at the bottom of the page.

Before:

<img width="2048" alt="image" src="https://user-images.githubusercontent.com/50732795/212600557-fc9a5fee-48e6-4f2f-a43b-95edb513f9eb.png">

After:

<img width="2048" alt="image" src="https://user-images.githubusercontent.com/50732795/212600601-3d875bc8-6122-4e8b-9045-62fa8ad77453.png">
