### PR TITLE
Add Freshdesk widget to every screen for support requests

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -2,6 +2,46 @@
   <div class="flex flex-col min-h-screen">
     <Header />
     <NuxtPage />
+    <button
+      type="button"
+      class="btn-tertiary fixed right-6 bottom-6 border rounded-full shadow-lg flex justify-center w-16 h-16"
+      @click="openFreshWorksWidget"
+    >
+      <messages-bubble-double
+        class="icon-lg"
+        aria-hidden="true"
+      />
+    </button>
     <Footer class="mt-auto" />
   </div>
 </template>
+
+<script setup>
+useHead({
+  script: [
+    {
+      innerHTML: `
+        window.fwSettings={
+        'widget_id':51000002960
+        };
+        !function(){if("function"!=typeof window.FreshworksWidget){var n=function(){n.q.push(arguments)};n.q=[],window.FreshworksWidget=n}}()
+      `,
+      type: 'text/javascript',
+      charset: 'utf-8'
+    },
+    {
+      src: 'https://aus-widget.freshworks.com/widgets/51000002960.js',
+      defer: true,
+      async: true,
+      type: 'text/javascript',
+    },
+  ],
+});
+onMounted(() => {
+  window.FreshworksWidget('hide', 'launcher');
+});
+
+function openFreshWorksWidget() {
+  window.FreshworksWidget('open');
+}
+</script>

--- a/components/icons/MessagesBubbleDouble.vue
+++ b/components/icons/MessagesBubbleDouble.vue
@@ -1,0 +1,26 @@
+<template>
+  <svg
+    width="25"
+    height="25"
+    viewBox="0 0 25 25"
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+  >
+    <path
+      fill-rule="evenodd"
+      clip-rule="evenodd"
+      d="M24.25 13.5C24.25 10.6005 21.8995 8.25 19 8.25H16C13.1005 8.25 10.75 10.6005 10.75 13.5C10.75 16.3995 13.1005 18.75 16 18.75H16.75L21.25 23.25V18.226C23.0783 17.3617 24.246 15.5223 24.25 13.5V13.5Z"
+      stroke="black"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M7.75 12.75L4.75 15.75V10.726C2.53125 9.67785 1.3373 7.23009 1.87719 4.83634C2.41708 2.4426 4.54613 0.744307 7 0.750014H10C12.3218 0.750299 14.368 2.27514 15.032 4.50001"
+      stroke="black"
+      stroke-width="1.5"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+  </svg>
+</template>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -34,8 +34,13 @@ export default defineNuxtConfig({
     buildAssetsDir: '/nuxt/',
     head: {
       title: 'Centrapay Docs',
-      link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }]
-    }
+      link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
+      meta: [
+        // This is needed to send the entire URL of the page in Freshdesk support tickets
+        // Refer to https://community.freshworks.com/freshdesk-11246/where-does-it-come-from-23026
+        { name: 'referrer', content: 'no-referrer-when-downgrade' }
+      ],
+    },
   },
   postcss: {
     plugins: {


### PR DESCRIPTION
This widget allows users to send support requests. These support requests will be sent to our Freshdesk account. Here is an example support request: https://centrapay.freshdesk.com/a/tickets/5312

The widget can be customised via this link: https://centrapay.freshdesk.com/a/admin/widgets/51000002960

<img width="2048" alt="Screen Shot 2023-01-17 at 9 08 59 AM" src="https://user-images.githubusercontent.com/50732795/212796788-795ffbef-ce7b-43ff-9489-f9f66255f442.png">

<img width="413" alt="Screen Shot 2023-01-17 at 9 09 28 AM" src="https://user-images.githubusercontent.com/50732795/212796781-f6702652-9609-4509-be14-80c40a9ede30.png">

<img width="2048" alt="Screen Shot 2023-01-17 at 9 09 11 AM" src="https://user-images.githubusercontent.com/50732795/212796767-f8be22fa-3b91-4112-8a3a-a788c10cb101.png">

Test plan:
- Navigate to https://docs.centrapay.com, see that the freshdesk widget appears
- Fill out the freshdesk widget form and submit it - there should be a ticket created on Freshdesk