### PR TITLE
🐚 Fix Docs link in App Shell

### DIFF
--- a/components/AppShell.vue
+++ b/components/AppShell.vue
@@ -63,11 +63,17 @@
                       :href="item.href"
                       target="_blank"
                       class="group mt-2 w-full flex items-center pl-2 pr-1 py-2 text-left text-content-primary text-base leading-6 font-medium rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
-                      :class="item.current ? 'bg-gray-50 text-content-primary': ''"
                       @click="sidebarOpen = false"
                     >
                       {{ item.name }}
                     </a>
+                    <NuxtLink
+                      class="bg-gray-50 group mt-2 w-full flex items-center pl-2 pr-1 py-2 text-left text-content-primary text-base leading-6 font-medium rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
+                      to="/"
+                      @click="sidebarOpen = false"
+                    >
+                      Docs
+                    </NuxtLink>
                   </div>
                 </nav>
               </div>
@@ -97,7 +103,7 @@
           </div>
         </div>
         <NuxtLink
-          href="/"
+          to="/"
           class="flex items-center justify-center h-16 w-16 bg-brand-primary focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
         >
           <centrapay-logo class="text-content-on-color icon-2xl" />
@@ -106,7 +112,7 @@
       <div class="hidden md:flex md:flex-1 md:justify-between md:py-3">
         <div class="flex items-center">
           <NuxtLink
-            href="/"
+            to="/"
             class="flex items-center justify-center h-16 w-16 bg-brand-primary focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
           >
             <centrapay-logo class="text-content-on-color icon-2xl" />
@@ -118,10 +124,15 @@
               :href="item.href"
               target="_blank"
               class="text-gray-600 text-sm leading-5 font-medium px-3 py-2 rounded-lg hover:bg-gray-200 hover:text-content-primary focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
-              :class="item.current ? 'bg-gray-100': ''"
             >
               {{ item.name }}
             </a>
+            <NuxtLink
+              to="/"
+              class="bg-gray-100 text-gray-600 text-sm leading-5 font-medium px-3 py-2 rounded-lg hover:bg-gray-200 hover:text-content-primary focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
+            >
+              Docs
+            </NuxtLink>
           </div>
         </div>
       </div>
@@ -165,11 +176,10 @@ import {
 } from '@headlessui/vue';
 
 const externalNavigation = [
-  { name: 'Products', href: 'https://centrapay.com/', current: false },
-  { name: 'Solutions', href: 'https://centrapay.com/', current: false },
-  { name: 'Resources', href: 'https://centrapay.com/', current: false },
-  { name: 'Pricing', href: 'https://centrapay.com/', current: false },
-  { name: 'Docs', href: '/', current: true },
+  { name: 'Products', href: 'https://centrapay.com/' },
+  { name: 'Solutions', href: 'https://centrapay.com/' },
+  { name: 'Resources', href: 'https://centrapay.com/' },
+  { name: 'Pricing', href: 'https://centrapay.com/' },
 ];
 
 const sidebarOpen = ref(false);

--- a/components/SiteNavigation.vue
+++ b/components/SiteNavigation.vue
@@ -35,7 +35,7 @@
               :key="firstChild.title"
             >
               <NuxtLink
-                :href="firstChild._path"
+                :to="firstChild._path"
                 class="group mt-2 flex w-full items-center rounded-md py-2 pl-6 pr-2 text-sm font-medium text-content-secondary hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
                 @click="$emit('link-clicked')"
               >
@@ -47,7 +47,7 @@
                   :key="secondChild.title"
                 >
                   <NuxtLink
-                    :href="secondChild._path"
+                    :to="secondChild._path"
                     class="group mt-2 flex w-full items-center rounded-md py-2 pl-8 pr-2 text-sm font-medium text-gray-600 hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
                     @click="$emit('link-clicked')"
                   >


### PR DESCRIPTION
Link should be a `NuxtLink` as it is internal.
Route to docs homepage.
Change NuxtLink to have `to` property instead of `href`.

**Test plan**: Expect pressing `Docs` to route home. Expect other external links to open new tab.