### PR TITLE
Fix bug where direct navigation to Farmlands POS guide page keeps nav…

### DIFF
--- a/components/SiteNavigation.vue
+++ b/components/SiteNavigation.vue
@@ -118,7 +118,11 @@ const urlToActiveNav = {
   '/guides/farmlands-pos-integration': '/connections/farmlands/farmlands-pos-integration'
 };
 const route = useRoute();
-const currentPath = computed(() => urlToActiveNav[route.path] || route.path);
+
+const currentPath = computed(() => {
+  const path = route.path.endsWith('/') ? route.path.slice(0, -1) : route.path;
+  return urlToActiveNav[path] || path;
+});
 </script>
 
 <style scoped>


### PR DESCRIPTION
… menu closed

The problem is to do with trailing slashes being added by GitHub pages when refreshing the page or directly navigating to a page.

We should change where the site is hosted as it seems like this behaviour is not configurable in GitHub pages.

There is a small UI bug where after reloading or directly navigating to the Farmlands POS guide page, opening and closing the nav menu un-highlights the Farmlands POS guide in the nav menu. This should be fixed after changing the site host.

Test plan:
- Navigate to https://docs.centrapay.com/guides/farmlands-pos-integration/ - see that the nav menu "Connections" section is open