### PR TITLE
🔧 Make API reference links open in new tab

### DIFF
--- a/components/content/ProseA.vue
+++ b/components/content/ProseA.vue
@@ -29,5 +29,5 @@ const props = defineProps({
 
 const isApiReferenceLink = props.href.startsWith('https://docs.centrapay.com/api');
 
-const isExternalLink = !props.href.startsWith('https://docs.centrapay.com');
+const isExternalLink = !props.href.startsWith('https://docs.centrapay.com') || isApiReferenceLink;
 </script>


### PR DESCRIPTION
**Test plan**: Click API reference link and expect new tab to open.