### PR TITLE
add error response for create invitations

### DIFF
--- a/legacy/src/api/invitations.md
+++ b/legacy/src/api/invitations.md
@@ -102,9 +102,10 @@ An Invitation can be used to allow users to claim ownership of a resource on the
 
 {% h4 Error Responses %}
 
-| Status |         Code         |                             Description                             |
-| :----- | :------------------- | :------------------------------------------------------------------ |
-| 403    | INVALID_ACCOUNT_TYPE | The resourceId is associated with an account with a non `org` type. |
+| Status |           Code            |                                 Description                                  |
+| :----- | :-------------------------| :--------------------------------------------------------------------------- |
+| 403    | INVALID_ACCOUNT_TYPE      | The resourceId is associated with an account with a non `org` type.          |
+| 403    | RECIPIENT_ALREADY_INVITED | An active invitation with this recipientAlias and resourceId already exists. |
 
 ### Get an Invitation by code **EXPERIMENTAL**
 

--- a/legacy/src/api/invitations.md
+++ b/legacy/src/api/invitations.md
@@ -102,10 +102,10 @@ An Invitation can be used to allow users to claim ownership of a resource on the
 
 {% h4 Error Responses %}
 
-| Status |           Code            |                                 Description                                  |
-| :----- | :-------------------------| :--------------------------------------------------------------------------- |
-| 403    | INVALID_ACCOUNT_TYPE      | The resourceId is associated with an account with a non `org` type.          |
-| 403    | RECIPIENT_ALREADY_INVITED | An active invitation with this recipientAlias and resourceId already exists. |
+| Status |           Code            |                                                       Description                                                           |
+| :----- | :-------------------------| :-------------------------------------------------------------------------------------------------------------------------- |
+| 403    | INVALID_ACCOUNT_TYPE      | The resourceId is associated with an account with a non `org` type.                                                         |
+| 403    | RECIPIENT_ALREADY_INVITED | An active invitation for this recipientAlias and resource already exists, or the recipient has already joined the resource. |
 
 ### Get an Invitation by code **EXPERIMENTAL**
 


### PR DESCRIPTION
The create invitation API now returns an error if an invitation already exists that:
1. has matching recipientAlias
2. has matching resourceId
3. has not expired

This change is to add the error response to the docs.
Story: https://www.notion.so/centrapay/Invite-Members-to-account-using-email-API-calls-5a0af08b6a68462f9d04793a77e34251