### PR TITLE
💅 Remove font weight on prose links and accent colour from h4

### DIFF
--- a/components/content/ProseA.vue
+++ b/components/content/ProseA.vue
@@ -2,7 +2,7 @@
   <NuxtLink
     :to="props.href"
     :target="isExternalLink ? '_blank' : '_self'"
-    class="no-underline hover:no-underline inline-flex justify-center items-center"
+    class="font-normal no-underline hover:no-underline inline-flex justify-center items-center"
   >
     <span class="hover:underline"><slot /></span>
     <span v-if="isExternalLink || isApiReferenceLink">&nbsp;</span>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -29,7 +29,7 @@ const tailwindConfig = {
                 textDecorationLine: 'underline',
               },
             },
-            'h2 > a, h3 > a': {
+            'h2 > a, h3 > a, h4 > a': {
               color: colors.light['content-primary'],
               '&:hover': {
                 textDecorationLine: 'none',


### PR DESCRIPTION
Test plan: Expect links from markdown content to have normal font weight. Expect h4 when added to not be accent colour.