### PR TITLE
⏮️ Revert: Keep Nuxt default scroll behaviour

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -18,14 +18,6 @@
 </template>
 
 <script setup>
-const nuxtApp = useNuxtApp();
-nuxtApp.hook('page:finish', () => {
-  window.scrollTo({
-    top: 0,
-    behavior: 'instant',
-  });
-});
-
 useHead({
   script: [
     {


### PR DESCRIPTION
A hook had been added to scroll to the top instantly when on a new page. 

This was because the following behaviour was undesirable: Scrolling to bottom of Farmlands Partner page and clicking 'POS Integration Guide' resulted in the POS Integration Guide loading and then scrolling automatically from the bottom to the top of the page. However, this caused a regression as if your URL led to a title, e.g. https://docs.centrapay.com/guides/farmlands-pos-integration/#pre-auth-flow you would end up at the top of the page.

By default, Nuxt scrolls to the top when you go to another page, but the scroll is smooth.
We could override the [scrollBehaviour](https://nuxtjs.org/docs/configuration-glossary/configuration-router#scrollbehavior) to provide instant scrolling on a new page. Here is the default behaviour: https://github.com/nuxt/nuxt/blob/2.x-dev/packages/vue-app/template/router.scrollBehavior.js
IMO we should revert and keep the default behaviour.