### PR TITLE
Update App Shell to match mobile design

### DIFF
--- a/components/AppShell.vue
+++ b/components/AppShell.vue
@@ -2,133 +2,77 @@
   <div class="min-h-full">
     <TransitionRoot
       as="template"
-      :show="sidebarOpen"
+      :show="mainMenuOpen"
     >
       <Dialog
         as="div"
-        class="relative z-40 md:hidden"
-        @close="sidebarOpen = false"
+        class="relative md:hidden"
       >
-        <TransitionChild
-          as="template"
-          enter="transition-opacity ease-linear duration-300"
-          enter-from="opacity-0"
-          enter-to="opacity-100"
-          leave="transition-opacity ease-linear duration-300"
-          leave-from="opacity-100"
-          leave-to="opacity-0"
-        >
-          <div class="fixed inset-0 bg-gray-600 bg-opacity-75" />
-        </TransitionChild>
-
-        <div class="fixed inset-0 z-40 flex">
+        <div class="fixed inset-x-0 inset-y-0 pt-16 flex min-h-full">
           <TransitionChild
             as="template"
-            enter="transition ease-in-out duration-300 transform"
-            enter-from="-translate-x-full"
-            enter-to="translate-x-0"
-            leave="transition ease-in-out duration-300 transform"
-            leave-from="translate-x-0"
-            leave-to="-translate-x-full"
+            enter="transition ease-in-out duration-150 transform"
+            enter-from="-translate-y-full"
+            enter-to="translate-y-0"
+            leave="transition ease-in-out duration-150 transform"
+            leave-from="translate-y-0"
+            leave-to="-translate-y-full"
           >
-            <DialogPanel class="relative flex w-full max-w-xs flex-1 flex-col bg-surface-primary pt-5 pb-4">
-              <TransitionChild
-                as="template"
-                enter="ease-in-out duration-300"
-                enter-from="opacity-0"
-                enter-to="opacity-100"
-                leave="ease-in-out duration-300"
-                leave-from="opacity-100"
-                leave-to="opacity-0"
-              >
-                <div class="absolute top-0 right-0 -mr-12 pt-2">
-                  <!-- FIXME: This should be a button -->
-                  <div
-                    type="button"
-                    class="ml-1 flex h-10 w-10 items-center justify-center rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"
-                    @click="sidebarOpen = false"
-                  >
-                    <span class="sr-only">Close sidebar</span>
-                    <close-outline class="text-content-on-color" />
-                  </div>
-                </div>
-              </TransitionChild>
-              <div class="h-0 flex-1 overflow-y-auto">
+            <DialogPanel class="relative flex w-full flex-1 flex-col bg-surface-primary">
+              <div class="h-0 flex-1 overflow-y-auto pt-5 pb-4">
                 <nav class="space-y-1 px-2">
-                  <div class="pt-1 pb-4">
-                    <SiteNavigation @link-clicked="sidebarOpen = false" />
-                    <NuxtLink
-                      v-for="item in primaryNavigation"
-                      :key="item.name"
-                      :href="item.href"
-                      :target="item.target"
-                      class="group mt-2 w-full flex items-center pl-2 pr-1 py-2 text-left text-content-primary text-base leading-6 font-medium rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
-                      @click="sidebarOpen = false"
-                    >
-                      {{ item.name }}
-                    </NuxtLink>
-                  </div>
+                  <SiteNavigation @link-clicked="mainMenuOpen = false" />
                 </nav>
               </div>
             </DialogPanel>
           </TransitionChild>
-          <div
-            class="w-14 flex-shrink-0"
-            aria-hidden="true"
-          >
-            <!-- Dummy element to force sidebar to shrink to fit close icon -->
-          </div>
         </div>
       </Dialog>
     </TransitionRoot>
 
     <div class="fixed bg-white inset-x-0 z-10 flex h-16 flex-shrink-0 shadow">
-      <div class="flex w-full justify-between md:hidden">
-        <!-- FIXME: This should be a button -->
-        <div
-          type="button"
-          class="flex items-center pl-6 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
-          @click="sidebarOpen = true"
-        >
-          <div>
-            <span class="sr-only">Open sidebar</span>
-            <navigation-menu class="text-content-tertiary" />
-          </div>
-        </div>
-        <NuxtLink
-          to="/"
-          class="flex items-center justify-center h-16 w-16 bg-brand-primary focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
-        >
-          <centrapay-logo class="text-content-on-color icon-2xl" />
-        </NuxtLink>
-      </div>
-      <div class="hidden md:flex md:flex-1 md:justify-between md:py-3">
+      <div class="flex w-full justify-between">
         <div class="flex items-center">
           <NuxtLink
             to="/"
             class="flex items-center justify-center h-16 w-16 bg-brand-primary focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
+            @click="mainMenuOpen = false"
           >
             <centrapay-logo class="text-content-on-color icon-2xl" />
           </NuxtLink>
           <div class="flex flex-row space-x-1 ml-7">
             <NuxtLink
-              v-for="item in primaryNavigation"
-              :key="item.name"
-              :href="item.href"
-              :target="item.target"
-              class="text-gray-600 text-sm leading-5 font-medium px-3 py-2 rounded-lg hover:bg-gray-200 hover:text-content-primary focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
-              :class="item.current ? 'bg-gray-100': ''"
+              href="/"
+              target="_self"
+              class="text-gray-600 text-sm leading-5 font-medium px-3 py-2 rounded-lg bg-gray-100 hover:bg-gray-200 hover:text-content-primary focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
+              @click="mainMenuOpen = false"
             >
-              {{ item.name }}
+              Docs
             </NuxtLink>
           </div>
         </div>
+        <button
+          class="flex items-center pr-6 md:hidden focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
+          @click="mainMenuOpen = !mainMenuOpen"
+        >
+          <span class="sr-only">Open Main Menu</span>
+          <navigation-menu
+            v-if="!mainMenuOpen"
+            class="block h-6 w-6 text-content-tertiary"
+            aria-hidden="true"
+          />
+          <close-outline
+            v-else
+            class="block h-6 w-6 text-content-tertiary"
+            aria-hidden="true"
+          />
+        </button>
       </div>
     </div>
 
     <!-- Static sidebar for desktop -->
     <div class="hidden border-t md:fixed md:h-full md:inset-y-16 md:flex md:w-64 xl:w-80 md:flex-col">
-      <div class="flex flex-grow flex-col overflow-y-auto border-r border-gray-200 bg-white">
+      <div class="flex flex-grow flex-col overflow-y-auto pt-5 border-r border-gray-200 bg-white">
         <div class="flex flex-grow flex-col">
           <nav
             class="flex-1 space-y-1 bg-white px-2"
@@ -163,9 +107,5 @@ import {
   DisclosurePanel,
 } from '@headlessui/vue';
 
-const primaryNavigation = [
-  { name: 'Docs', href: '/', target: '_self', current: true },
-];
-
-const sidebarOpen = ref(false);
+const mainMenuOpen = ref(false);
 </script>


### PR DESCRIPTION
Test plan:
- Verify navbar visible in mobile view
- Verify Centrapay logo is on the left hand side of the navbar to maintain UI consistency
- Verify sidebar button is on the right of the navbar to make it more accessible
- Verify sidebar transitions up from below the navbar when sidebar button pressed
- Verify sidebar dialog button updates to close button when sidebar is open
- Verify sidebar is closed when Centrapay Logo or "Docs" are pressed
- Verify no UI/UX regressions for displays at or above the medium breakpoint

Standard view:
<img width="350" alt="image" src="https://user-images.githubusercontent.com/46909693/214225165-88a6c7af-6bf5-42c3-a9d0-10f3978b89b9.png">


Sidebar open:
<img width="349" alt="image" src="https://user-images.githubusercontent.com/46909693/214225206-3c81384f-7c90-4b2f-ba51-3312894735e0.png">


No regressions on >md screen sizes
<img width="1322" alt="image" src="https://user-images.githubusercontent.com/46909693/214225500-4c113a8b-15f0-4030-8040-1bab0ef5397c.png">

