### PR TITLE
Make POS guide the default guides content

### DIFF
--- a/components/SiteNavigation.vue
+++ b/components/SiteNavigation.vue
@@ -97,7 +97,7 @@ const navigation = [
     children: [
       {
         title: 'Merchant Integrations',
-        path: '/guides/merchant-integrations',
+        path: '/guides/point-of-sale',
         children: [
           {
             title: 'Point of Sale',

--- a/content/guides/merchant-integrations.md
+++ b/content/guides/merchant-integrations.md
@@ -1,2 +1,0 @@
-<!-- FIXME: Create a Merchant Integration landing page -->
-<meta http-equiv="refresh" content="0; URL=/guides/merchant-payment-conditions">

--- a/content/reference/merchant-integrations.md
+++ b/content/reference/merchant-integrations.md
@@ -1,2 +1,0 @@
-<!-- FIXME: Create a Merchant Integration landing page -->
-<meta http-equiv="refresh" content="0; URL=/guides/merchant-payment-conditions">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -25,7 +25,7 @@
         class="mb-4"
         title="Guides"
         description="Checkout our Guides for hints on where to begin."
-        :link="config.baseUrl + '/guides'"
+        link="/guides/point-of-sale"
       />
       <landing-page-card
         icon-name="Rocket"


### PR DESCRIPTION
Update the "Guides" home page card and the "Merchant Integrations" sidebar item to point to the Point of Sale guide. This is likely temporary until we have appropriate default content. The POS guide is a more sensible default in the meantime.

Test plan:
- Confirm that the Guides home page card takes readers to the POS guide content
- Confirm that the Merchant Integrations sidebar item takes readers to the Point of Sale guide content