### PR TITLE
❌ Remove tailwind typography extension for link styling

### DIFF
--- a/components/Prose.vue
+++ b/components/Prose.vue
@@ -6,7 +6,7 @@
       prose-h2:scroll-mt-16 prose-h2:mt-8 prose-h2:pt-8 prose-h2:border-t
       prose-h3:scroll-mt-20
       prose-lead:text-slate-500
-      prose-a:no-underline
+      prose-a:no-underline prose-a:text-content-primary hover:prose-a:no-underline
       prose-pre:bg-transparent prose-pre:my-0
       prose-img:mb-8 prose-img:mx-auto prose-img:object-contain
     "

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,21 +16,6 @@ const tailwindConfig = {
         ...colors.light,
         current: 'currentColor',
       },
-      maxWidth: {
-        '8xl': '88rem',
-      },
-      typography: (theme) => ({
-        DEFAULT: {
-          css: {
-            'h2 > a, h3 > a': {
-              color: colors.light['content-primary'],
-              '&:hover': {
-                textDecorationLine: 'none',
-              },
-            },
-          },
-        },
-      }),
     },
   },
   plugins: [


### PR DESCRIPTION
The ProseA.vue file applies styling to links within the body. Therefore, the heading styling can be taken to the Prose.vue file. This removes having additional styling in our tailwind config.

Test plan: Expect links that are headings and body links to appear unchanged.

<img width="1326" alt="Screenshot 2023-01-25 at 2 32 02 PM" src="https://user-images.githubusercontent.com/64108933/214460274-10129bb2-8c09-40b8-ae51-e588ac45a647.png">

