### PR TITLE
🐛 Fix link colour in Farmlands partner page

### DIFF
--- a/pages/connections/farmlands.vue
+++ b/pages/connections/farmlands.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <header
-      class="bg-bottom bg-cover bg-[#174B33] bg-blend-overlay bg-[url('~/assets/images/countryside.jpg')]"
+      class="not-prose bg-bottom bg-cover bg-[#174B33] bg-blend-overlay bg-[url('~/assets/images/countryside.jpg')]"
     >
       <Prose class="desktop-gutters px-8 py-16 space-y-6">
         <h1 class="type-display text-content-inverse-primary mb-8 mt-4">


### PR DESCRIPTION
Fix regression introduced in Pull Request #623.

Prose class was overriding the links to make them text-content-primary. Fix the header section to not use the prose class.

Test plan: Expect links to appear as per screenshot.
<img width="223" alt="Screenshot 2023-01-26 at 11 12 12 AM" src="https://user-images.githubusercontent.com/64108933/214703367-27ed4c3d-1471-492d-a22e-de0883e0a722.png">
