### PR TITLE
🐛 Fix: Open disclosure of active navigation item when link in body is clicked

### DIFF
--- a/components/AppShell.vue
+++ b/components/AppShell.vue
@@ -71,7 +71,7 @@
     </div>
 
     <!-- Static sidebar for desktop -->
-    <div class="hidden border-t md:fixed md:h-full md:inset-y-16 md:flex md:w-64 xl:w-80 md:flex-col">
+    <div class="hidden md:fixed md:h-full md:inset-y-16 md:flex md:w-64 xl:w-80 md:flex-col">
       <div class="flex flex-grow flex-col overflow-y-auto pt-5 border-r border-gray-200 bg-white">
         <div class="flex flex-grow flex-col">
           <nav

--- a/components/SiteNavigation.vue
+++ b/components/SiteNavigation.vue
@@ -4,67 +4,18 @@
       v-for="item in navigation"
       :key="item.title"
     >
-      <Disclosure
-        v-if="item.children"
-        v-slot="{ open }"
-        as="div"
-        :default-open="currentPath.startsWith(item.path)"
-      >
-        <DisclosureButton
-          class="group mt-2 w-full flex items-center pl-2 pr-1 py-2 space-x-2 text-left rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
-          :class="currentPath.startsWith(item.path) ? 'bg-gray-100' : ''"
-        >
-          <component
-            :is="item.icon"
-            class="icon-md flex-shrink-0 text-content-tertiary group-hover:text-content-secondary"
-            aria-hidden="true"
-          />
-          <span class="flex-1 text-content-primary text-base leading-5 font-medium">{{ item.title }}</span>
-          <disclosure-arrow-right :class="[open ? 'text-gray-400 rotate-90' : 'text-gray-300', 'ml-3 icon-md flex-shrink-0 transform transition-colors duration-150 ease-in-out group-hover:text-gray-400']" />
-        </DisclosureButton>
-        <transition
-          enter-active-class="transition duration-100 ease-out"
-          enter-from-class="transform scale-95 opacity-0"
-          enter-to-class="transform scale-100 opacity-100"
-          leave-active-class="transition duration-75 ease-out"
-          leave-from-class="transform scale-100 opacity-100"
-          leave-to-class="transform scale-95 opacity-0"
-        >
-          <DisclosurePanel>
-            <div
-              v-for="firstChild in item.children"
-              :key="firstChild.title"
-            >
-              <NuxtLink
-                :to="firstChild.path"
-                class="group mt-2 flex w-full items-center rounded-md py-2 pl-6 pr-2 text-sm font-medium text-content-secondary hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
-                @click="$emit('link-clicked')"
-              >
-                {{ firstChild.title }}
-              </NuxtLink>
-              <div v-if="firstChild.children">
-                <div
-                  v-for="secondChild in firstChild.children"
-                  :key="secondChild.title"
-                >
-                  <NuxtLink
-                    :to="secondChild.path"
-                    class="group mt-2 flex w-full items-center rounded-md py-2 pl-8 pr-2 text-sm font-medium text-gray-600 hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
-                    @click="$emit('link-clicked')"
-                  >
-                    {{ secondChild.title }}
-                  </NuxtLink>
-                </div>
-              </div>
-            </div>
-          </DisclosurePanel>
-        </transition>
-      </Disclosure>
+      <div v-if="item.children">
+        <SiteNavigationDisclosure
+          :url-to-active-nav="urlToActiveNav"
+          :navigation-item="item"
+          @link-clicked="$emit('link-clicked')"
+        />
+      </div>
       <NuxtLink
         v-else
         target="_blank"
         :to="item.path"
-        class="group mt-2 w-full flex items-center pl-2 pr-1 py-2 space-x-2 text-left rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
+        class="group mt-2 w-full flex items-center pl-3 pr-1 py-2 space-x-3 text-left rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
       >
         <component
           :is="item.icon"
@@ -78,14 +29,7 @@
 </template>
 
 <script setup>
-import { useRoute } from 'vue-router';
-import {
-  Disclosure,
-  DisclosureButton,
-  DisclosurePanel,
-} from '@headlessui/vue';
-
-emits: ['link-clicked' ];
+const emit = defineEmits([ 'link-clicked' ]);
 
 const config = useRuntimeConfig();
 // TODO Make the navigation dynamically pick up all the pages in content folder
@@ -185,19 +129,4 @@ const urlToActiveNav = {
   '/guides/requesting-payment': '/reference/merchant-integrations/requesting-payment',
   '/guides/merchant-integration-barcode-flow': '/reference/merchant-integrations/merchant-integration-barcode-flow',
 };
-const route = useRoute();
-
-const currentPath = computed(() => {
-  const path = route.path.endsWith('/') ? route.path.slice(0, -1) : route.path;
-  return urlToActiveNav[path] || path;
-});
 </script>
-
-<style scoped>
-.router-link-active {
-  @apply
-    bg-gray-50
-    text-content-primary
-  ;
-}
-</style>

--- a/components/SiteNavigationDisclosure.vue
+++ b/components/SiteNavigationDisclosure.vue
@@ -1,0 +1,100 @@
+<template>
+  <Disclosure
+    as="div"
+  >
+    <DisclosureButton
+      class="group mt-2 w-full flex items-center pl-3 pr-1 py-2 space-x-3 text-left rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
+      :class="currentPath.startsWith(navigationItem.path) ? 'bg-gray-100' : ''"
+      @click="open = !open"
+    >
+      <component
+        :is="navigationItem.icon"
+        class="icon-md flex-shrink-0 text-content-tertiary group-hover:text-content-secondary"
+        aria-hidden="true"
+      />
+      <span class="flex-1 text-content-primary text-base leading-5 font-medium">{{ navigationItem.title }}</span>
+      <disclosure-arrow-right :class="[open ? 'text-gray-400 rotate-90' : 'text-gray-300', 'ml-3 icon-md flex-shrink-0 transform transition-colors duration-150 ease-in-out group-hover:text-gray-400']" />
+    </DisclosureButton>
+    <transition
+      enter-active-class="transition duration-100 ease-out"
+      enter-from-class="transform scale-95 opacity-0"
+      enter-to-class="transform scale-100 opacity-100"
+      leave-active-class="transition duration-75 ease-out"
+      leave-from-class="transform scale-100 opacity-100"
+      leave-to-class="transform scale-95 opacity-0"
+    >
+      <div v-show="open">
+        <DisclosurePanel static>
+          <div
+            v-for="firstChild in navigationItem.children"
+            :key="firstChild.title"
+          >
+            <NuxtLink
+              :to="firstChild.path"
+              class="group mt-2 flex w-full items-center rounded-md py-2 pl-3 pr-2 text-sm font-medium text-content-secondary hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
+              @click="$emit('link-clicked')"
+            >
+              {{ firstChild.title }}
+            </NuxtLink>
+            <div v-if="firstChild.children">
+              <div
+                v-for="secondChild in firstChild.children"
+                :key="secondChild.title"
+              >
+                <NuxtLink
+                  :to="secondChild.path"
+                  class="group mt-2 flex w-full items-center rounded-md py-2 pl-11 pr-2 text-sm font-medium text-gray-600 hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
+                  @click="$emit('link-clicked')"
+                >
+                  {{ secondChild.title }}
+                </NuxtLink>
+              </div>
+            </div>
+          </div>
+        </DisclosurePanel>
+      </div>
+    </transition>
+  </Disclosure>
+</template>
+
+<script setup>
+import { ref } from 'vue';
+import { useRoute } from 'vue-router';
+
+import {
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel,
+} from '@headlessui/vue';
+
+const props = defineProps({
+  navigationItem: { type: Object, required: true },
+  urlToActiveNav: { type: Object, required: true },
+});
+
+const emit = defineEmits([ 'link-clicked' ]);
+
+const route = useRoute();
+const currentPath = computed(() => {
+  const path = route.path.endsWith('/') ? route.path.slice(0, -1) : route.path;
+  return props.urlToActiveNav[path] || path;
+});
+const open = ref(currentPath.value.startsWith(props.navigationItem.path));
+watch(currentPath, (newPath) => {
+  if (open.value) {
+    // If disclosure is already open, leave it open
+    return;
+  }
+  open.value = newPath.startsWith(props.navigationItem.path);
+});
+</script>
+
+<style scoped>
+.router-link-active {
+  @apply
+    bg-gray-100
+    text-content-primary
+    hover:bg-gray-200
+  ;
+}
+</style>


### PR DESCRIPTION
Previous behaviour: If you were on the Farmlands POS Integration guide and clicked a link in the body to a page under 'References', the 'References' section would show as active but the disclosure would not open. Change to open the disclosure of the active navigation section when the route changes.

Test plan: Expect disclosure of active navigation section to open when route changes.

<img width="319" alt="Screenshot 2023-01-26 at 4 21 39 PM" src="https://user-images.githubusercontent.com/64108933/214752008-42c38a41-7183-4810-8fc2-62bdba0ff4fc.png">
