### PR TITLE
add accountName to invitation params

### DIFF
--- a/legacy/src/api/invitations.md
+++ b/legacy/src/api/invitations.md
@@ -47,10 +47,10 @@ An Invitation can be used to allow users to claim ownership of a resource on the
 
 ### Params
 
-| Field |  Type  |                                                                              Description                                                                              |
-| :---- | :----- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| role  | String | The role that will be assigned to the account. Supported values are `account-owner`, `cashier`. Required when [Invitation](#invitation) type is `account-membership`. |
-| accountName  | String | The name of the business that is inviting a new member. Used when creating a new account membership |
+|    Field    |  Type  |                                              Description                                               |
+| :---------- | :----- | :----------------------------------------------------------------------------------------------------- |
+| role        | String | The role assigned to the recipient, for invitations of type `account-membership`.                      |
+| accountName | String | The name of the account that the recipient is invited to, for invitations of type `account-membership` |
 
 ## Operations
 
@@ -72,13 +72,14 @@ An Invitation can be used to allow users to claim ownership of a resource on the
 
 {% h4 Required Fields %}
 
-|     Field      |        Type        |                               Description                                            |
-| :------------- | :----------------- | :----------------------------------------------------------------------------------- |
-| type           | String             | The type of invitation. Supported values are `account-membership`.                   |
-| resourceId     | String             | The id of the related resource.                                                      |
-| resourceType   | String             | The type of the related resource. Supported values are `account`.                    |
-| recipientAlias | String             | The email address of the user accepting the Invitation.                              |
-| params         | Object             | [Params](#params) depending on the Invitation type.                                  |
+|     Field      |  Type  |                                 Description                                 |
+| :------------- | :----- | :-------------------------------------------------------------------------- |
+| type           | String | The type of invitation. Supported values are `account-membership`.          |
+| resourceId     | String | The id of the related resource.                                             |
+| resourceType   | String | The type of the related resource. Supported values are `account`.           |
+| recipientAlias | String | The email address of the user accepting the Invitation.                     |
+| params         | Object | [Params](#params) depending on the Invitation type.                         |
+| role           | String | The role that will be assigned to the user when the Invitation is accepted. |
 
 {% h4 Example response payload %}
 

--- a/legacy/src/api/invitations.md
+++ b/legacy/src/api/invitations.md
@@ -50,6 +50,7 @@ An Invitation can be used to allow users to claim ownership of a resource on the
 | Field |  Type  |                                                                              Description                                                                              |
 | :---- | :----- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | role  | String | The role that will be assigned to the account. Supported values are `account-owner`, `cashier`. Required when [Invitation](#invitation) type is `account-membership`. |
+| accountName  | String | The name of the business inviting a new member. Required when [Invitation](#invitation) type is `account-membership`. |
 
 ## Operations
 

--- a/legacy/src/api/invitations.md
+++ b/legacy/src/api/invitations.md
@@ -50,7 +50,7 @@ An Invitation can be used to allow users to claim ownership of a resource on the
 | Field |  Type  |                                                                              Description                                                                              |
 | :---- | :----- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | role  | String | The role that will be assigned to the account. Supported values are `account-owner`, `cashier`. Required when [Invitation](#invitation) type is `account-membership`. |
-| accountName  | String | The name of the business inviting a new member. Required when [Invitation](#invitation) type is `account-membership`. |
+| accountName  | String | The name of the business that is inviting a new member. Used when creating a new account membership |
 
 ## Operations
 
@@ -96,7 +96,8 @@ An Invitation can be used to allow users to claim ownership of a resource on the
   "updatedBy": "crn:WIj211vFs9cNACwBb04vQw:api-key:MyApiKey",
   "recipientAlias": "user@org.com",
   "params": {
-		"role": "cashier"
+		"role": "cashier",
+    "accountName": "Centrapay Cafe"
 	}
 }
 {% endjson %}
@@ -157,7 +158,8 @@ An Invitation can be used to allow users to claim ownership of a resource on the
       "updatedBy": "crn:WIj211vFs9cNACwBb04vQw:api-key:MyApiKey",
       "recipientAlias": "user@org.com",
       "params": {
-        "role": "account-owner"
+        "role": "account-owner",
+        "accountName": "Centrapay Cafe"
       }
     },
     {
@@ -173,7 +175,8 @@ An Invitation can be used to allow users to claim ownership of a resource on the
       "updatedBy": "crn:WIj211vFs9cNACwBb04vQw:api-key:MyApiKey",
       "recipientAlias": "john.doe@org.com",
       "params": {
-        "role": "cashier"
+        "role": "cashier",
+        "accountName": "Centrapay Tea Warehouse"
       }
     },
   ]


### PR DESCRIPTION
In order for the business name to be included in the invitation a model a decision was made to include the accountName in the invitation params object. 

[Notion Story](https://www.notion.so/centrapay/Invite-Members-to-account-using-email-API-calls-5a0af08b6a68462f9d04793a77e34251#ef92c233cbcf49f0bfe336a89fef2cbe)

[Invitation Model](https://www.notion.so/centrapay/Invitations-Table-210a1f84d210468886a40c70ea2220bc#f21fb9dd5ffc4af29dc8817941cce870)

[Accept invitation component example](https://www.figma.com/file/sYaRtjGrveRms2lnRxUo3a/Components?t=DmxkSh2FRF6LvncD-0)

How to test: 

1. Check the accountName exists on the params description on the invitation docs