### PR TITLE
Make navigation dynamically pick up pages in the content folder

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -27,4 +27,5 @@ jobs:
           node-version: '16'
       - run: yarn install --frozen-lock-file
       - run: yarn lint
+      - run: yarn test
       - run: ./build.sh

--- a/app.vue
+++ b/app.vue
@@ -18,6 +18,8 @@
 </template>
 
 <script setup>
+import Navigation from './utils/Navigation';
+
 useHead({
   titleTemplate: (titleChunk) => titleChunk === 'Centrapay Docs' ? titleChunk : `${titleChunk} - Centrapay Docs`,
   script: [
@@ -53,6 +55,10 @@ useHead({
     },
   ],
 });
+const config = useRuntimeConfig();
+const content = await queryContent().find();
+Navigation.create({ baseUrl: config.public.baseUrl, content });
+
 onMounted(() => {
   window.FreshworksWidget('hide', 'launcher');
 });

--- a/components/SiteNavigation.vue
+++ b/components/SiteNavigation.vue
@@ -1,12 +1,11 @@
 <template>
   <div>
     <div
-      v-for="item in navigation"
+      v-for="item in menu.children"
       :key="item.title"
     >
-      <div v-if="item.children">
+      <div v-if="item.children.length">
         <SiteNavigationDisclosure
-          :url-to-active-nav="urlToActiveNav"
           :navigation-item="item"
           @link-clicked="$emit('link-clicked')"
         />
@@ -14,7 +13,7 @@
       <NuxtLink
         v-else
         target="_blank"
-        :to="item.path"
+        :to="item.to"
         class="group mt-2 w-full flex items-center pl-3 pr-1 py-2 space-x-3 text-left rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
       >
         <component
@@ -29,104 +28,8 @@
 </template>
 
 <script setup>
+import Navigation from '../utils/Navigation';
 const emit = defineEmits([ 'link-clicked' ]);
 
-const config = useRuntimeConfig();
-// TODO Make the navigation dynamically pick up all the pages in content folder
-const navigation = [
-  {
-    title: 'Reference',
-    path: '/reference',
-    icon: 'receipt',
-    children: [
-      {
-        title: 'Merchant Integrations',
-        path: '/guides/point-of-sale',
-        children: [
-          {
-            title: 'Point of Sale',
-            path: '/guides/point-of-sale',
-          },
-          {
-            title: 'Requesting Payment',
-            path: '/guides/requesting-payment',
-          },
-          {
-            title: 'QR Code Flow',
-            path: '/guides/merchant-integration-qr-code-flow',
-          },
-          {
-            title: 'Barcode Flow',
-            path: '/guides/merchant-integration-barcode-flow',
-          },
-          {
-            title: 'Error Handling',
-            path: '/guides/merchant-integration-error-handling',
-          },
-          {
-            title: 'Transaction Reporting',
-            path: '/guides/transaction-reporting',
-          },
-          {
-            title: 'Initiating Refunds',
-            path: '/guides/initiating-refunds',
-          },
-          {
-            title: 'Line Items',
-            path: '/guides/line-items',
-          },
-          {
-            title: 'Payment Conditions',
-            path: '/guides/payment-conditions',
-          },
-          {
-            title: 'Requesting Pre Auth',
-            path: '/guides/requesting-pre-auth',
-          },
-          {
-            title: 'Patron Not Present',
-            path: '/guides/patron-not-present',
-          },
-        ]
-      }
-    ]
-  },
-  {
-    title: 'Connections',
-    path: '/connections',
-    icon: 'connections',
-    children: [
-      {
-        title: 'Farmlands',
-        path: '/connections/farmlands',
-        children: [
-          {
-            title: 'POS Integration Guide',
-            path: '/guides/farmlands-pos-integration',
-          }
-        ]
-      }
-    ]
-  },
-  {
-    title: 'API',
-    path: config.baseUrl + '/api',
-    icon: 'settings',
-  }
-];
-
-const urlToActiveNav = {
-  '/guides/farmlands-pos-integration': '/connections/farmlands/farmlands-pos-integration',
-  '/guides/payment-conditions': '/reference/merchant-integrations/payment-conditions',
-  '/guides/requesting-pre-auth': '/reference/merchant-integrations/requesting-pre-auth',
-  '/guides/patron-not-present': '/reference/merchant-integrations/patron-not-present',
-  '/guides/merchant-integration-error-handling': '/reference/merchant-integrations/merchant-integration-error-handling',
-  '/guides/line-items': '/reference/merchant-integrations/line-items',
-  '/guides/initiating-refunds': '/reference/merchant-integrations/initiating-refunds',
-  '/guides/point-of-sale': '/reference/merchant-integrations/point-of-sale',
-  '/guides/merchant-integration-qr-code-flow': '/reference/merchant-integrations/merchant-integration-qr-code-flow',
-  '/guides/transaction-reporting': '/reference/merchant-integrations/transaction-reporting',
-  '/guides/requesting-payment': '/reference/merchant-integrations/requesting-payment',
-  '/guides/merchant-integration-barcode-flow': '/reference/merchant-integrations/merchant-integration-barcode-flow',
-};
+const menu = Navigation.getMenu();
 </script>

--- a/components/SiteNavigationDisclosure.vue
+++ b/components/SiteNavigationDisclosure.vue
@@ -4,7 +4,7 @@
   >
     <DisclosureButton
       class="group mt-2 w-full flex items-center pl-3 pr-1 py-2 space-x-3 text-left rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
-      :class="currentPath.startsWith(navigationItem.path) ? 'bg-gray-100' : ''"
+      :class="isNavItemActive ? 'bg-gray-100' : ''"
       @click="open = !open"
     >
       <component
@@ -30,7 +30,7 @@
             :key="firstChild.title"
           >
             <NuxtLink
-              :to="firstChild.path"
+              :to="firstChild.to"
               class="group mt-2 flex w-full items-center rounded-md py-2 pl-3 pr-2 text-sm font-medium text-content-secondary hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
               @click="$emit('link-clicked')"
             >
@@ -42,7 +42,7 @@
                 :key="secondChild.title"
               >
                 <NuxtLink
-                  :to="secondChild.path"
+                  :to="secondChild.to"
                   class="group mt-2 flex w-full items-center rounded-md py-2 pl-11 pr-2 text-sm font-medium text-gray-600 hover:bg-gray-200 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
                   @click="$emit('link-clicked')"
                 >
@@ -59,33 +59,30 @@
 
 <script setup>
 import { ref } from 'vue';
-import { useRoute } from 'vue-router';
 
 import {
   Disclosure,
   DisclosureButton,
   DisclosurePanel,
 } from '@headlessui/vue';
+import Navigation from '../utils/Navigation';
 
 const props = defineProps({
   navigationItem: { type: Object, required: true },
-  urlToActiveNav: { type: Object, required: true },
 });
 
 const emit = defineEmits([ 'link-clicked' ]);
 
 const route = useRoute();
-const currentPath = computed(() => {
-  const path = route.path.endsWith('/') ? route.path.slice(0, -1) : route.path;
-  return props.urlToActiveNav[path] || path;
-});
-const open = ref(currentPath.value.startsWith(props.navigationItem.path));
-watch(currentPath, (newPath) => {
+const currentNavPath = computed(() => Navigation.getCurrentNavPath(route.path));
+const isNavItemActive = computed(() => currentNavPath.value.startsWith(props.navigationItem.to));
+const open = ref(isNavItemActive.value);
+watch(currentNavPath, (newPath) => {
   if (open.value) {
     // If disclosure is already open, leave it open
     return;
   }
-  open.value = newPath.startsWith(props.navigationItem.path);
+  open.value = newPath.startsWith(props.navigationItem.to);
 });
 </script>
 

--- a/content/guides/farmlands-pos-integration.md
+++ b/content/guides/farmlands-pos-integration.md
@@ -2,6 +2,10 @@
 title: Farmlands POS Integration Guide
 img: /farmlands-pos-integration-cover.jpg
 description: Centrapay and Farmlands have entered into a partnership to allow Farmlands Card Partners to accept Farmlands Card payments at the point of sale.
+nav:
+  path: Connections/Farmlands
+  title: POS Integration Guide
+  order: 1
 ---
 
 Centrapay and Farmlands have entered into a partnership to allow Farmlands Card Partners to accept Farmlands Card payments at the point of sale. The benefits include real-time standard industry card checks, the elimination of reconciliation EDI files or manual PDF invoicing, and it unlocks the ability to accept many more payment methods on the Centrapay platform. This solution positions Card Partners to be able to accept digital Farmlands Card payments in the future.

--- a/content/guides/initiating-refunds.md
+++ b/content/guides/initiating-refunds.md
@@ -1,5 +1,8 @@
 ---
 title: Initiating Refunds
+nav:
+  path: Reference/Merchant Integrations
+  order: 7
 ---
 
 Refunds are initiated by calling the [Refund Payment Request](https://docs.centrapay.com/api/payment-requests#refund-a-payment-request-experimental) endpoint.

--- a/content/guides/line-items.md
+++ b/content/guides/line-items.md
@@ -1,5 +1,8 @@
 ---
 title: Line Items
+nav:
+  path: Reference/Merchant Integrations
+  order: 8
 ---
 
 [Line Items](https://docs.centrapay.com/api/payment-requests#line-item) are used to communicate the details of a purchase to a Patron.

--- a/content/guides/merchant-integration-barcode-flow.md
+++ b/content/guides/merchant-integration-barcode-flow.md
@@ -1,5 +1,9 @@
 ---
 title: Barcode Flow for Merchants
+nav:
+  path: Reference/Merchant Integrations
+  title: Barcode Flow
+  order: 4
 ---
 
 Connecting with Patrons using our Barcode Flow requires the Patron to present a Barcode and the merchant integration to scan it in order to [create a Payment Request](https://docs.centrapay.com/api/payment-requests#create-a-payment-request).

--- a/content/guides/merchant-integration-error-handling.md
+++ b/content/guides/merchant-integration-error-handling.md
@@ -1,5 +1,9 @@
 ---
 title: Merchant Integration Error Handling
+nav:
+  path: Reference/Merchant Integrations
+  title: Error Handling
+  order: 5
 ---
 
 Below are our guidelines for dealing with inconsistencies in [Payment Request](https://docs.centrapay.com/api/payment-requests#payment-request) statuses due to network issues or race conditions.

--- a/content/guides/merchant-integration-qr-code-flow.md
+++ b/content/guides/merchant-integration-qr-code-flow.md
@@ -1,5 +1,9 @@
 ---
 title: QR Code Flow for Merchants
+nav:
+  path: Reference/Merchant Integrations
+  title: QR Code Flow
+  order: 3
 ---
 
 Connecting with Patrons using our QR Code Flow requires the merchant integration to create a [Payment Request](https://docs.centrapay.com/api/payment-requests) and present a QR Code for the Patron to scan.

--- a/content/guides/patron-not-present.md
+++ b/content/guides/patron-not-present.md
@@ -1,5 +1,8 @@
 ---
 title: Patron Not Present
+nav:
+  path: Reference/Merchant Integrations
+  order: 11
 ---
 
 Centrapay’s Patron Not Present extension allows a merchant to complete a payment when the Patron is not physically present at the time of payment (e.g. phone-based orders).

--- a/content/guides/payment-conditions.md
+++ b/content/guides/payment-conditions.md
@@ -1,5 +1,8 @@
 ---
 title: Payment Conditions
+nav:
+  path: Reference/Merchant Integrations
+  order: 9
 ---
 
 Some [Asset Types](https://docs.centrapay.com/api/asset-types) such as tokens or closed-loop cards may require conditional operator approval. Merchant integrations are required to support [Payment Conditions](https://docs.centrapay.com/api/payment-requests#payment-condition) for these asset types in order for them to be accepted for payment.

--- a/content/guides/point-of-sale.md
+++ b/content/guides/point-of-sale.md
@@ -1,5 +1,8 @@
 ---
 title: Point of Sale
+nav:
+  path: Reference/Merchant Integrations
+  order: 1
 ---
 
 Integrating a point of sale (POS) terminal with Centrapay APIs allows merchants to accept payment via any Centrapay-enabled apps without installing additional POS hardware or software.

--- a/content/guides/requesting-payment.md
+++ b/content/guides/requesting-payment.md
@@ -1,5 +1,8 @@
 ---
 title: Requesting Payment
+nav:
+  path: Reference/Merchant Integrations
+  order: 2
 ---
 
 Centrapay’s payment protocol requires a merchant integration to connect with the Patron in order to create a [Payment Request](https://docs.centrapay.com/api/payment-requests); and poll it for payment confirmation.

--- a/content/guides/requesting-pre-auth.md
+++ b/content/guides/requesting-pre-auth.md
@@ -1,5 +1,8 @@
 ---
 title: Requesting Pre Auth
+nav:
+  path: Reference/Merchant Integrations
+  order: 10
 ---
 
 Centrapay’s Pre Auth extension allows a patron to authorize payment up to a limit when the actual payment amount is not yet known.

--- a/content/guides/transaction-reporting.md
+++ b/content/guides/transaction-reporting.md
@@ -1,5 +1,8 @@
 ---
 title: Transaction Reporting
+nav:
+  path: Reference/Merchant Integrations
+  order: 6
 ---
 
 Centrapay allows merchants to give their Patrons choice over which digital assets to use for payment.

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "lint": "vue-cli-service lint --max-warnings 0 --no-fix .",
     "start": "nuxt dev --no-clear",
-    "generate": "nuxt generate"
+    "generate": "nuxt generate",
+    "test": "vitest --watch=false"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.14.7",
@@ -26,7 +27,8 @@
     "nuxt": "^3.1.1",
     "postcss": "^8.4.16",
     "remark-sectionize": "^1.1.1",
-    "tailwindcss": "^3.1.8"
+    "tailwindcss": "^3.1.8",
+    "vitest": "^0.28.3"
   },
   "dependencies": {
     "@headlessui/vue": "1.6.0"

--- a/utils/Navigation.js
+++ b/utils/Navigation.js
@@ -1,0 +1,91 @@
+import Page from './Page';
+
+let navigation;
+
+class Navigation {
+  constructor(props) {
+    this.menu = props.menu;
+    this.pathToActiveNav = props.pathToActiveNav;
+  }
+
+  static create({ baseUrl, content }) {
+    const menu = {
+      children: [
+        {
+          title: 'Reference',
+          to: '/reference',
+          icon: 'receipt',
+          children: [],
+        },
+        {
+          title: 'Connections',
+          to: '/connections',
+          icon: 'connections',
+          children: [],
+        },
+        {
+          title: 'API',
+          to: baseUrl + '/api',
+          icon: 'settings',
+          children: [],
+        },
+      ]
+    };
+    const pathToActiveNav = {};
+    navigation = new Navigation({ menu, pathToActiveNav });
+    const pages = content
+      .map(c => Page.fromContent(c))
+      .sort((a, b) => a.order - b.order);
+    pages.forEach(page => navigation.insertPage({ page }));
+
+    // FIXME remove this block once merchant integrations has a landing page
+    const merchantIntegrations = navigation.findItem({ title: 'Merchant Integrations' });
+    if(merchantIntegrations) {
+      merchantIntegrations.to = merchantIntegrations.children[0].to;
+    }
+  }
+
+  static getMenu() {
+    return navigation.menu;
+  }
+
+  static getCurrentNavPath(path) {
+    const pathToActiveNav = navigation.pathToActiveNav;
+    const strippedPath = path.endsWith('/') ? path.slice(0, -1) : path;
+    return pathToActiveNav[strippedPath] || strippedPath;
+  }
+
+  insertPage({ page, navigationItem = this.menu, depth = 1 }) {
+    const hasChildren = page.hasChildrenAtNavDepth(depth);
+    const titleAtDepth = page.titleAtNavDepth(depth);
+    let item = this.findItem({ item: navigationItem, title: titleAtDepth });
+    if(!item) {
+      item = {
+        title: hasChildren ? titleAtDepth : page.navTitle,
+        to: hasChildren ? page.pathAtNavDepth(depth) : page.path,
+        children: [],
+      };
+      navigationItem.children.push(item);
+    }
+    if(!hasChildren) {
+      return;
+    }
+    this.insertPage({ page, navigationItem: item, depth: depth + 1 });
+    this.pathToActiveNav[page.path] = page.routePath;
+  }
+
+  findItem({ item = this.menu, title }) {
+    if (item.title === title) {
+      return item;
+    }
+    for (let i = 0; i < item.children?.length; i++) {
+      let result = this.findItem({ item: item.children[i], title });
+      if (result != null) {
+        return result;
+      }
+    }
+    return;
+  };
+}
+
+export default Navigation;

--- a/utils/Page.js
+++ b/utils/Page.js
@@ -1,0 +1,61 @@
+function toKebabCase(string) {
+  return string
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/[\s_]+/g, '-')
+    .toLowerCase();
+}
+
+/**
+ *  Encapsulates all the metadata of one of the Markdown
+ *  pages in the /content folder, including the front matter.
+ */
+class Page {
+  constructor(props) {
+    this.title = props.title;
+    this.nav = props.nav;
+    this.path = props.path;
+  }
+
+  static fromContent(content) {
+    const { _path, title, nav } = content;
+    return new Page({
+      path: _path,
+      title,
+      nav,
+    });
+  }
+
+  get fullNavPath() {
+    return `${this.nav.path}/${this.navTitle}`;
+  }
+
+  get routePath() {
+    return `/${toKebabCase(this.fullNavPath)}`;
+  }
+
+  get order() {
+    return this.nav.order;
+  }
+
+  get navTitle() {
+    return this.nav.title || this.title;
+  }
+
+  hasChildrenAtNavDepth(depth) {
+    const split = this.fullNavPath.split('/');
+    return split.length > depth;
+  }
+
+  titleAtNavDepth(depth) {
+    const split = this.fullNavPath.split('/');
+    return split[depth - 1];
+  }
+
+  pathAtNavDepth(depth) {
+    const split = this.fullNavPath.split('/');
+    const a = split.splice(0, depth);
+    return `/${a.join('/').toLowerCase()}`;
+  }
+}
+
+export default Page;

--- a/utils/__tests__/Navigation.test.js
+++ b/utils/__tests__/Navigation.test.js
@@ -1,0 +1,119 @@
+import Navigation from '../Navigation';
+
+describe('Navigation', () => {
+  describe('create', () => {
+    it('should create the navigation menu when passed an array of content pages', () => {
+      const content = [
+        {
+          _path: '/guides/farmlands-pos-integration',
+          title: 'POS Integration Guide',
+          nav: {
+            path: 'Connections/Farmlands',
+            order: 1
+          },
+        },
+        {
+          _path: '/guides/point-of-sale',
+          title: 'Point of Sale',
+          nav: {
+            path: 'Reference/Merchant Integrations',
+            title: 'overridden title',
+            order: 2
+          },
+        },
+        {
+          _path: '/guides/line-items',
+          title: 'Line Items',
+          nav: {
+            path: 'Reference/Merchant Integrations',
+            order: 1
+          },
+        },
+      ];
+      Navigation.create({ baseUrl: 'https://www.baseurl', content });
+      const menu = Navigation.getMenu();
+      expect(menu).toEqual({
+        children: [
+          {
+            title: 'Reference',
+            to: '/reference',
+            icon: 'receipt',
+            children: [
+              {
+                title: 'Merchant Integrations',
+                to: '/guides/line-items',
+                children: [
+                  {
+                    title: 'Line Items',
+                    to: '/guides/line-items',
+                    children: [],
+                  },
+                  {
+                    title: 'overridden title',
+                    to: '/guides/point-of-sale',
+                    children: [],
+                  },
+                ]
+              }
+            ]
+          },
+          {
+            title: 'Connections',
+            to: '/connections',
+            icon: 'connections',
+            children: [
+              {
+                title: 'Farmlands',
+                to: '/connections/farmlands',
+                children: [
+                  {
+                    title: 'POS Integration Guide',
+                    to: '/guides/farmlands-pos-integration',
+                    children: [],
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            title: 'API',
+            to: 'https://www.baseurl/api',
+            icon: 'settings',
+            children: [],
+          }
+        ]});
+    });
+  });
+
+  describe('getCurrentNavPath', () => {
+    it('should return nav path when the current route has no trailing slash', () => {
+      Navigation.create({ baseUrl: 'https://www.baseurl', content: [] });
+      const result = Navigation.getCurrentNavPath('Connections/Farmlands');
+      expect(result).toEqual('Connections/Farmlands');
+    });
+
+    it('should strip trailing slash from nav path when the current route has a trailing slash', () => {
+      Navigation.create({ baseUrl: 'https://www.baseurl', content: [] });
+      const result = Navigation.getCurrentNavPath('Connections/Farmlands/');
+      expect(result).toEqual('Connections/Farmlands');
+    });
+
+    it('should map current route to nav path when the current route must be mapped', () => {
+      Navigation.create({
+        baseUrl: 'https://www.baseurl',
+        content: [
+          {
+            _path: '/guides/farmlands-pos-integration',
+            title: 'Farmlands POS Integration',
+            nav: {
+              path: 'Connections/Farmlands',
+              order: 1
+            },
+          },
+        ]
+      });
+      const result = Navigation.getCurrentNavPath('/guides/farmlands-pos-integration');
+      expect(result).toEqual('/connections/farmlands/farmlands-pos-integration');
+    });
+  });
+});

--- a/utils/__tests__/Page.test.js
+++ b/utils/__tests__/Page.test.js
@@ -1,0 +1,68 @@
+import Page from '../Page';
+
+describe('Page', () => {
+  describe('fromContent', () => {
+    it('should return page when passed content', () => {
+      const content = {
+        _path: '/guides/farmlands-pos-guide',
+        title: 'Farmlands POS Integration Guide',
+        nav: {
+          order: 1,
+          title: 'Override',
+          path: 'Reference/Farmlands',
+        }
+      };
+      const result = Page.fromContent(content);
+      expect(result).toEqual({
+        path: '/guides/farmlands-pos-guide',
+        title: 'Farmlands POS Integration Guide',
+        nav: {
+          order: 1,
+          title: 'Override',
+          path: 'Reference/Farmlands',
+        }
+      });
+    });
+  });
+
+  const page = Page.fromContent({
+    title: 'Farmlands POS Integration Guide',
+    nav: {
+      path: 'References/Farmlands',
+      title: 'Override',
+    }
+  });
+  for(let i = 1; i < 4; i++) {
+    describe('hasChildrenAtNavDepth', () => {
+      const expected = i === 3 ? false : true;
+      it(`should return ${expected} when the page has children at nav depth ${i}`, () => {
+        const result = page.hasChildrenAtNavDepth(i);
+        expect(result).toEqual(expected);
+      });
+    });
+
+    describe('titleAtNavDepth', () => {
+      const expected = {
+        1: 'References',
+        2: 'Farmlands',
+        3: 'Override',
+      };
+      it(`should return ${expected[i]} when passed nav depth ${i}`, () => {
+        const result = page.titleAtNavDepth(i);
+        expect(result).toEqual(expected[i]);
+      });
+    });
+
+    describe('pathAtNavDepth', () => {
+      const expected = {
+        1: '/references',
+        2: '/references/farmlands',
+        3: '/references/farmlands/override'
+      };
+      it(`should return ${expected[i]} when passed nav depth ${i}`, () => {
+        const result = page.pathAtNavDepth(i);
+        expect(result).toEqual(expected[i]);
+      });
+    });
+  };
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1076,6 +1076,18 @@
     "@types/connect" "*"
     "@types/node" "*"
 
+"@types/chai-subset@^1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@types/chai-subset/-/chai-subset-1.3.3.tgz#97893814e92abd2c534de422cb377e0e0bdaac94"
+  integrity sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==
+  dependencies:
+    "@types/chai" "*"
+
+"@types/chai@*", "@types/chai@^4.3.4":
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.4.tgz#e913e8175db8307d78b4e8fa690408ba6b65dee4"
+  integrity sha512-KnRanxnpfpjUTqTCXslZSEdLfXExwgNxYPdiO2WGUj8+HDjFi8R3k5RVKPeSCzLjCcshCAtVO2QBbVuAV4kTnw==
+
 "@types/connect-history-api-fallback@*":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz#d1f7a8a09d0ed5a57aee5ae9c18ab9b803205dae"
@@ -1338,6 +1350,42 @@
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@vitejs/plugin-vue/-/plugin-vue-4.0.0.tgz#93815beffd23db46288c787352a8ea31a0c03e5e"
   integrity sha512-e0X4jErIxAB5oLtDqbHvHpJe/uWNkdpYV83AOG2xo2tEVSzCzewgJMtREZM30wXnM5ls90hxiOtAuVU6H5JgbA==
+
+"@vitest/expect@0.28.3":
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-0.28.3.tgz#8cd570b662e709f56ba29835879890c87429a194"
+  integrity sha512-dnxllhfln88DOvpAK1fuI7/xHwRgTgR4wdxHldPaoTaBu6Rh9zK5b//v/cjTkhOfNP/AJ8evbNO8H7c3biwd1g==
+  dependencies:
+    "@vitest/spy" "0.28.3"
+    "@vitest/utils" "0.28.3"
+    chai "^4.3.7"
+
+"@vitest/runner@0.28.3":
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-0.28.3.tgz#a59bc7a1457957291b6bf1964831284768168314"
+  integrity sha512-P0qYbATaemy1midOLkw7qf8jraJszCoEvjQOSlseiXZyEDaZTZ50J+lolz2hWiWv6RwDu1iNseL9XLsG0Jm2KQ==
+  dependencies:
+    "@vitest/utils" "0.28.3"
+    p-limit "^4.0.0"
+    pathe "^1.1.0"
+
+"@vitest/spy@0.28.3":
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-0.28.3.tgz#6f6f7ecdeefecb023a96e69b6083e0314ea6f04c"
+  integrity sha512-jULA6suS6CCr9VZfr7/9x97pZ0hC55prnUNHNrg5/q16ARBY38RsjsfhuUXt6QOwvIN3BhSS0QqPzyh5Di8g6w==
+  dependencies:
+    tinyspy "^1.0.2"
+
+"@vitest/utils@0.28.3":
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-0.28.3.tgz#75c076d4fdde5c48ee5de2808c83d615fc74d4ef"
+  integrity sha512-YHiQEHQqXyIbhDqETOJUKx9/psybF7SFFVCNfOvap0FvyUqbzTSDCa3S5lL4C0CLXkwVZttz9xknDoyHMguFRQ==
+  dependencies:
+    cli-truncate "^3.1.0"
+    diff "^5.1.0"
+    loupe "^2.3.6"
+    picocolors "^1.0.0"
+    pretty-format "^27.5.1"
 
 "@vue/babel-helper-vue-transform-on@^1.0.2":
   version "1.0.2"
@@ -1792,6 +1840,11 @@ acorn-walk@^7.0.0, acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^6.4.1:
   version "6.4.2"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
@@ -1917,7 +1970,12 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
-ansi-styles@^6.1.0:
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
+ansi-styles@^6.0.0, ansi-styles@^6.1.0:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-6.2.1.tgz#0e62320cf99c21afff3b3012192546aacbfb05c5"
   integrity sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==
@@ -2115,6 +2173,11 @@ assert@^1.1.1:
   dependencies:
     object-assign "^4.1.1"
     util "0.10.3"
+
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 assign-symbols@^1.0.0:
   version "1.0.0"
@@ -2684,6 +2747,19 @@ ccount@^2.0.0:
   resolved "https://registry.yarnpkg.com/ccount/-/ccount-2.0.1.tgz#17a3bf82302e0870d6da43a01311a8bc02a3ecf5"
   integrity sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==
 
+chai@^4.3.7:
+  version "4.3.7"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.3.7.tgz#ec63f6df01829088e8bf55fca839bcd464a8ec51"
+  integrity sha512-HLnAzZ2iupm25PlN0xFreAlBA5zaBSv3og0DdeGA4Ar6h6rJ3A0rolRUKJhSF2V10GZKDgWF/VmAEsNWjCRB+A==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.2"
+    deep-eql "^4.1.2"
+    get-func-name "^2.0.0"
+    loupe "^2.3.1"
+    pathval "^1.1.1"
+    type-detect "^4.0.5"
+
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
@@ -2743,6 +2819,11 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
+
+check-error@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
+  integrity sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==
 
 check-types@^8.0.3:
   version "8.0.3"
@@ -2870,6 +2951,14 @@ cli-spinners@^2.0.0, cli-spinners@^2.6.1:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.7.0.tgz#f815fd30b5f9eaac02db604c7a231ed7cb2f797a"
   integrity sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==
+
+cli-truncate@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-truncate/-/cli-truncate-3.1.0.tgz#3f23ab12535e3d73e839bb43e73c9de487db1389"
+  integrity sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==
+  dependencies:
+    slice-ansi "^5.0.0"
+    string-width "^5.0.0"
 
 cli-width@^3.0.0:
   version "3.0.0"
@@ -3894,6 +3983,13 @@ decode-uri-component@^0.2.0:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
+deep-eql@^4.1.2:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.3.tgz#7c7775513092f7df98d8df9996dd085eb668cc6d"
+  integrity sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==
+  dependencies:
+    type-detect "^4.0.0"
+
 deep-equal@^1.0.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.1.1.tgz#b5c98c942ceffaf7cb051e24e1434a25a2e6076a"
@@ -4095,7 +4191,7 @@ didyoumean@^1.2.2:
   resolved "https://registry.yarnpkg.com/didyoumean/-/didyoumean-1.2.2.tgz#989346ffe9e839b4555ecf5666edea0d3e8ad037"
   integrity sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==
 
-diff@^5.0.0:
+diff@^5.0.0, diff@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.1.0.tgz#bc52d298c5ea8df9194800224445ed43ffc87e40"
   integrity sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==
@@ -5457,6 +5553,11 @@ get-caller-file@^2.0.1, get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
+get-func-name@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
+  integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
+
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.3.tgz#063c84329ad93e83893c7f4f243ef63ffa351385"
@@ -6598,6 +6699,11 @@ is-fullwidth-code-point@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
   integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
+is-fullwidth-code-point@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz#fae3167c729e7463f8461ce512b080a49268aa88"
+  integrity sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==
+
 is-glob@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
@@ -7122,7 +7228,7 @@ loader-utils@^2.0.0:
     emojis-list "^3.0.0"
     json5 "^2.1.2"
 
-local-pkg@^0.4.3:
+local-pkg@^0.4.2, local-pkg@^0.4.3:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.3.tgz#0ff361ab3ae7f1c19113d9bb97b98b905dbc4963"
   integrity sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==
@@ -7276,6 +7382,13 @@ longest-streak@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-3.1.0.tgz#62fa67cd958742a1574af9f39866364102d90cd4"
   integrity sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==
+
+loupe@^2.3.1, loupe@^2.3.6:
+  version "2.3.6"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.6.tgz#76e4af498103c532d1ecc9be102036a21f787b53"
+  integrity sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==
+  dependencies:
+    get-func-name "^2.0.0"
 
 lower-case@^1.1.1:
   version "1.1.4"
@@ -8746,6 +8859,13 @@ p-limit@^2.0.0, p-limit@^2.2.0, p-limit@^2.2.1:
   dependencies:
     p-try "^2.0.0"
 
+p-limit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
+  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
 p-locate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-3.0.0.tgz#322d69a05c0264b25997d9f40cd8a891ab0064a4"
@@ -8975,6 +9095,11 @@ pathe@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.0.tgz#e2e13f6c62b31a3289af4ba19886c230f295ec03"
   integrity sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==
+
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
 pbkdf2@^3.0.3:
   version "3.1.2"
@@ -9722,6 +9847,15 @@ pretty-error@^2.0.2:
     lodash "^4.17.20"
     renderkid "^2.0.4"
 
+pretty-format@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
+
 process-nextick-args@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
@@ -9925,6 +10059,11 @@ rc9@^2.0.0:
     defu "^6.1.1"
     destr "^1.2.1"
     flat "^5.0.2"
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 read-cache@^1.0.0:
   version "1.0.0"
@@ -10633,6 +10772,11 @@ side-channel@^1.0.4:
     get-intrinsic "^1.0.2"
     object-inspect "^1.9.0"
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
@@ -10668,6 +10812,14 @@ slice-ansi@^4.0.0:
     ansi-styles "^4.0.0"
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
+
+slice-ansi@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-5.0.0.tgz#b73063c57aa96f9cd881654b15294d95d285c42a"
+  integrity sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==
+  dependencies:
+    ansi-styles "^6.0.0"
+    is-fullwidth-code-point "^4.0.0"
 
 slugify@^1.6.5:
   version "1.6.5"
@@ -10908,6 +11060,11 @@ stable@^0.1.8:
   resolved "https://registry.yarnpkg.com/stable/-/stable-0.1.8.tgz#836eb3c8382fe2936feaf544631017ce7d47a3cf"
   integrity sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==
 
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
 stackframe@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/stackframe/-/stackframe-1.3.4.tgz#b881a004c8c149a5e8efef37d51b16e412943310"
@@ -10996,7 +11153,7 @@ string-width@^3.0.0, string-width@^3.1.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^5.1.0"
 
-string-width@^5.0.1, string-width@^5.1.2:
+string-width@^5.0.0, string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-5.1.2.tgz#14f8daec6d81e7221d2a357e668cab73bdbca794"
   integrity sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==
@@ -11379,6 +11536,21 @@ tiny-invariant@^1.1.0:
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
   integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
 
+tinybench@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.3.1.tgz#14f64e6b77d7ef0b1f6ab850c7a808c6760b414d"
+  integrity sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==
+
+tinypool@^0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.3.1.tgz#a99c2e446aba9be05d3e1cb756d6aed7af4723b6"
+  integrity sha512-zLA1ZXlstbU2rlpA4CIeVaqvWq41MTWqLY3FfsAXgC8+f7Pk7zroaJQxDgxn1xNudKW6Kmj4808rPFShUlIRmQ==
+
+tinyspy@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-1.0.2.tgz#6da0b3918bfd56170fb3cd3a2b5ef832ee1dff0d"
+  integrity sha512-bSGlgwLBYf7PnUsQ6WOc6SJ3pGOcd+d8AA6EUnLDDM0kWEstC1JIlSZA3UNliDXhd9ABoS7hiRBDCu+XP/sf1Q==
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
@@ -11514,6 +11686,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-detect@^4.0.0, type-detect@^4.0.5:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
+  integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
 type-fest@^0.20.2:
   version "0.20.2"
@@ -12043,6 +12220,20 @@ vfile@^5.0.0:
     unist-util-stringify-position "^3.0.0"
     vfile-message "^3.0.0"
 
+vite-node@0.28.3:
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-0.28.3.tgz#5d693c237d5467f167f81d158a56d3408fea899c"
+  integrity sha512-uJJAOkgVwdfCX8PUQhqLyDOpkBS5+j+FdbsXoPVPDlvVjRkb/W/mLYQPSL6J+t8R0UV8tJSe8c9VyxVQNsDSyg==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.3.4"
+    mlly "^1.1.0"
+    pathe "^1.1.0"
+    picocolors "^1.0.0"
+    source-map "^0.6.1"
+    source-map-support "^0.5.21"
+    vite "^3.0.0 || ^4.0.0"
+
 vite-node@^0.28.2:
   version "0.28.2"
   resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-0.28.2.tgz#58b52fc638f86fee9bfe4990abaea7e4d74f6514"
@@ -12090,6 +12281,36 @@ vite-plugin-checker@^0.5.4:
     rollup "^3.7.0"
   optionalDependencies:
     fsevents "~2.3.2"
+
+vitest@^0.28.3:
+  version "0.28.3"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.28.3.tgz#58322a5ae64854d4cdb75451817b9fb795f9102e"
+  integrity sha512-N41VPNf3VGJlWQizGvl1P5MGyv3ZZA2Zvh+2V8L6tYBAAuqqDK4zExunT1Cdb6dGfZ4gr+IMrnG8d4Z6j9ctPw==
+  dependencies:
+    "@types/chai" "^4.3.4"
+    "@types/chai-subset" "^1.3.3"
+    "@types/node" "*"
+    "@vitest/expect" "0.28.3"
+    "@vitest/runner" "0.28.3"
+    "@vitest/spy" "0.28.3"
+    "@vitest/utils" "0.28.3"
+    acorn "^8.8.1"
+    acorn-walk "^8.2.0"
+    cac "^6.7.14"
+    chai "^4.3.7"
+    debug "^4.3.4"
+    local-pkg "^0.4.2"
+    pathe "^1.1.0"
+    picocolors "^1.0.0"
+    source-map "^0.6.1"
+    std-env "^3.3.1"
+    strip-literal "^1.0.0"
+    tinybench "^2.3.1"
+    tinypool "^0.3.1"
+    tinyspy "^1.0.2"
+    vite "^3.0.0 || ^4.0.0"
+    vite-node "0.28.3"
+    why-is-node-running "^2.2.2"
 
 vm-browserify@^1.0.1:
   version "1.1.2"
@@ -12477,6 +12698,14 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
+why-is-node-running@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.2.2.tgz#4185b2b4699117819e7154594271e7e344c9973e"
+  integrity sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
+
 wide-align@^1.1.2:
   version "1.1.5"
   resolved "https://registry.yarnpkg.com/wide-align/-/wide-align-1.1.5.tgz#df1d4c206854369ecf3c9a4898f1b23fbd9d15d3"
@@ -12665,6 +12894,11 @@ yargs@^17.5.1:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yocto-queue@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.0.0.tgz#7f816433fb2cbc511ec8bf7d263c3b58a1a3c251"
+  integrity sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==
 
 yorkie@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
We cut some corners by making the navigation static to hit some deadlines.

Having a static navigation menu will mean that when adding pages, there will need to be additional steps followed to add the page to the left hand navigation menu on the site.

Making the navigation menu dynamic means that when adding pages, you will only have to define where it should sit in the nav. The new page will automatically appear on the navigation menu on the site.

Adding new sections will still need to be manual. This is a fine compromise because new sections are rare.

Test plan:
- Ensure that there are no regressions in the site
- Add a new page with a navPath --> this page should automatically appear in the nav menu on the site