### PR TITLE
Remove page scroll animations

### DIFF
--- a/components/Layout.vue
+++ b/components/Layout.vue
@@ -168,10 +168,3 @@ if(imageSrc) {
   });
 }
 </script>
-
-<style>
-html {
-  @apply
-    scroll-smooth;
-}
-</style>


### PR DESCRIPTION
The smooth scrolling behaviour was causing the page to scroll up from the current view port position to the top of the page whenever a page transition occurred. This removes the smooth scrolling behaviour entirely and brings us back in line with the default Nuxt scrolling behaviour as defined here https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/pages/runtime/router.options.ts

Now readers start at the top of the page after a page transition.

Test plan:
1. Check that page transitions start readers at the top of the page without any upwards scrolling after a page occurred
2. Check that there is no smooth scrolling occurring when clicking link headings
3. Check that clicking the back button takes the reader back to their previous anchor
4. Check 1, 2 and 3 on Chrome, Firefox, Edge and Safari