### PR TITLE
Updated all guides under Reference based on American spelling

### DIFF
--- a/content/guides/merchant-integration-barcode-flow.md
+++ b/content/guides/merchant-integration-barcode-flow.md
@@ -6,7 +6,7 @@ Connecting with Patrons using our Barcode Flow requires the Patron to present a 
 
 ## Barcode Flow
 
-The sequence diagram below indicates the expected flow of behaviour between the Patron, the Point of Sale (POS) and Centrapay.
+The sequence diagram below indicates the expected flow of behavior between the Patron, the Point of Sale (POS) and Centrapay.
 
 ```mermaid
 sequenceDiagram

--- a/content/guides/merchant-integration-qr-code-flow.md
+++ b/content/guides/merchant-integration-qr-code-flow.md
@@ -4,7 +4,7 @@ title: QR Code Flow for Merchants
 
 Connecting with Patrons using our QR Code Flow requires the merchant integration to create a [Payment Request](https://docs.centrapay.com/api/payment-requests) and present a QR Code for the Patron to scan.
 
-The sequence diagram below indicates the expected flow of behaviour between the Patron, the Point of Sale (POS) and Centrapay.
+The sequence diagram below indicates the expected flow of behavior between the Patron, the Point of Sale (POS) and Centrapay.
 
 ```mermaid
 sequenceDiagram

--- a/content/guides/payment-conditions.md
+++ b/content/guides/payment-conditions.md
@@ -60,9 +60,9 @@ When Payment Conditions are present on a [Payment Request](https://docs.centrapa
 
 3. **Repeat** the above steps when polling shows conditions have changed.
 
-## Additional Behaviours
+## Additional Behaviors
 
-The payment request status must always be polled after [accepting](https://docs.centrapay.com/api/payment-requests#accept-payment-condition-for-a-payment-request-experimental) or [declining](https://docs.centrapay.com/api/payment-requests#decline-payment-condition-for-a-payment-request-experimental) a condition as these actions may trigger the additional behaviours below.
+The payment request status must always be polled after [accepting](https://docs.centrapay.com/api/payment-requests#accept-payment-condition-for-a-payment-request-experimental) or [declining](https://docs.centrapay.com/api/payment-requests#decline-payment-condition-for-a-payment-request-experimental) a condition as these actions may trigger the additional behaviors below.
 
 - Conditions can be linked such that they are added or voided due to state changes on the [Payment Request](https://docs.centrapay.com/api/payment-requests#payment-request). Note that accepting or declining a voided condition will fail.
 - The [Patron Not Present extension](/guides/patron-not-present) may prevent the presentation of conditions that are impossible to satisfy such as checking photo ID.

--- a/content/guides/point-of-sale.md
+++ b/content/guides/point-of-sale.md
@@ -30,4 +30,4 @@ Our payment protocol supports several optional extensions. Please review the ext
 
 Contact [integrations@centrapay.com](mailto:integrations@centrapay.com) to get started with API keys.
 
-Once you have confirmed your integration needs we will then provide you with a customised integration checklist for certification.
+Once you have confirmed your integration needs we will then provide you with a customized integration checklist for certification.

--- a/content/guides/requesting-pre-auth.md
+++ b/content/guides/requesting-pre-auth.md
@@ -2,14 +2,14 @@
 title: Requesting Pre Auth
 ---
 
-Centrapay’s Pre Auth extension allows a patron to authorise payment up to a limit when the actual payment amount is not yet known.
+Centrapay’s Pre Auth extension allows a patron to authorize payment up to a limit when the actual payment amount is not yet known.
 
 ## Restrictions
 
 Pre Auth payments are not supported in all cases.
 
 1. Not all asset types support Pre Auth - Payment options for [Asset Types](https://docs.centrapay.com/api/asset-types) that do not support Pre Auth will be excluded when a [Payment Request](https://docs.centrapay.com/api/payment-requests#payment-request) is created with the `preAuth` flag.
-2. Pre Auth is incompatible with Multi-Asset payments - Only one asset type can be authorised for a Pre Auth.
+2. Pre Auth is incompatible with Multi-Asset payments - Only one asset type can be authorized for a Pre Auth.
 
 ## Pre Auth Flow
 
@@ -26,32 +26,32 @@ sequenceDiagram
 	participant Centrapay
 
 	note over Patron, POS: Connect with Patron
-	POS->>Centrapay: Create Authorisation
+	POS->>Centrapay: Create Authorization
 
 	note over POS: Poll for Payment Confirmation
 
-	note over POS: ✅ Display Successful Authorisation
+	note over POS: ✅ Display Successful Authorization
 
 	note over POS, Centrapay: ⏱️ Some time later..
 
-	loop 0..Many (Up to Authorised Amount)
-		POS->>Centrapay: Make Confirmations Against Authorised Funds
+	loop 0..Many (Up to Authorized Amount)
+		POS->>Centrapay: Make Confirmations Against Authorized Funds
 		note over POS: ✅ Display Successful Confirmation
 	end
 
-	POS->>Centrapay: Release Remaining Authorised Funds
+	POS->>Centrapay: Release Remaining Authorized Funds
 	note over POS: ✅ Display Successful Release
 ```
 
-1. The POS places a hold on funds by creating an Authorisation.
-2. The POS draws down on authorised funds by making Confirmations against the authorisation when the purchase is ready to be fulfilled.
+1. The POS places a hold on funds by creating an Authorization.
+2. The POS draws down on authorized funds by making Confirmations against the authorization when the purchase is ready to be fulfilled.
 3. The POS releases any remaining funds that have not been confirmed back to the Patron.
 
-### Authorise
+### Authorize
 
-An authorisation is created when the [Payment Request is created](https://docs.centrapay.com/api/payment-requests#create-a-payment-request) with the `preAuth` flag while [Requesting Payment](/guides/requesting-payment).
+An authorization is created when the [Payment Request is created](https://docs.centrapay.com/api/payment-requests#create-a-payment-request) with the `preAuth` flag while [Requesting Payment](/guides/requesting-payment).
 
-Once the authorisation is successful, the Payment Request `preAuthStatus` is set to `authorized`.
+Once the authorization is successful, the Payment Request `preAuthStatus` is set to `authorized`.
 
 ```mermaid
 sequenceDiagram
@@ -71,22 +71,22 @@ sequenceDiagram
 		end
 	end
 
-	note over POS: ✅ Display Successful Authorisation
+	note over POS: ✅ Display Successful Authorization
 ```
 
 ### Confirm
 
-Merchants can draw down on authorised funds by making one or more [confirmations](https://docs.centrapay.com/api/payment-requests#make-a-confirmation-against-a-pre-auth-payment-request-experimental) against an authorised amount. Confirmations must be made with an `idempotencyKey` in order to prevent merchants from drawing down on authorised funds twice.
+Merchants can draw down on authorized funds by making one or more [confirmations](https://docs.centrapay.com/api/payment-requests#make-a-confirmation-against-a-pre-auth-payment-request-experimental) against an authorized amount. Confirmations must be made with an `idempotencyKey` in order to prevent merchants from drawing down on authorized funds twice.
 
-Confirmations against authorised funds have limits:
+Confirmations against authorized funds have limits:
 
-- Authorisations must be followed up with a confirmation - otherwise, the authorisation will expire and the funds will be returned to the asset holder.
+- Authorizations must be followed up with a confirmation - otherwise, the authorization will expire and the funds will be returned to the asset holder.
 
     The `preAuthExpiry` may be adjusted to match pre-determined expiry rules set by the asset provider.
 
-- Multiple confirmations can be performed against an authorisation but the total value cannot exceed the original authorised value.
+- Multiple confirmations can be performed against an authorization but the total value cannot exceed the original authorized value.
 
-> Making confirmations is only allowed against authorisations that have had zero or more confirmations made against them.
+> Making confirmations is only allowed against authorizations that have had zero or more confirmations made against them.
 
 ```mermaid
 sequenceDiagram
@@ -96,23 +96,23 @@ sequenceDiagram
 	participant POS
 	participant C as Centrapay
 
-	POS->>C: Create Authorisation
+	POS->>C: Create Authorization
 
 	note over POS, C: ⏱️ Some time later..
 
-	loop 0..Many (Up to Authorised Amount)
-		POS->>C: Make Confirmations Against Authorised Funds
+	loop 0..Many (Up to Authorized Amount)
+		POS->>C: Make Confirmations Against Authorized Funds
 		Note over POS: ✅ Display Successful Confirmation
 	end
 ```
 
 ### Release
 
-Authorised funds that have not been confirmed can optionally be [released](https://docs.centrapay.com/api/payment-requests#release-funds-held-for-a-pre-auth-payment-request-experimental) so that the asset holder is granted access to their remaining funds without needing to wait for the authorisation to expire.
+Authorized funds that have not been confirmed can optionally be [released](https://docs.centrapay.com/api/payment-requests#release-funds-held-for-a-pre-auth-payment-request-experimental) so that the asset holder is granted access to their remaining funds without needing to wait for the authorization to expire.
 
-Once releasing any remaining authorised funds is successful, the Payment Request `preAuthStatus` is set to `released`.
+Once releasing any remaining authorized funds is successful, the Payment Request `preAuthStatus` is set to `released`.
 
-> Releasing is only allowed against authorisations that have had zero or more confirmations made against them.
+> Releasing is only allowed against authorizations that have had zero or more confirmations made against them.
 
 ```mermaid
 sequenceDiagram
@@ -123,17 +123,17 @@ sequenceDiagram
 	participant C as Centrapay
 
 	note over POS: All Confirmations Have Been Completed
-		POS->>C: Release Remaining Authorised Funds
+		POS->>C: Release Remaining Authorized Funds
 		Note over POS: ✅ Display Successful Confirmation
 ```
 
 ### Expiry
 
-Authorisations automatically expire after 3 months. Any unreleased funds are subsequently released to the Patron.
+Authorizations automatically expire after 3 months. Any unreleased funds are subsequently released to the Patron.
 
 ### Refund
 
-[Refunds](/guides/initiating-refunds) can be made against authorisations, confirmations, released authorisations and expired authorisations.
+[Refunds](/guides/initiating-refunds) can be made against authorizations, confirmations, released authorizations and expired authorizations.
 
 Refunds made against confirmations must include the `confirmationIdempotencyKey` field that is the same as the `idempotencyKey` used for original confirmation.
 
@@ -141,4 +141,4 @@ Refunds made against confirmations must include the `confirmationIdempotencyKey`
 
 [Voiding a Payment Request](https://docs.centrapay.com/api/payment-requests#void-a-payment-request-experimental) will cancel a Payment Request and trigger any refunds necessary. This operation is useful if the POS needs to back out of a transaction due to a network error for example. Voiding can only be used up to 24 hours after the Payment Request was created.
 
-> Voiding is only allowed against Payment Requests awaiting authorisation and Payment Requests that have been successfully authorised.
+> Voiding is only allowed against Payment Requests awaiting authorization and Payment Requests that have been successfully authorized.


### PR DESCRIPTION
All guides except Farmlands guides will follow American spelling convention. 

Example: Authorized instead of Authorised. 

Test Plan: 

1. Go to this [link](https://docs.centrapay.com/)
2. Expand the Reference sidebar menu
3. Click individual guides under Reference
4. Read the guides and spot for American spelling convention 😀

The latest version:
![Screenshot 2023-02-02 at 4 56 47 PM](https://user-images.githubusercontent.com/32785419/216228572-db98dab7-06e0-4b6e-9d2d-a619cf081c41.png)
![Screenshot 2023-02-02 at 4 57 04 PM](https://user-images.githubusercontent.com/32785419/216228588-724b12ae-ce0d-49c6-a3fc-60e531e0f370.png)

The old version:
![screen](https://user-images.githubusercontent.com/32785419/216248020-d370a87d-6870-4e92-99f9-4bd797f134dc.png)

![Screenshot 2023-02-02 at 7 17 38 PM](https://user-images.githubusercontent.com/32785419/216247328-bdb69aa9-a308-458a-961e-b9e60282efd8.png)

