### PR TITLE
Added social media tag description and title for all guides

### DIFF
--- a/content/guides/farmlands-pos-integration.md
+++ b/content/guides/farmlands-pos-integration.md
@@ -1,7 +1,7 @@
 ---
 title: Farmlands POS Integration Guide
 img: /farmlands-pos-integration-cover.jpg
-description: Centrapay and Farmlands have entered into a partnership to allow Farmlands Card Partners to accept Farmlands Card payments at the point of sale.
+description: Farmlands has partnered with Centrapay to deliver new ways for your business to authorise and process Farmlands Card payments that are faster, easier, and more secure than ever.
 nav:
   path: Connections/Farmlands
   title: POS Integration Guide
@@ -844,15 +844,15 @@ When the Cardholder presents a transaction reference (e.g. a [Payment Request](h
 sequenceDiagram
 	autonumber
 
-	participant P as Cardholder
+	participant Cardholder
 	participant POS
-	participant C as Centrapay
+	participant Centrapay
 
-	P->>POS: Present Transaction Reference
+	Cardholder->>POS: Present Transaction Reference
 
 	Note over POS: Look up Payment Request ID
 
-	POS->>C: Refund Payment Request
+	POS->>Centrapay: Refund Payment Request
 
 	Note over POS: ✅ Display Refund Confirmation
 ```

--- a/content/guides/initiating-refunds.md
+++ b/content/guides/initiating-refunds.md
@@ -1,5 +1,6 @@
 ---
 title: Initiating Refunds
+description: How to issue refunds on the Centrapay payment platform.
 nav:
   path: Reference/Merchant Integrations
   order: 7

--- a/content/guides/line-items.md
+++ b/content/guides/line-items.md
@@ -1,15 +1,16 @@
 ---
 title: Line Items
+description: Line items are used to communicate the details of a purchase to a patron.
 nav:
   path: Reference/Merchant Integrations
   order: 8
 ---
 
-[Line Items](https://docs.centrapay.com/api/payment-requests#line-item) are used to communicate the details of a purchase to a Patron.
+[Line Items](https://docs.centrapay.com/api/payment-requests#line-item) are used to communicate the details of a purchase to a patron.
 
 ## Restrictions
 
-1. The price of a Line Item MUST represent the amount that a Patron will pay for that Line Item, including tax and any discounts applied (e.g. price = product price * qty - discounts + tax).
+1. The price of a Line Item MUST represent the amount that a patron will pay for that Line Item, including tax and any discounts applied (e.g. price = product price * qty - discounts + tax).
 
     ```json [Example]
     [

--- a/content/guides/merchant-integration-barcode-flow.md
+++ b/content/guides/merchant-integration-barcode-flow.md
@@ -1,16 +1,17 @@
 ---
 title: Barcode Flow for Merchants
+description: How merchants can accept payments by scanning a barcode presented by the patron.
 nav:
   path: Reference/Merchant Integrations
   title: Barcode Flow
   order: 4
 ---
 
-Connecting with Patrons using our Barcode Flow requires the Patron to present a Barcode and the merchant integration to scan it in order to [create a Payment Request](https://docs.centrapay.com/api/payment-requests#create-a-payment-request).
+Connecting with patrons using our Barcode Flow requires the patron to present a Barcode and the merchant integration to scan it in order to [create a Payment Request](https://docs.centrapay.com/api/payment-requests#create-a-payment-request).
 
 ## Barcode Flow
 
-The sequence diagram below indicates the expected flow of behavior between the Patron, the Point of Sale (POS) and Centrapay.
+The sequence diagram below indicates the expected flow of behavior between the patron, the Point of Sale (POS) and Centrapay.
 
 ```mermaid
 sequenceDiagram
@@ -37,7 +38,7 @@ sequenceDiagram
 	Note over Patron: ✅ Display Successful Payment
 ```
 
-1. The Patron presents a Barcode for the POS to scan.
+1. The patron presents a Barcode for the POS to scan.
 2. The POS [creates a Centrapay Payment Request](https://docs.centrapay.com/api/payment-requests#create-a-payment-request) with the Barcode.
 
     ```bash [Request]
@@ -118,7 +119,7 @@ sequenceDiagram
     }
     ```
 
-4. While the POS continues to poll, the Patron [pays the Payment Request](https://docs.centrapay.com/api/payment-requests#pay-a-payment-request-experimental) via their Centrapay integrated app.
+4. While the POS continues to poll, the patron [pays the Payment Request](https://docs.centrapay.com/api/payment-requests#pay-a-payment-request-experimental) via their Centrapay integrated app.
 
     ```bash [Request]
     curl -X POST https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw/pay \
@@ -190,9 +191,9 @@ sequenceDiagram
 
 ## Quick Pay Flow
 
-Quick Pay is used to immediately confirm the payment without requiring Patron approval.
+Quick Pay is used to immediately confirm the payment without requiring patron approval.
 
-The Patron’s barcode must be linked to an asset type that allows Quick Pay in order to use this flow. See [Asset Types](https://docs.centrapay.com/api/asset-types) for the list of asset types that support Quick Pay.
+The patron’s barcode must be linked to an asset type that allows Quick Pay in order to use this flow. See [Asset Types](https://docs.centrapay.com/api/asset-types) for the list of asset types that support Quick Pay.
 
 ```mermaid
 sequenceDiagram
@@ -216,7 +217,7 @@ sequenceDiagram
 	Note over Patron: ✅ Display Successful Payment
 ```
 
-1. The Patron presents a Barcode for the POS to scan.
+1. The patron presents a Barcode for the POS to scan.
 2. The POS [creates a Centrapay Payment Request](https://docs.centrapay.com/api/payment-requests#create-a-payment-request) with the Barcode.
 
     ```bash [Request]
@@ -354,7 +355,7 @@ sequenceDiagram
 	POS->>Centrapay: Create Payment Request with Barcode
 ```
 
-1. The Patron presents a barcode for the POS to scan.
+1. The patron presents a barcode for the POS to scan.
 2. The POS [decodes the scanned barcode](https://docs.centrapay.com/api/scanned-codes#decode-scanned-code) and applies any provider-related discounts.
 
     ```bash [Request]

--- a/content/guides/merchant-integration-error-handling.md
+++ b/content/guides/merchant-integration-error-handling.md
@@ -1,5 +1,6 @@
 ---
 title: Merchant Integration Error Handling
+description: How to deal with inconsistencies in Payment Request statuses due to network issues or race conditions.
 nav:
   path: Reference/Merchant Integrations
   title: Error Handling

--- a/content/guides/merchant-integration-qr-code-flow.md
+++ b/content/guides/merchant-integration-qr-code-flow.md
@@ -1,39 +1,40 @@
 ---
 title: QR Code Flow for Merchants
+description: How merchants can accept payments by presenting a QR code to the patron.
 nav:
   path: Reference/Merchant Integrations
   title: QR Code Flow
   order: 3
 ---
 
-Connecting with Patrons using our QR Code Flow requires the merchant integration to create a [Payment Request](https://docs.centrapay.com/api/payment-requests) and present a QR Code for the Patron to scan.
+Connecting with patrons using our QR Code Flow requires the merchant integration to create a [Payment Request](https://docs.centrapay.com/api/payment-requests) and present a QR Code for the patron to scan.
 
-The sequence diagram below indicates the expected flow of behavior between the Patron, the Point of Sale (POS) and Centrapay.
+The sequence diagram below indicates the expected flow of behavior between the patron, the Point of Sale (POS) and Centrapay.
 
 ```mermaid
 sequenceDiagram
 	autonumber
 
-	participant P as Patron
+	participant Patron
 	participant POS
-	participant C as Centrapay
+	participant Centrapay
 
-	POS->>C: Create Payment Request
+	POS->>Centrapay: Create Payment Request
 
 	note over POS: Present QR Code
 
-	P->>POS: Scan QR Code
+	Patron->>POS: Scan QR Code
 
 	par
 		loop
-			POS->>C: Poll for Payment Confirmation
+			POS->>Centrapay: Poll for Payment Confirmation
 		end
 
-		P->>C: Pay Payment Request
+		Patron->>Centrapay: Pay Payment Request
 	end
 
 	Note over POS: ✅ Display Successful Payment
-	Note over P: ✅ Display Successful Payment
+	Note over Patron: ✅ Display Successful Payment
 ```
 
 1. The POS [creates a Payment Request](https://docs.centrapay.com/api/payment-requests#create-a-payment-request) and presents a QR code to the Patron on a customer-facing display.
@@ -79,7 +80,7 @@ sequenceDiagram
     }
     ```
 
-2. The Patron scans the QR code using a Centrapay-enabled app.
+2. The patron scans the QR code using a Centrapay-enabled app.
 3. The POS [polls the Payment Request for](https://docs.centrapay.com/api/payment-requests#get-a-payment-request) Payment Confirmation.
 
     ```bash [Request]
@@ -113,7 +114,7 @@ sequenceDiagram
     }
     ```
 
-4. While the POS continues to poll, the Patron [pays the Payment Request](https://docs.centrapay.com/api/payment-requests#pay-a-payment-request-experimental) via their Centrapay integrated app. When the Payment Request status is `paid`, the POS stops polling and displays confirmation of the successful payment.
+4. While the POS continues to poll, the patron [pays the Payment Request](https://docs.centrapay.com/api/payment-requests#pay-a-payment-request-experimental) via their Centrapay integrated app. When the Payment Request status is `paid`, the POS stops polling and displays confirmation of the successful payment.
 
     ```bash [Request]
     curl -X POST https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw/pay \

--- a/content/guides/patron-not-present.md
+++ b/content/guides/patron-not-present.md
@@ -1,11 +1,12 @@
 ---
 title: Patron Not Present
+description: Centrapay’s Patron Not Present extension allows a merchant to complete a payment when the patron is not physically present at the time of payment.
 nav:
   path: Reference/Merchant Integrations
   order: 11
 ---
 
-Centrapay’s Patron Not Present extension allows a merchant to complete a payment when the Patron is not physically present at the time of payment (e.g. phone-based orders).
+Centrapay’s Patron Not Present extension allows a merchant to complete a payment when the patron is not physically present at the time of payment (e.g. phone-based orders).
 
 You can enable this extension by [creating a Payment Request](https://docs.centrapay.com/api/payment-requests#create-a-payment-request) with the `patronNotPresent` flag set to true.
 

--- a/content/guides/payment-conditions.md
+++ b/content/guides/payment-conditions.md
@@ -1,5 +1,6 @@
 ---
 title: Payment Conditions
+description: Payment Conditions enable integrations to require conditional approval to accept specific Asset Types as payment.
 nav:
   path: Reference/Merchant Integrations
   order: 9
@@ -17,7 +18,7 @@ Examples of Payment Conditions include:
 
 In order to support Payment Conditions, the merchant integration must extend Centrapay's payment protocol by [creating the Payment Request](https://docs.centrapay.com/api/payment-requests#create-a-payment-request) with the `conditionsEnabled` flag set to true.
 
-The example flow below assumes that the merchant integration has first connected with the Patron when [Requesting Payment](/guides/requesting-payment) using the [QR Code Flow for Merchants](/guides/merchant-integration-qr-code-flow) or the [Barcode Flow for Merchants](/guides/merchant-integration-barcode-flow).
+The example flow below assumes that the merchant integration has first connected with the patron when [Requesting Payment](/guides/requesting-payment) using the [QR Code Flow for Merchants](/guides/merchant-integration-qr-code-flow) or the [Barcode Flow for Merchants](/guides/merchant-integration-barcode-flow).
 
 ```mermaid
 sequenceDiagram
@@ -53,13 +54,13 @@ When Payment Conditions are present on a [Payment Request](https://docs.centrapa
 
     Merchant integrations should prompt the terminal operator to [accept](https://docs.centrapay.com/api/payment-requests#accept-payment-condition-for-a-payment-request-experimental) or [decline](https://docs.centrapay.com/api/payment-requests#decline-payment-condition-for-a-payment-request-experimental) any conditions that have status `awaiting-merchant`.
 
-    Consumer apps should inform the Patron to [accept](https://docs.centrapay.com/api/payment-requests#accept-payment-condition-for-a-payment-request-experimental) or [decline](https://docs.centrapay.com/api/payment-requests#decline-payment-condition-for-a-payment-request-experimental) any conditions that have status `awaiting-patron`.
+    Consumer apps should inform the patron to [accept](https://docs.centrapay.com/api/payment-requests#accept-payment-condition-for-a-payment-request-experimental) or [decline](https://docs.centrapay.com/api/payment-requests#decline-payment-condition-for-a-payment-request-experimental) any conditions that have status `awaiting-patron`.
 
 2. **Inform**
 
     Merchant integrations should inform the terminal operator of any conditions that have status `awaiting-patron` using the `message` provided with the condition.
 
-    Consumer apps should inform the Patron of any conditions that have status `awaiting-merchant` using the `message` provided with the condition.
+    Consumer apps should inform the patron of any conditions that have status `awaiting-merchant` using the `message` provided with the condition.
 
 3. **Repeat** the above steps when polling shows conditions have changed.
 

--- a/content/guides/point-of-sale.md
+++ b/content/guides/point-of-sale.md
@@ -1,5 +1,6 @@
 ---
 title: Point of Sale
+description: How to integrate a point of sale (POS) terminal with Centrapay APIs.
 nav:
   path: Reference/Merchant Integrations
   order: 1

--- a/content/guides/requesting-payment.md
+++ b/content/guides/requesting-payment.md
@@ -1,11 +1,12 @@
 ---
 title: Requesting Payment
+description: How to request payment on the Centrapay payment platform.
 nav:
   path: Reference/Merchant Integrations
   order: 2
 ---
 
-Centrapay’s payment protocol requires a merchant integration to connect with the Patron in order to create a [Payment Request](https://docs.centrapay.com/api/payment-requests); and poll it for payment confirmation.
+Centrapay’s payment protocol requires a merchant integration to connect with the patron in order to create a [Payment Request](https://docs.centrapay.com/api/payment-requests); and poll it for payment confirmation.
 
 Additionally, merchant integrations can opt into protocol extensions when creating a Payment Request in order to unlock acceptance of a wider set of payment options.
 
@@ -13,7 +14,7 @@ Additionally, merchant integrations can opt into protocol extensions when creati
 
 The [Payment Request](https://docs.centrapay.com/api/payment-requests) object is a core part of Centrapay’s payment protocol. It represents the intention of a merchant to receive payment, defines the amount to be paid, and the acceptable [Asset Types](https://docs.centrapay.com/api/asset-types) for payment.
 
-In order to [create a Payment Request](https://docs.centrapay.com/api/payment-requests#create-a-payment-request), a merchant integration must connect with the Patron. Centrapay supports two different options to connect with Patrons. We recommend that merchant integrations implement both options to support the complete set of apps within Centrapay’s ecosystem.
+In order to [create a Payment Request](https://docs.centrapay.com/api/payment-requests#create-a-payment-request), a merchant integration must connect with the patron. Centrapay supports two different options to connect with patrons. We recommend that merchant integrations implement both options to support the complete set of apps within Centrapay’s ecosystem.
 1. [QR Code Flow for Merchants](/guides/merchant-integration-qr-code-flow)
 2. [Barcode Flow for Merchants](/guides/merchant-integration-barcode-flow)
 
@@ -26,7 +27,7 @@ We require compliant integrations to provide the following optional fields when 
 | `externalRef`       | The merchant’s identifier for the transaction. Typically this is also printed on the paper receipt and required for [Initiating Refunds](/guides/initiating-refunds). |
 | `terminalId`        | The logical identifier of the terminal. Useful for auditing and debugging.                                                                                            |
 | `deviceId`          | The hardware identifier of the terminal. Useful for auditing and debugging.                                                                                           |
-| `patronNotPresent`  | This flag indicates whether a Patron is physically present at the point of sale. Setting this flag can change the liability for some asset types.                     |
+| `patronNotPresent`  | This flag indicates whether a patron is physically present at the point of sale. Setting this flag can change the liability for some asset types.                     |
 | `conditionsEnabled` | The flag which indicates [Payment Conditions](/guides/payment-conditions) are supported.                                                            |
 
 ### Short Codes
@@ -38,7 +39,7 @@ Short codes can be used for [Initiating Refunds](/guides/initiating-refunds).
 
 ## Polling for Payment Confirmation
 
-After connecting with the Patron, the POS must [poll the Payment Request status](https://docs.centrapay.com/api/payment-requests#get-a-payment-request) every second until the status has changed.
+After connecting with the patron, the POS must [poll the Payment Request status](https://docs.centrapay.com/api/payment-requests#get-a-payment-request) every second until the status has changed.
 
 ```mermaid
 sequenceDiagram

--- a/content/guides/requesting-pre-auth.md
+++ b/content/guides/requesting-pre-auth.md
@@ -1,5 +1,6 @@
 ---
 title: Requesting Pre Auth
+description: Centrapay’s Pre Auth extension allows a patron to authorize payment up to a limit when the actual payment amount is not yet known.
 nav:
   path: Reference/Merchant Integrations
   order: 10

--- a/content/guides/transaction-reporting.md
+++ b/content/guides/transaction-reporting.md
@@ -1,11 +1,12 @@
 ---
 title: Transaction Reporting
+description: Guidelines on communicating the Asset Types used for payment to the user in any transaction reporting function on the merchant side.
 nav:
   path: Reference/Merchant Integrations
   order: 6
 ---
 
-Centrapay allows merchants to give their Patrons choice over which digital assets to use for payment.
+Centrapay allows merchants to give their patrons choice over which digital assets to use for payment.
 
 The settlement process to the merchant will differ depending on which [Asset Types](https://docs.centrapay.com/api/asset-types) have been selected for payment by the patron.
 


### PR DESCRIPTION
Open Grave title and description have been added to all guides under References. 

Test Plan:
For screens over 1980 X 1080px and mobile using Meta for Developers
1. Go to https://developers.facebook.com/tools/debug/
2. Key in https://docs.centrapay.com/guides/point-of-sale
3. Enter https://docs.centrapay.com/guides/point-of-sale to debug
4. Click Fetch New Information
5. The title and description are clear and the title font size is larger than the description

For screens over 1980 X 1080px and mobile using Social Share Previews
1. Go to https://socialsharepreview.com
2. Key in https://docs.centrapay.com/guides/point-of-sale
3. Enter https://docs.centrapay.com/guides/point-of-sale to debug
5. The title and description are clear and the title font size is larger than the description


Link preview on Facebook for short description: 
![Screenshot 2023-02-08 at 10 36 45 AM](https://user-images.githubusercontent.com/32785419/217372098-ca75d871-1a75-4bd1-910f-a7719fa07539.png)


Link preview on Facebook for long description:
![Screenshot 2023-02-08 at 10 42 24 AM](https://user-images.githubusercontent.com/32785419/217373588-ef917acc-7b53-447f-a5e3-41a25376849f.png)

Twitter: 
Short Description:
![Screenshot 2023-02-08 at 10 36 57 AM](https://user-images.githubusercontent.com/32785419/217372269-b7276fce-ee78-42d3-a49d-3c28b14a4f3c.png)

Long Description:
![Screenshot 2023-02-08 at 10 43 48 AM](https://user-images.githubusercontent.com/32785419/217373620-5a9a4a04-998e-44aa-b75d-8c9650b325e2.png)

LinkedIn:
Short Description:
![Screenshot 2023-02-08 at 10 37 05 AM](https://user-images.githubusercontent.com/32785419/217372189-583c4ade-d42b-4c1b-bfca-fc0b0aed0f8e.png)


Long Description:
![Screenshot 2023-02-08 at 10 43 39 AM](https://user-images.githubusercontent.com/32785419/217373655-8847e283-9400-4c90-8021-9604db0fb37a.png)

