### PR TITLE
Set the hostname of the site in production

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -15,6 +15,7 @@ import mdx from '@astrojs/mdx';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://docs.centrapay.com',
   integrations: [
     vue(),
     tailwind({


### PR DESCRIPTION
We were using Astro.url.origin to set the URL for our API link in the Nav and throughout our site metadata. This was being set to localhost in our production build.

Astro allows us to set the final deployed URL in the site config https://docs.astro.build/en/reference/configuration-reference/#site

This means that the site URL will now be set to docs.centrapay.com in production mode and development mode still uses localhost -> https://github.com/withastro/astro/pull/1387

Test plan:
- Ensure that the API links in the Nav and Homepage navigate to our API docs correctly
- Ensure our page metadata uses the correct site urls for img and og:img
- Confirm running the site in development mode uses localhost in the links above