### PR TITLE
🤝 Fix Lighthouse accessibility links for colors

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -17,7 +17,7 @@
           />
         </a>
       </div>
-      <p class="mt-8 text-xs leading-5 text-content-tertiary md:order-1 md:mt-0">
+      <p class="mt-8 text-xs leading-5 text-content-primary md:order-1 md:mt-0">
         {{ `&#169; ${year} Centrapay - All rights reserved.` }}
       </p>
     </div>

--- a/src/components/Layout.vue
+++ b/src/components/Layout.vue
@@ -19,7 +19,7 @@
           >
             <p
               v-if="collectionName"
-              class="type-overline text-brand-accent"
+              class="type-overline text-content-primary"
             >
               {{ collectionName }}
             </p>
@@ -43,7 +43,7 @@
         >
           <h2
             id="on-this-page-title"
-            class="type-overline text-brand-accent"
+            class="type-overline text-content-primary"
           >
             On this page
           </h2>

--- a/src/components/icons/MessagesBubbleDouble.vue
+++ b/src/components/icons/MessagesBubbleDouble.vue
@@ -10,14 +10,14 @@
       fill-rule="evenodd"
       clip-rule="evenodd"
       d="M24.25 13.5C24.25 10.6005 21.8995 8.25 19 8.25H16C13.1005 8.25 10.75 10.6005 10.75 13.5C10.75 16.3995 13.1005 18.75 16 18.75H16.75L21.25 23.25V18.226C23.0783 17.3617 24.246 15.5223 24.25 13.5V13.5Z"
-      stroke="black"
+      stroke="currentColor"
       stroke-width="1.5"
       stroke-linecap="round"
       stroke-linejoin="round"
     />
     <path
       d="M7.75 12.75L4.75 15.75V10.726C2.53125 9.67785 1.3373 7.23009 1.87719 4.83634C2.41708 2.4426 4.54613 0.744307 7 0.750014H10C12.3218 0.750299 14.368 2.27514 15.032 4.50001"
-      stroke="black"
+      stroke="currentColor"
       stroke-width="1.5"
       stroke-linecap="round"
       stroke-linejoin="round"

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -78,10 +78,10 @@ const navigation = Navigation.create({ baseUrl: Astro.url.origin, content: guide
         <button
           id="freshdesk"
           type="button"
-          class="btn-tertiary fixed right-6 bottom-6 border rounded-full shadow-lg flex justify-center w-16 h-16"
+          class="btn bg-interactive-quaternary fixed right-6 bottom-6 border rounded-full shadow-lg flex justify-center w-16 h-16 hover:bg-interactive-quaternary-hover active:bg-interactive-quaternary-active"
         >
           <MessagesBubbleDouble
-            class="icon-lg"
+            class="icon-lg text-content-on-color"
             aria-hidden="true"
           />
         </button>


### PR DESCRIPTION
* The text brand-accent on a white background when the font is type overline -> text-content-primary
* The footer copyright text which is content-tertiary on a background of surface-tertiary -> text-content-primary
* The Freskdesk button with background interactive-tertiary over the footer background of surface-tertiary -> bg-interactive-tertiary and text-content-on-color, add hover and active states.


<img width="102" alt="Screenshot 2023-02-20 at 9 13 09 PM" src="https://user-images.githubusercontent.com/64108933/220051377-ad7b13df-2fd1-4b18-96a7-cd58ccb2f734.png">
<img width="116" alt="Screenshot 2023-02-20 at 9 12 41 PM" src="https://user-images.githubusercontent.com/64108933/220051389-85adf229-96b2-487d-864a-e2c6257a2c30.png">
<img width="1355" alt="Screenshot 2023-02-20 at 9 10 58 PM" src="https://user-images.githubusercontent.com/64108933/220051394-ca19cde2-cd75-414a-a04d-d1e5222adf1f.png">
<img width="1356" alt="Screenshot 2023-02-20 at 9 10 46 PM" src="https://user-images.githubusercontent.com/64108933/220051407-813025f4-90bb-44ce-9610-05d567e666be.png">
