### PR TITLE
🐛 Fix: Hide site navigation scrollbar when not required

### DIFF
--- a/src/components/AppShell.vue
+++ b/src/components/AppShell.vue
@@ -77,7 +77,7 @@
 
     <!-- Static sidebar for desktop -->
     <div class="hidden md:fixed md:h-full md:flex md:w-64 xl:w-80 md:flex-col">
-      <div class="flex flex-grow flex-col mt-16 py-5 overflow-y-scroll border-r border-gray-200 bg-white">
+      <div class="flex flex-grow flex-col mt-16 py-5 overflow-y-auto border-r border-gray-200 bg-white">
         <nav
           class="flex-1 space-y-1 bg-white px-2"
           aria-label="Sidebar"


### PR DESCRIPTION
Visual bug introduced in Pull Request #659.
Test plan: Site navigation scroll bar should not be visibile with all disclosures collapsed. Expect to still be able to scroll and view API link.