### PR TITLE
Remove mention of introduction from the farmlands portal introduction

### DIFF
--- a/src/components/Farmlands.vue
+++ b/src/components/Farmlands.vue
@@ -86,7 +86,7 @@
             description="A secure web portal for Farmlands Card payments. This option allows Card Partners to authorise payments without having to integrate their retail point of sale system."
             button-url=""
             :link="{
-              text: 'Portal Introduction Guide',
+              text: 'Portal Guide',
               url: '/guides/farmlands-portal',
             }"
           />

--- a/src/components/Farmlands.vue
+++ b/src/components/Farmlands.vue
@@ -87,7 +87,7 @@
             button-url=""
             :link="{
               text: 'Portal Introduction Guide',
-              url: '/guides/farmlands-portal-introduction',
+              url: '/guides/farmlands-portal',
             }"
           />
         </div>

--- a/src/content/guides/farmlands-card-partner-support.mdx
+++ b/src/content/guides/farmlands-card-partner-support.mdx
@@ -39,7 +39,7 @@ Go to the Payments page on the Centrapay Business Portal, select the transaction
 
 **Is there a portal guide that covers additional Trouble Shooting FAQs and that can help with training?**
 
-Yes. If you go to the portal and click on the dashboard there is a guides section or go to the [Farmlands Portal Introduction Guide](https://docs.centrapay.com/guides/farmlands-portal-introduction)
+Yes. If you go to the portal and click on the dashboard there is a guides section or go to the [Farmlands Portal Guide](https://docs.centrapay.com/guides/farmlands-portal)
 
 ## Support for POS Integrators
 

--- a/src/content/guides/farmlands-portal.mdx
+++ b/src/content/guides/farmlands-portal.mdx
@@ -7,7 +7,7 @@ nav:
   order: 2
 ---
 
-Farmlands Co-operative (Farmands) have partnered with Centrapay Payment Gateway (Centrapay) to deliver a secure web portal for Farmlands Card payments. This option allows Card Partners to gain a real-time authorisation without having to integrate a Point Of Sale (POS) system.
+Farmlands Co-operative (Farmlands) have partnered with Centrapay Payment Gateway (Centrapay) to deliver a secure web portal for Farmlands Card payments. This option allows Card Partners to gain a real-time authorisation without having to integrate a Point Of Sale (POS) system.
 
 ### Key Benefits:
 

--- a/src/content/guides/farmlands-portal.mdx
+++ b/src/content/guides/farmlands-portal.mdx
@@ -1,9 +1,9 @@
 ---
-title: Farmlands Portal Introduction Guide
+title: Farmlands Portal Guide
 description: Farmlands Co-operative (Farmands) have partnered with Centrapay Payment Gateway (Centrapay) to deliver a secure web portal for Farmlands Card payments.
 nav:
   path: Connections/Farmlands
-  title: Portal Introduction Guide
+  title: Portal Guide
   order: 2
 ---
 


### PR DESCRIPTION
Farmlands have requested that we remove the word 'Introduction' from the 'Farmlands Portal Introduction', see https://www.notion.so/centrapay/Update-Docs-using-feedback-from-Farmlands-25fa8a70c6674ef0bb32cb8b94ec273c?pvs=4

I have also removed 'introduction' from the file name because the file name and title should be consistent with one another.
