### PR TITLE
Fix reference link for centrapay integrations

### DIFF
--- a/src/utils/Navigation.js
+++ b/src/utils/Navigation.js
@@ -42,6 +42,7 @@ class Navigation {
       'App Integrations',
       'Digital Assets',
       'Centrapay Experiences',
+      'Centrapay Integrations',
     ];
     sectionHeaderTitle.forEach((title) => {
       const category = navigation.findItem({ title: title });


### PR DESCRIPTION
Currently the nav link for Centrapay Integrations takes you to a non-existing page