### PR TITLE
Fix wording in integrating third party asset guide

### DIFF
--- a/src/content/guides/integrating-third-party-asset.mdx
+++ b/src/content/guides/integrating-third-party-asset.mdx
@@ -8,7 +8,7 @@ nav:
 
 By integrating with Centrapay as a third-party asset provider, you can take advantage of our connections with terminals, point-of-sale systems, and merchant networks, thereby expanding the reach of your digital asset to a wider audience.
 
-Once you have defined your asset with Centrapay and implemented the required Uplink APIs, consumers will be able to spend your digital asset using one of our payment flows wherever merchants accept your digital asset.
+Once you have defined your asset as a [Payment Method](#defining-a-payment-method) with Centrapay and implemented the required [Uplink APIs](#uplink-api-spec), consumers will be able to spend your digital asset using one of our payment flows wherever merchants accept your digital asset.
 
 ## Defining a Payment Method
 
@@ -34,7 +34,7 @@ The liveness of a payment method can be either main or test. This can be used to
 - Test and main assets must share the same namespace but end in `test` or `main`. For example, `centrapay.main` and `centrapay.test`.
 - Integrating a test asset is optional.
 - A set of uplink APIs must be provided for both main and test.
-- [Centrapay Merchants](https://docs.centrapay.com/api/merchants) need a test flag in order to accept test assets as a payment option.
+- [Centrapay Merchants](https://docs.centrapay.com/api/merchants) need a test flag in order to accept test assets.
 
 ### Description
 
@@ -46,15 +46,15 @@ An example description is `Centrapay NZD`, `Bitcoin`, or `Ethereum`.
 
 ### Supported Currencies
 
-Payment Requests have a value determined by the currency a Merchant accepts. You should supply a finite list of three-letter [ISO currency codes](https://en.wikipedia.org/wiki/ISO_4217).
+[Payment Requests](https://docs.centrapay.com/api/payment-requests) have a value determined by the currency a Merchant accepts. You should supply a finite list of three-letter [ISO currency codes](https://en.wikipedia.org/wiki/ISO_4217) that is supported by your asset.
 
-### Example Payment Option
+### Example Definition
 
-| Field                                         | Type   | Description                                                                                                            | Examples     |
-| --------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------- | ------------ |
-| [Namespace](#namespace)                       | String | A name used for identifying the payment option in the format \{namespace\}.\{liveness\}.                               | bitcoin.main |
-| [Description](#description)                   | String | A short human readable description can be provided for a payment option.                                               | Bitcoin      |
-| [Supported Currencies](#supported-currencies) | Array  | A list of supported currencies referencing the three letter https://en.wikipedia.org/wiki/ISO_4217 for valid payments. | NZD, USD     |
+| Field                                         | Type   | Description                                                         | Examples          |
+| --------------------------------------------- | ------ | ------------------------------------------------------------------- | ----------------- |
+| [Namespace](#namespace)                       | String | A name used for uniquely identifying the asset as a payment method. | centrapay-example |
+| [Description](#description)                   | String | A short human readable description.                                 | Centrapay Money   |
+| [Supported Currencies](#supported-currencies) | Array  | A list of supported currency codes.                                 | NZD, USD          |
 
 ## Uplink API Requirements
 
@@ -347,12 +347,12 @@ Status Code `200`
 
 ## Implementation Checklist
 
-To enable merchants to accept your asset as a payment option, you must complete an integration certification. When you're ready or need assistance/have questions integrating, please contact the Centrapay Engineering team at integrations@centrapay.com.
+To enable merchants to accept your asset as a payment method, you must complete an integration certification. When you're ready or need assistance/have questions integrating, please contact the Centrapay Engineering team at integrations@centrapay.com.
 
-- Payment Option
+- Payment Method
   - Namespace
   - Description
   - Supported Currencies
-- Uplink urls for main liveness payment option
-- (Optional) Uplink urls for test liveness payment option
+- Uplink urls for main liveness payment method
+- (Optional) Uplink urls for test liveness payment method
 - An email address to contact for API spec enhancements


### PR DESCRIPTION
The wording around payment method, asset type, and payment option was inconsistent.


