### PR TITLE
Document one million dollar limit on monetary values

### DIFF
--- a/legacy/src/api/data-types.md
+++ b/legacy/src/api/data-types.md
@@ -33,10 +33,10 @@ typically represented as an [ISO 4217][]{:.external} code.
 
 {% h4 Fields %}
 
-|   Name   |        Type        |                        Description                         |
-| -------- | ------------------ | ---------------------------------------------------------- |
-| amount   | {% dt BigNumber %} | Value in the currency's smallest denomination (eg. cents). |
-| currency | String             | Currency code (eg. "NZD").                                 |
+|   Name   |        Type        |                                          Description                                          |
+| -------- | ------------------ | --------------------------------------------------------------------------------------------- |
+| amount   | {% dt BigNumber %} | Value in the currency's smallest denomination (eg. cents). Value must be less than 100000000. |
+| currency | String             | Currency code (eg. "NZD").                                                                    |
 
 
 ## CRN


### PR DESCRIPTION
Documents the one million dollar limit on monetary values added in https://bitbucket.org/centrapay/kari/pull-requests/1777.