### PR TITLE
Fix image path in Farmlands Connection page metadata

### DIFF
--- a/src/layouts/FarmlandsLayout.astro
+++ b/src/layouts/FarmlandsLayout.astro
@@ -1,10 +1,9 @@
 ---
 import ConnectionLayout from '../layouts/ConnectionLayout.astro';
 import Farmlands from '../components/Farmlands.vue';
-const { title, description } = Astro.props.frontmatter;
-const previewImg = 'countryside.jpg'
+const { title, description, img } = Astro.props.frontmatter;
 ---
-<ConnectionLayout title={title} description={description} img={previewImg}>
+<ConnectionLayout title={title} description={description} img={img}>
   <div slot="header">
     <Farmlands />
   </div>

--- a/src/pages/connections/farmlands.mdx
+++ b/src/pages/connections/farmlands.mdx
@@ -2,6 +2,7 @@
 layout: ../../layouts/FarmlandsLayout.astro
 title: Farmlands Connection
 description: Farmlands has partnered with Centrapay to deliver new ways for your business to authorise and process Farmlands Card payments that are faster, easier, and more secure than ever.
+img: /countryside.jpg
 ---
 import Grid from '../../components/Grid.vue';
 import SolutionCard from '../../components/SolutionCard.vue';


### PR DESCRIPTION
Add a leading slash to the file path so that it resolves and renders correctly in link previews.

Test plan:
- Confirm that the link preview for the Farmlands Connection page renders the correct image using [localtunnel](https://localtunnel.github.io/www/)

![image](https://user-images.githubusercontent.com/46909693/231671715-be14b77c-d599-47af-a2f0-54047428792e.png)
