### PR TITLE
Deploy Centrapay Docs previews to S3

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,36 @@
+name: Deploy Centrapay Docs Dev
+
+on:
+  workflow_dispatch
+
+jobs:
+  deploy-dev:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          working-directory: legacy
+      - uses: actions/cache@v1
+        with:
+          path: legacy/vendor/bundle
+          key: ${{ runner.os }}-gems-v2-${{ hashFiles('**/Gemfile.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-gems-v2
+      - run: gem install bundler
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '16'
+      - run: yarn install --frozen-lock-file
+      - run: ./build.sh http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::450412180052:role/github-actions-centrapay-docs
+          role-session-name: centrapay-docs-preview-deploy-session
+          aws-region: ap-southeast-1
+      - run: ./scripts/deploy-dev.sh

--- a/build.sh
+++ b/build.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+url="${1:-}"
+
 cd legacy
 
 bundle install
@@ -9,7 +11,11 @@ bundle exec jekyll build
 
 cd ../
 
-yarn build
+if [[ -n "$url" ]]; then
+  yarn build --site "$url"
+else
+  yarn build
+fi
 
 rsync -a dist/* _site/
 

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+dist=_site/
+find $dist || exit 1
+
+find $dist -type f -exec gzip -9 {} \; -exec mv {}.gz {} \;
+
+aws s3 cp $dist s3://centrapay-docs.dev/ --recursive --content-encoding gzip
+
+echo "Centrapay Docs preview deployed to: http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com"


### PR DESCRIPTION
Publish Centrapay Docs to S3 to allow stakeholders (designers, third parties) to review changes before they go live.

Note that this is a separate CD pipeline with a manual trigger for now. This [tech debt](https://www.notion.so/centrapay/Centrapay-Docs-previews-only-support-one-deployment-at-a-time-2b5bb39fd3d14437a5ad4977fd6474cd) will be addressed in upcoming PRs. These changes have a large footprint so I've opted to get previews working now to utilise them for testing the next steps.

Test plan:
- Confirm that [Centrapay Docs can be deployed to S3](http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/) for feature branches
- Confirm that users can see Centrapay Docs without needing authentication