### PR TITLE
Define order of side bar headings

### DIFF
--- a/src/utils/Navigation.js
+++ b/src/utils/Navigation.js
@@ -13,13 +13,20 @@ class Navigation {
           title: 'Reference',
           to: '/reference',
           icon: 'Receipt',
-          children: [],
+          children: [
+            { title: 'Centrapay Experiences', children: [] },
+            { title: 'Digital Assets', children: [] },
+            { title: 'App Integrations', children: [] },
+            { title: 'Merchant Integrations', children: [] },
+          ],
         },
         {
           title: 'Connections',
           to: '/connections',
           icon: 'Connections',
-          children: [],
+          children: [
+            { title: 'Farmlands', children: [] },
+          ],
         },
         {
           title: 'API',
@@ -31,10 +38,16 @@ class Navigation {
     };
     const pathToActiveNav = {};
     const navigation = new Navigation({ menu, pathToActiveNav });
-    const pages = content
-      .map(c => Page.fromContent(c))
-      .sort((a, b) => a.order - b.order);
-    pages.forEach(page => navigation.insertPage({ page }));
+
+    const headings = navigation.menu.children;
+    const subHeadings = headings.map(c => c.children).flat();
+    for (const subHeading of subHeadings) {
+      const sectionPages = content
+        .map(c => Page.fromContent(c))
+        .filter(a => a.nav.path.split('/')[1] === subHeading.title)
+        .sort((a, b) => a.order - b.order);
+      sectionPages.forEach(page => navigation.insertPage({ page }));
+    }
 
     // FIXME remove this block once each section header has a landing page
     const sectionHeaderTitle = [
@@ -42,10 +55,9 @@ class Navigation {
       'App Integrations',
       'Digital Assets',
       'Centrapay Experiences',
-      'Centrapay Integrations',
     ];
     sectionHeaderTitle.forEach((title) => {
-      const category = navigation.findItem({ title: title });
+      const category = navigation.findItem({ title });
       if(category) {
         category.to = category.children[0].to;
       }

--- a/src/utils/Navigation.js
+++ b/src/utils/Navigation.js
@@ -39,14 +39,14 @@ class Navigation {
     const pathToActiveNav = {};
     const navigation = new Navigation({ menu, pathToActiveNav });
 
-    const headings = navigation.menu.children;
-    const subHeadings = headings.map(c => c.children).flat();
+    const pages = content.map(c => Page.fromContent(c));
+
+    const subHeadings = navigation.menu.children.map(c => c.children).flat();
     for (const subHeading of subHeadings) {
-      const sectionPages = content
-        .map(c => Page.fromContent(c))
+      pages
         .filter(a => a.nav.path.split('/')[1] === subHeading.title)
-        .sort((a, b) => a.order - b.order);
-      sectionPages.forEach(page => navigation.insertPage({ page }));
+        .sort((a, b) => a.order - b.order)
+        .forEach(page => navigation.insertPage({ page }));
     }
 
     // FIXME remove this block once each section header has a landing page

--- a/src/utils/Navigation.js
+++ b/src/utils/Navigation.js
@@ -25,7 +25,7 @@ class Navigation {
           to: '/connections',
           icon: 'Connections',
           children: [
-            { title: 'Farmlands', children: [] },
+            { title: 'Farmlands', to: '/connections/farmlands', children: [] },
           ],
         },
         {
@@ -50,15 +50,9 @@ class Navigation {
     }
 
     // FIXME remove this block once each section header has a landing page
-    const sectionHeaderTitle = [
-      'Merchant Integrations',
-      'App Integrations',
-      'Digital Assets',
-      'Centrapay Experiences',
-    ];
-    sectionHeaderTitle.forEach((title) => {
-      const category = navigation.findItem({ title });
-      if(category) {
+    subHeadings.forEach((subHeading) => {
+      const category = navigation.findItem({ title: subHeading.title });
+      if(category && !category.to) {
         category.to = category.children[0].to;
       }
     });

--- a/src/utils/Navigation.js
+++ b/src/utils/Navigation.js
@@ -41,12 +41,20 @@ class Navigation {
 
     const pages = content.map(c => Page.fromContent(c));
 
-    const subHeadings = navigation.menu.children.map(c => c.children).flat();
+    const subHeadings = navigation.menu.children.map(c => c.children).flat().map(a => a.title);
     for (const subHeading of subHeadings) {
       pages
-        .filter(a => a.nav.path.split('/')[1] === subHeading.title)
+        .filter(a => a.nav.path.split('/')[1] === subHeading)
         .sort((a, b) => a.order - b.order)
         .forEach(page => navigation.insertPage({ page }));
+    }
+
+    const err = pages.filter(a => !subHeadings.includes(a.nav.path.split('/')[1]));
+    if (err) {
+      throw Error(
+        `The following pages have invalid paths: ${err.map(i => i.title)}.
+        If you are adding the page under a new subheading, ensure the subheading is included in the children list of the parent heading above.`
+      );
     }
 
     // FIXME remove this block once each section header has a landing page

--- a/src/utils/__tests__/Navigation.test.js
+++ b/src/utils/__tests__/Navigation.test.js
@@ -17,6 +17,42 @@ describe('Navigation', () => {
         },
         {
           collection: 'guides',
+          slug: 'payment-flows',
+          data: {
+            title: 'Payment Flows',
+            nav: {
+              path: 'Reference/Centrapay Experiences',
+              title: 'Payment Flows',
+              order: 1
+            },
+          },
+        },
+        {
+          collection: 'guides',
+          slug: 'creating-test-money',
+          data: {
+            title: 'Creating Test Money',
+            nav: {
+              path: 'Reference/Digital Assets',
+              title: 'Creating Test Money',
+              order: 1
+            },
+          },
+        },
+        {
+          collection: 'guides',
+          slug: 'example-oidc-consumer',
+          data: {
+            title: 'Example OIDC Consumer',
+            nav: {
+              path: 'Reference/App Integrations',
+              title: 'Example OIDC Consumer',
+              order: 1
+            },
+          },
+        },
+        {
+          collection: 'guides',
           slug: 'point-of-sale',
           data: {
             title: 'Point of Sale',
@@ -47,6 +83,39 @@ describe('Navigation', () => {
             to: '/reference',
             icon: 'Receipt',
             children: [
+              {
+                title: 'Centrapay Experiences',
+                to: '/guides/payment-flows',
+                children: [
+                  {
+                    title: 'Payment Flows',
+                    to: '/guides/payment-flows',
+                    children: [],
+                  },
+                ]
+              },
+              {
+                title: 'Digital Assets',
+                to: '/guides/creating-test-money',
+                children: [
+                  {
+                    title: 'Creating Test Money',
+                    to: '/guides/creating-test-money',
+                    children: [],
+                  },
+                ]
+              },
+              {
+                title: 'App Integrations',
+                to: '/guides/example-oidc-consumer',
+                children: [
+                  {
+                    title: 'Example OIDC Consumer',
+                    to: '/guides/example-oidc-consumer',
+                    children: [],
+                  },
+                ]
+              },
               {
                 title: 'Merchant Integrations',
                 to: '/guides/line-items',

--- a/src/utils/__tests__/testNav.test.js
+++ b/src/utils/__tests__/testNav.test.js
@@ -156,5 +156,74 @@ describe('Navigation', () => {
         pathToActiveNav: undefined,
       });
     });
+
+    test('Content is child of nav', () => {
+      expect(TestNav.create({
+        nav: [
+          {
+            title: 'API',
+            children: [
+              {
+                title: 'API Guide',
+              },
+              {
+                title: 'API Integration',
+              },
+            ]
+          }
+        ],
+        content: [
+          {
+            data: {
+              nav: {
+                path: 'API/API Guide'
+              }
+            },
+          },
+          {
+            data: {
+              nav: {
+                path: 'API/API Integration'
+              }
+            },
+          },
+        ],
+      })).toEqual({
+        menu: {
+          children: [
+            {
+              title: 'API',
+              children: [
+                {
+                  title: 'API Guide',
+                  children: [
+                    {
+                      data: {
+                        nav: {
+                          path: 'API/API Guide'
+                        }
+                      },
+                    }
+                  ],
+                },
+                {
+                  title: 'API Integration',
+                  children: [
+                    {
+                      data: {
+                        nav: {
+                          path: 'API/API Integration'
+                        }
+                      },
+                    }
+                  ],
+                }
+              ],
+            }
+          ]
+        },
+        pathToActiveNav: undefined,
+      });
+    });
   });
 });

--- a/src/utils/__tests__/testNav.test.js
+++ b/src/utils/__tests__/testNav.test.js
@@ -20,7 +20,7 @@ describe('Navigation', () => {
       });
     });
 
-    test('API ', () => {
+    test('Children is populated with single title nav entry', () => {
       expect(TestNav.create({
         nav: [
           {
@@ -33,6 +33,43 @@ describe('Navigation', () => {
           children: [
             {
               title: 'API',
+            }
+          ]
+        },
+        pathToActiveNav: undefined,
+      });
+    });
+
+    test('Content is child of nav', () => {
+      expect(TestNav.create({
+        nav: [
+          {
+            title: 'API',
+          }
+        ],
+        content: [
+          {
+            data: {
+              nav: {
+                path: 'API'
+              }
+            }
+          }
+        ],
+      })).toEqual({
+        menu: {
+          children: [
+            {
+              title: 'API',
+              children: [
+                {
+                  data: {
+                    nav: {
+                      path: 'API'
+                    }
+                  }
+                }
+              ],
             }
           ]
         },

--- a/src/utils/__tests__/testNav.test.js
+++ b/src/utils/__tests__/testNav.test.js
@@ -1,0 +1,19 @@
+import TestNav from '../testNav';
+
+describe('Navigation', () => {
+  describe('create', () => {
+    test('returns TestNav object', () => {
+      expect(TestNav.create({})).toEqual({
+        menu: undefined,
+        pathToActiveNav: undefined,
+      });
+    });
+
+    test('menu is empty when no content is empty', () => {
+      expect(TestNav.create({ content: [] })).toEqual({
+        menu: [],
+        pathToActiveNav: undefined,
+      });
+    });
+  });
+});

--- a/src/utils/__tests__/testNav.test.js
+++ b/src/utils/__tests__/testNav.test.js
@@ -33,6 +33,7 @@ describe('Navigation', () => {
           children: [
             {
               title: 'API',
+              children: []
             }
           ]
         },
@@ -71,6 +72,85 @@ describe('Navigation', () => {
                 }
               ],
             }
+          ]
+        },
+        pathToActiveNav: undefined,
+      });
+    });
+
+    test('Content is children of different nav', () => {
+      expect(TestNav.create({
+        nav: [
+          {
+            title: 'API',
+          },
+          {
+            title: 'Reference',
+          }
+        ],
+        content: [
+          {
+            data: {
+              title: 'content 1',
+              nav: {
+                path: 'API'
+              }
+            }
+          },
+          {
+            data: {
+              title: 'content 2',
+              nav: {
+                path: 'Reference'
+              }
+            }
+          },
+          {
+            data: {
+              title: 'content 3',
+              nav: {
+                path: 'Reference'
+              }
+            }
+          },
+        ],
+      })).toEqual({
+        menu: {
+          children: [
+            {
+              title: 'API',
+              children: [
+                {
+                  data: {
+                    title: 'content 1',
+                    nav: {
+                      path: 'API'
+                    }
+                  }
+                }
+              ],
+            },
+            {
+              title: 'Reference',
+              children: [
+                {
+                  data: {
+                    title: 'content 2',
+                    nav: {
+                      path: 'Reference'
+                    }
+                  }
+                },
+                {
+                  data: {
+                    title: 'content 3',
+                    nav: {
+                      path: 'Reference'
+                    }
+                  }
+                }
+              ],
+            },
           ]
         },
         pathToActiveNav: undefined,

--- a/src/utils/__tests__/testNav.test.js
+++ b/src/utils/__tests__/testNav.test.js
@@ -4,14 +4,38 @@ describe('Navigation', () => {
   describe('create', () => {
     test('returns TestNav object', () => {
       expect(TestNav.create({})).toEqual({
-        menu: undefined,
+        menu: {
+          children: []
+        },
         pathToActiveNav: undefined,
       });
     });
 
-    test('menu is empty when no content is empty', () => {
+    test('menu is empty when content is empty', () => {
       expect(TestNav.create({ content: [] })).toEqual({
-        menu: [],
+        menu: {
+          children: []
+        },
+        pathToActiveNav: undefined,
+      });
+    });
+
+    test('API ', () => {
+      expect(TestNav.create({
+        nav: [
+          {
+            title: 'API',
+          }
+        ],
+        content: []
+      })).toEqual({
+        menu: {
+          children: [
+            {
+              title: 'API',
+            }
+          ]
+        },
         pathToActiveNav: undefined,
       });
     });

--- a/src/utils/testNav.js
+++ b/src/utils/testNav.js
@@ -7,9 +7,10 @@ class NavGroup {
   }
 
   static create({ nav, content }) {
+    const children = content.filter(c => c.data.nav.path === nav.title);
     return new NavGroup({
       title: nav.title,
-      children: content
+      children,
     });
   }
 }

--- a/src/utils/testNav.js
+++ b/src/utils/testNav.js
@@ -6,10 +6,10 @@ class TestNav {
     this.pathToActiveNav = props.pathToActiveNav;
   }
 
-  static create({ baseUrl, content = [] }) {
+  static create({ nav = [], content = [] }) {
     return new TestNav({
       menu: {
-        children: content
+        children: nav
       }
     });
   }

--- a/src/utils/testNav.js
+++ b/src/utils/testNav.js
@@ -6,8 +6,12 @@ class TestNav {
     this.pathToActiveNav = props.pathToActiveNav;
   }
 
-  static create({ baseUrl, content }) {
-    return new TestNav({});
+  static create({ baseUrl, content = [] }) {
+    return new TestNav({
+      menu: {
+        children: content
+      }
+    });
   }
 }
 

--- a/src/utils/testNav.js
+++ b/src/utils/testNav.js
@@ -1,5 +1,19 @@
 import Page from './Page';
 
+class NavGroup {
+  constructor({ title, children }) {
+    this.title = title;
+    this.children = children;
+  }
+
+  static create({ nav, content }) {
+    return new NavGroup({
+      title: nav.title,
+      children: content
+    });
+  }
+}
+
 class TestNav {
   constructor(props) {
     this.menu = props.menu;
@@ -9,7 +23,7 @@ class TestNav {
   static create({ nav = [], content = [] }) {
     return new TestNav({
       menu: {
-        children: nav
+        children: nav.map(n => NavGroup.create({ nav: n, content }))
       }
     });
   }

--- a/src/utils/testNav.js
+++ b/src/utils/testNav.js
@@ -1,0 +1,14 @@
+import Page from './Page';
+
+class TestNav {
+  constructor(props) {
+    this.menu = props.menu;
+    this.pathToActiveNav = props.pathToActiveNav;
+  }
+
+  static create({ baseUrl, content }) {
+    return new TestNav({});
+  }
+}
+
+export default TestNav;


### PR DESCRIPTION
Matthias has requested that "Centrapay Experiences" should be the first heading under "Reference" in the side bar.
This change allows side bar headings to be re-ordered, so that "Centrapay Experiences" can be moved to the top.

Testing:
Assert that "Centrapay Experiences" is the first heading under "Reference" in the side bar.
Assert that all other headings still appear and perform correctly when clicked.