### PR TITLE
Update cancellation reasons table

### DIFF
--- a/legacy/src/api/payment-requests/payment-requests.md
+++ b/legacy/src/api/payment-requests/payment-requests.md
@@ -283,7 +283,6 @@ Payment Activities are created when a Payment Request has been **created**, **pa
 | PAYMENT_DECLINED             | The payment parameters were valid but payment was declined because additional payment restrictions were violated. For example, asset not active, asset overdrawn, quota exceeded or line item category restrictions. |
 | PAYMENT_REQUEST_EXPIRED      | The payment request has expired.                                                                                                                                                                                     |
 | NO_AVAILABLE_PAYMENT_OPTIONS | No payment options match the requested payment parameters.                                                                                                                                                           |
-| LINE_ITEMS_INVALID           | The line items on payment request was invalid                                                                                                                                                                        |
 
 ## Operations
 

--- a/legacy/src/api/payment-requests/payment-requests.md
+++ b/legacy/src/api/payment-requests/payment-requests.md
@@ -276,7 +276,6 @@ Payment Activities are created when a Payment Request has been **created**, **pa
 | CANCELLED_BY_MERCHANT        | The merchant cancelled the payment request by calling the cancel or void endpoint.                                                                                                                                   |
 | CANCELLED_BY_PATRON          | The patron cancelled the transaction.                                                                                                                                                                                |
 | PATRON_CODE_INVALID          | The patron code on the payment request was invalid.                                                                                                                                                                  |
-| INSUFFICIENT_ASSET_VALUE     | The asset has insufficient funds to pay the payment request or the transaction amount received by Centrapay is less than the total of the payment.                                                                   |
 | PAYMENT_FAILED               | The payment request failed for an unknown reason.                                                                                                                                                                    |
 | PATRON_CODE_EXPIRED          | The patron code on the payment request has expired.                                                                                                                                                                  |
 | DECLINED_BY_PATRON           | The payment was declined by the patron during approval steps.                                                                                                                                                        |
@@ -284,6 +283,7 @@ Payment Activities are created when a Payment Request has been **created**, **pa
 | PAYMENT_DECLINED             | The payment parameters were valid but payment was declined because additional payment restrictions were violated. For example, asset not active, asset overdrawn, quota exceeded or line item category restrictions. |
 | PAYMENT_REQUEST_EXPIRED      | The payment request has expired.                                                                                                                                                                                     |
 | NO_AVAILABLE_PAYMENT_OPTIONS | No payment options match the requested payment parameters.                                                                                                                                                           |
+| LINE_ITEMS_INVALID           | The line items on payment request was invalid                                                                                                                                                                        |
 
 ## Operations
 


### PR DESCRIPTION
In this PR,  `INSUFFICIENT_ASSET_VALUE `is removed from the table.

Reason:
    - `INSUFFICIENT_ASSET_VALUE ` is currently masked in the payment request and it's always changed to `PAYMENT_DECLINED`.  Also, in Notion [Cancellation Reasons](https://www.notion.so/centrapay/cc8804baaca0436f8d0c5ea17879a99e?v=cc0d6e9786a9430c9ad4f483f4d52c47&pvs=4) that `INSUFFICIENT_ASSET_VALUE ` is an internal name, its public name is `PAYMENT_DECLINED` 
![Screenshot 2023-05-09 at 4 01 09 PM](https://user-images.githubusercontent.com/74471007/236990863-b7c4e7a5-b653-49eb-bcca-6b5ba615ba18.png)

We've already had `PAYMENT_DECLINED` publicly documented, hence  `INSUFFICIENT_ASSET_VALUE ` could be removed from the table.
<br>