### PR TITLE
add INACTIVE_ASSET cancellation reason

### DIFF
--- a/legacy/src/api/payment-requests/payment-requests.md
+++ b/legacy/src/api/payment-requests/payment-requests.md
@@ -283,7 +283,7 @@ Payment Activities are created when a Payment Request has been **created**, **pa
 | PAYMENT_DECLINED             | The payment parameters were valid but payment was declined because additional payment restrictions were violated. For example, asset not active, asset overdrawn, quota exceeded or line item category restrictions. |
 | PAYMENT_REQUEST_EXPIRED      | The payment request has expired.                                                                                                                                                                                     |
 | NO_AVAILABLE_PAYMENT_OPTIONS | No payment options match the requested payment parameters.                                                                                                                                                           |
-| INACTIVE_ASSET               | The asset on the payment request is inactive.                                                                                                                                                                        |
+| INACTIVE_ASSET               | The asset used to pay the payment request is inactive.                                                                                                                                                               |
 
 ## Operations
 

--- a/legacy/src/api/payment-requests/payment-requests.md
+++ b/legacy/src/api/payment-requests/payment-requests.md
@@ -283,6 +283,7 @@ Payment Activities are created when a Payment Request has been **created**, **pa
 | PAYMENT_DECLINED             | The payment parameters were valid but payment was declined because additional payment restrictions were violated. For example, asset not active, asset overdrawn, quota exceeded or line item category restrictions. |
 | PAYMENT_REQUEST_EXPIRED      | The payment request has expired.                                                                                                                                                                                     |
 | NO_AVAILABLE_PAYMENT_OPTIONS | No payment options match the requested payment parameters.                                                                                                                                                           |
+| INACTIVE_ASSET               | The asset on the payment request is inactive.                                                                                                                                                                        |
 
 ## Operations
 


### PR DESCRIPTION
This change adds the INACTIVE_ASSET cancellation reasons to the list, as we're now returning this when the provided token has already been redeemed.

ADR: https://www.notion.so/centrapay/Return-INACTIVE_ASSET-for-redeemed-Tokens-ca92971e4e224b1da7cda7cf85aaf7bc?pvs=4
Story: https://www.notion.so/centrapay/Improve-token-redemption-error-messaging-905187e6fe774baea7a1459fd03499fe?pvs=4 