### PR TITLE
Add collections and redemption conditions

### DIFF
--- a/legacy/src/api/assets/assets.md
+++ b/legacy/src/api/assets/assets.md
@@ -106,24 +106,26 @@ Gift cards have the following fields along with the base asset fields.
 <a name="tokens">
 ### Tokens (EXPERIMENTAL)
 
-Tokens are assets which can be spent only once. They are usually tied to a
-small set of merchants and have an expiry date. Token value may be set in
-multiple currencies and is the same for all tokens of the same type.
+Tokens are assets which can only be spent in full. 
+
+Every token is associated with a collection, which defines the branding and general rules for the tokens, such as active duration.
 
 Tokens have the following fields along with the base asset fields.
 
 {% h4 Fields %}
 
-|     Field     |             Type             |                                         Description                                          |
-| :------------ | :--------------------------- | :------------------------------------------------------------------------------------------- |
-| value         | Array {% opt %}              | The [Monetary Amounts][] representing the token's nominal value in its supported currencies. |
-| activeFrom    | {% dt Timestamp %} {% opt %} | The date when the asset becomes spendable.                                                   |
-| expiresAt     | {% dt Timestamp %} {% opt %} | The date when the asset expires.                                                             |
-| img           | String {% opt %}             | The img URL of the token.                                                                    |
-| issuer        | String {% opt %}             | The identifier for the issuer of the token.                                                  |
-| issuerWebsite | String {% opt %}             | The URL of the issuer of the token.                                                          |
-| issuerImg     | String {% opt %}             | The img URL of the issuer that the token belongs to.                                         |
-
+|     Field      |             Type             |                                                 Description                                                 |
+| :------------- | :--------------------------- | :---------------------------------------------------------------------------------------------------------- |
+| collectionId   | String                       | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
+| idempotencyKey | String                       | Client-supplied identifier that prevents double creation.                                                   |
+| createdBy      | {% dt CRN %}                 | The identity that created the activity.                                                                     |
+| value          | Array {% opt %}              | The [Monetary Amounts][] representing the token's nominal value in its supported currencies. **DEPRECATED** |
+| activeFrom     | {% dt Timestamp %} {% opt %} | The date when the asset becomes spendable.                                                                  |
+| expiresAt      | {% dt Timestamp %} {% opt %} | The date when the asset expires.                                                                            |
+| img            | String {% opt %}             | The img URL of the token.                                                                                   |
+| issuer         | String {% opt %}             | The identifier for the issuer of the token.                                                                 |
+| issuerWebsite  | String {% opt %}             | The URL of the issuer of the token.                                                                         |
+| issuerImg      | String {% opt %}             | The img URL of the issuer that the token belongs to.                                                        |
 
 ## Operations
 

--- a/legacy/src/api/assets/assets.md
+++ b/legacy/src/api/assets/assets.md
@@ -117,7 +117,6 @@ Tokens have the following fields along with the base asset fields.
 |     Field      |             Type             |                                                 Description                                                 |
 | :------------- | :--------------------------- | :---------------------------------------------------------------------------------------------------------- |
 | collectionId   | String                       | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
-| idempotencyKey | String                       | Client-supplied identifier that prevents double creation.                                                   |
 | createdBy      | {% dt CRN %}                 | The identity that created the activity.                                                                     |
 | value          | Array {% opt %}              | The [Monetary Amounts][] representing the token's nominal value in its supported currencies. **DEPRECATED** |
 | activeFrom     | {% dt Timestamp %} {% opt %} | The date when the asset becomes spendable.                                                                  |

--- a/legacy/src/api/assets/tokens.md
+++ b/legacy/src/api/assets/tokens.md
@@ -23,7 +23,129 @@ Token value may be set in multiple currencies and is the same for all tokens in 
 * TOC
 {:toc}
 
-## Create Token **EXPERIMENTAL**
+## Models
+
+### Token Collection
+<a name="token-collection">
+{% h4 Fields %}
+
+|       Field       |                  Type                   |                                     Description                                     |
+| :---------------- | :-------------------------------------- | :---------------------------------------------------------------------------------- |
+| name              | String                                  | The display name of the collection.                                                 |
+| accountId         | String                                  | The account that will own the collection.                                           |
+| tokenExpiresAfter | [TokenExpiresAfter](#tokenexpiresafter) | The active duration of all tokens created from this collection.                     |
+| type              | String                                  | The type of value exchanged when redeeming tokens, can be `product`                 |
+| maxValue          | {% dt Monetary %} {% opt %}             | The maximum agreed value that any merchants will be settled for a token redemption. |
+
+### TokenExpiresAfter
+<a name="tokenExpiresAfter">
+
+|  Field   |  Type  |                        Description                        |
+| :------- | :----- | :-------------------------------------------------------- |
+| period   | String | Supported values are `hour`, `day`, `week`, and `month` . |
+| duration | String | Number of `period` until token expiration.                |
+
+### Redemption Condition
+{% h4 Fields %}
+
+|      Field      |                     Type                      |                             Description                              |
+| :-------------- | :-------------------------------------------- | :------------------------------------------------------------------- |
+| merchantId      | String                                        | The identifier of the merchant that is accepting the collection.     |
+| allowedProducts | [AllowedProducts](#allowedproducts) {% opt %} | List of allowed products, required for collections of type `product` |
+
+
+### AllowedProducts
+<a name="allowedProducts">
+
+|  Field   |       Type        |                       Description                       |
+| :------- | :---------------- | :------------------------------------------------------ |
+| sku      | String            | The SKU of the product that is to be accepted.          |
+| name     | String            | Display name of the product                             |
+| maxValue | {% dt Monetary %} | The maximum value that the product can be redeemed for. |
+
+### Token
+{% h4 Fields %}
+
+|     Field      |  Type  |                                                 Description                                                 |
+| :------------- | :----- | :---------------------------------------------------------------------------------------------------------- |
+| collectionId   | String | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
+| idempotencyKey | String | Client-supplied identifier that prevents double creation.                                                   |
+
+## Operations
+### Create Token Collection **EXPERIMENTAL**
+
+{% reqspec %}
+  POST '/api/collections'
+  auth 'api-key'
+  body ({
+    "name": "Bread",
+		"accountId": "T3y6hogYA4d612BExypWYH",
+		"tokenExpiresAfter": {
+			"period": "month",
+			"duration": "1"
+		},
+		"maxValue": {
+			"currency": "NZD",
+			"amount": "400"
+		},
+		"type": "product",
+  })
+{% endreqspec %}
+
+{% h4 Example response payload %}
+{% json %}
+{
+  "id": "Xv990BzkgfoDS7bBls50pd",
+  "name": "Bread",
+	"accountId": "T3y6hogYA4d612BExypWYH",
+  "tokenExpiresAfter": {
+    "period": "month",
+    "duration": "1",
+  },
+  "maxValue": {
+		"currency": "NZD",
+		"amount": "400",
+	},
+  "test": true,
+	"type": "product",
+	"status": "active",
+	"createdBy": "crn::user:b657195e-dc2f-11ea-8566-e7710d592c99",
+	"createdAt": "2021-05-12T04:30:11.001Z",
+}
+{% endjson %}  
+
+### Create Redemption Condition **EXPERIMENTAL**
+
+{% reqspec %}
+  POST '/api/collections/{collectionId}/redemption-conditions'
+  auth 'api-key'
+  path_param 'collectionId', 'NFhUgPQEYbk2EbTXAYArTX'
+  body ({
+   "merchantId": "36EALpZ89XpShxM2Ee9sXT",
+		"allowedProducts": [
+			{ "sku": "100001", "name": "White Bread", "maxValue": { "currency": "NZD", "amount": "400" },}, 
+			{ "sku": "100002", "name": "Sourdough Bread", "maxValue": { "currency": "NZD", "amount": "800" },}, 
+		]
+  })
+{% endreqspec %}
+
+{% h4 Example response payload %}
+
+{% json %}
+{
+  "id": "1234",
+  "merchantId": "36EALpZ89XpShxM2Ee9sXT",
+  "collectionId": "NFhUgPQEYbk2EbTXAYArTX",
+  "allowedProducts": [
+	  { sku: "100001", name: "White Bread", maxValue: { currency: "NZD", amount: "400" },}, 
+	  { sku: "100002", name: "Sourdough Bread", maxValue: { currency: "NZD", amount: "800" },}, 
+  ],
+  "createdAt": "2022-05-12T04:30:11.001Z",
+  "createdBy": "crn::user:b657195e-dc2f-11ea-8566-e7710d592c99",
+}
+{% endjson %}
+
+### Create Token **EXPERIMENTAL**
 
 {% reqspec %}
   POST '/api/tokens'
@@ -33,13 +155,6 @@ Token value may be set in multiple currencies and is the same for all tokens in 
     "idempotencyKey": "payment-de32dd90-b46c-11ea-93c3-83a333b86e7b"
   })
 {% endreqspec %}
-
-{% h4 Fields %}
-
-|     Field      |  Type  |                                      Description                                       |
-| :------------- | :----- | :------------------------------------------------------------------------------------- |
-| collectionId   | String | The token collection that will govern the branding and redemption rules for the token. |
-| idempotencyKey | String | Client-supplied identifier that prevents double creation.                              |
 
 {% h4 Example response payload %}
 
@@ -70,109 +185,3 @@ Token value may be set in multiple currencies and is the same for all tokens in 
 | :----- | :-------------------- | :----------------------------------------------------------------------- |
 | 403    | TOKEN_ALREADY_CREATED | Token with supplied parameters already exists.                           |
 | 403    | LIVENESS_MISMATCH     | The account is test and the collection's liveness is main or vice versa. |
-
-## Create Token Collection
-
-{% reqspec %}
-  POST '/api/collections'
-  auth 'api-key'
-  body ({
-    "name": "Bread",
-		"accountId": "T3y6hogYA4d612BExypWYH",
-		"tokenExpiresAfter": {
-			"period": "month",
-			"duration": "1"
-		},
-		"maxValue": {
-			"currency": "NZD",
-			"amount": "400"
-		},
-		"type": "product",
-  })
-{% endreqspec %}
-
-{% h4 Fields %}
-
-|     Field      |  Type  |                                      Description                                       |
-| :------------- | :----- | :------------------------------------------------------------------------------------- |
-| name   | String | The display name of the collection. |
-| accountId | String | The account that will own the collection.                              |
-| tokenExpiresAfter   | String | The active duration of all tokens created from this collection. |
-| type | String | Supported values: <br> - `product`: tokens for this collection will be exchanged for one product. |
-| maxValue | {% dt Monetary %} {% opt %} | The maximum agreed value that any merchants will be settled for a token redemption. |
-
-{% h4 TokenExpiresAfter %}
-
-|     Field      |  Type  |                                      Description                                       |
-| :------------- | :----- | :------------------------------------------------------------------------------------- |
-| period | String | The unit of time to measure the duration until token expiration. It can be `hour`, `day`, `week`, and `month` .|
-| duration | String | The length of time for the token to remain valid before expiration. |
-
-{% h4 Example response payload %}
-{% json %}
-{
-  "id": "Xv990BzkgfoDS7bBls50pd",
-  "name": "Bread",
-	"accountId": "T3y6hogYA4d612BExypWYH",
-	"img": "https://static.centrapay.com/assets/media-uploads/{mediaUploadId}.png",
-  "tokenExpiresAfter": {
-    "period": "month",
-    "duration": "1",
-  },
-  "maxValue": {
-		"currency": "NZD",
-		"amount": "400",
-	},
-  "test": true,
-	"type": "product",
-	"status": "active",
-	"createdBy": "crn::user:b657195e-dc2f-11ea-8566-e7710d592c99",
-	"createdAt": "2021-05-12T04:30:11.001Z",
-}
-{% endjson %}  
-
-## Create Redemption Condition
-
-{% reqspec %}
-  POST '/api/collections/{collectionId}/redemption-conditions'
-  auth 'api-key'
-  path_param 'collectionId', 'NFhUgPQEYbk2EbTXAYArTX'
-  body ({
-   "merchantId": "36EALpZ89XpShxM2Ee9sXT",
-		"allowedProducts": [
-			{ "sku": "100001", "name": "White Bread", "maxValue": { "currency": "NZD", "amount": "400" },}, 
-			{ "sku": "100002", "name": "Sourdough Bread", "maxValue": { "currency": "NZD", "amount": "800" },}, 
-		]
-  })
-{% endreqspec %}
-
-{% h4 Fields %}
-
-|     Field      |  Type  |                                      Description                                       |
-| :------------- | :----- | :------------------------------------------------------------------------------------- |
-| merchantId   | String | The ID of the merchant that is accepting the collection. |
-| allowedProducts | String {% opt %} | List of allowed products, required for collections of type `product`                             |
-
-{% h4 AllowedProducts %}
-
-|     Field      |  Type  |                                      Description                                       |
-| :------------- | :----- | :------------------------------------------------------------------------------------- |
-| sku   | String | The SKU of the product that is to be accepted. |
-| name  | String | Display name of the product |
-| maxValue   | {% dt Monetary %} | The maximum value that the product can be redeemed for. |
-
-{% h4 Example response payload %}
-
-{% json %}
-{
-  "id": "1234",
-  "merchantId": "36EALpZ89XpShxM2Ee9sXT",
-  "collectionId": "NFhUgPQEYbk2EbTXAYArTX",
-  "allowedProducts": [
-	  { sku: "100001", name: "White Bread", maxValue: { currency: "NZD", amount: "400" },}, 
-	  { sku: "100002", name: "Sourdough Bread", maxValue: { currency: "NZD", amount: "800" },}, 
-  ],
-  "createdAt": "2022-05-12T04:30:11.001Z",
-  "createdBy": "crn::user:b657195e-dc2f-11ea-8566-e7710d592c99",
-}
-{% endjson %}

--- a/legacy/src/api/assets/tokens.md
+++ b/legacy/src/api/assets/tokens.md
@@ -70,3 +70,110 @@ Token value may be set in multiple currencies and is the same for all tokens in 
 | :----- | :-------------------- | :----------------------------------------------------------------------- |
 | 403    | TOKEN_ALREADY_CREATED | Token with supplied parameters already exists.                           |
 | 403    | LIVENESS_MISMATCH     | The account is test and the collection's liveness is main or vice versa. |
+
+## Create Token Collection
+
+{% reqspec %}
+  POST '/api/collections'
+  auth 'api-key'
+  body ({
+    "name": "Bread",
+		"accountId": "T3y6hogYA4d612BExypWYH",
+		"tokenExpiresAfter": {
+			"period": "months",
+			"duration": "1"
+		},
+		"maxValue": {
+			"currency": "NZD",
+			"amount": "400"
+		},
+		"type": "product",
+  })
+{% endreqspec %}
+
+{% h4 Fields %}
+
+|     Field      |  Type  |                                      Description                                       |
+| :------------- | :----- | :------------------------------------------------------------------------------------- |
+| name   | String | The display name of the collection. |
+| accountId | String | The account that will own the collection.                              |
+| tokenExpiresAfter   | String | The active duration of all tokens created from this collection. |
+| type | String | Supported values: <br> - `product`: tokens for this collection will be exchanged for one product. |
+| maxValue | {% dt Monetary %} {% opt %} | The maximum agreed value that any merchants will be settled for a token redemption. |
+| mediaUploadId | String {% opt %} | The id of the media upload image used for all tokens that are created from this collection. |
+
+{% h4 TokenExpiresAfter %}
+
+|     Field      |  Type  |                                      Description                                       |
+| :------------- | :----- | :------------------------------------------------------------------------------------- |
+| period | String | The unit of time to measure the duration until token expiration. It can be `hours`, `days`, `weeks`, and `months` .|
+| duration | String | The length of time for the token to remain valid before expiration. |
+
+{% h4 Example response payload %}
+{% json %}
+{
+  "id": "Xv990BzkgfoDS7bBls50pd",
+  "name": "Bread",
+	"accountId": "T3y6hogYA4d612BExypWYH",
+	"img": "https://static.centrapay.com/assets/media-uploads/{mediaUploadId}.png",
+  "tokenExpiresAfter": {
+    "period": "months",
+    "duration": "1",
+  },
+  "maxValue": {
+		"currency": "NZD",
+		"amount": "400",
+	},
+  "test": true,
+	"type": "product",
+	"status": "active",
+	"createdBy": "crn::user:b657195e-dc2f-11ea-8566-e7710d592c99",
+	"createdAt": "2021-05-12T04:30:11.001Z",
+}
+{% endjson %}  
+
+## Create Redemption Condition
+
+{% reqspec %}
+  POST '/api/collections/{collectionId}/redemption-conditions'
+  auth 'api-key'
+  path_param 'collectionId', 'NFhUgPQEYbk2EbTXAYArTX'
+  body ({
+   "merchantId": "36EALpZ89XpShxM2Ee9sXT",
+		"allowedProducts": [
+			{ "sku": "100001", "name": "White Bread", "maxValue": { "currency": "NZD", "amount": "400" },}, 
+			{ "sku": "100002", "name": "Sourdough Bread", "maxValue": { "currency": "NZD", "amount": "800" },}, 
+		]
+  })
+{% endreqspec %}
+
+{% h4 Fields %}
+
+|     Field      |  Type  |                                      Description                                       |
+| :------------- | :----- | :------------------------------------------------------------------------------------- |
+| merchantId   | String | The ID of the merchant that is accepting the collection. |
+| allowedProducts | String {% opt %} | List of allowed products, required for collections of type `product`                             |
+
+{% h4 AllowedProducts %}
+
+|     Field      |  Type  |                                      Description                                       |
+| :------------- | :----- | :------------------------------------------------------------------------------------- |
+| sku   | String | The SKU of the product that is to be accepted. |
+| name  | String | Display name of the product |
+| maxValue   | {% dt Monetary %} | The maximum value that the product can be redeemed for. |
+
+{% h4 Example response payload %}
+
+{% json %}
+{
+  "id": "1234",
+  "merchantId": "36EALpZ89XpShxM2Ee9sXT",
+  "collectionId": "NFhUgPQEYbk2EbTXAYArTX",
+  "allowedProducts": [
+	  { sku: "100001", name: "White Bread", maxValue: { currency: "NZD", amount: "400" },}, 
+	  { sku: "100002", name: "Sourdough Bread", maxValue: { currency: "NZD", amount: "800" },}, 
+  ],
+  "createdAt": "2022-05-12T04:30:11.001Z",
+  "createdBy": "crn::user:b657195e-dc2f-11ea-8566-e7710d592c99",
+}
+{% endjson %}

--- a/legacy/src/api/assets/tokens.md
+++ b/legacy/src/api/assets/tokens.md
@@ -23,7 +23,7 @@ A redemption condition is created for each merchant that accepts tokens from a c
 
 ## Models
 
-### Token Collection
+### Token Collection **EXPERIMENTAL**
 <a name="token-collection">
 {% h4 Fields %}
 
@@ -31,7 +31,7 @@ A redemption condition is created for each merchant that accepts tokens from a c
 | :---------------- | :---------------------------------------- | :---------------------------------------------------------------------------------- |
 | name              | String                                    | The display name of the collection.                                                 |
 | accountId         | String                                    | The account that will own the collection.                                           |
-| tokenExpiresAfter | [Token Expires After](#tokenexpiresafter) | The active duration of all tokens created from this collection.                     |
+| tokenExpiresAfter | [Token Expires After](#tokenExpiresAfter) | The active duration of all tokens created from this collection.                     |
 | type              | String                                    | The type of value exchanged when redeeming tokens, can be `product`                 |
 | maxValue          | {% dt Monetary %} {% opt %}               | The maximum agreed value that any merchants will be settled for a token redemption. |
 | id                | String                                    | The token collection id                                                             |
@@ -40,28 +40,28 @@ A redemption condition is created for each merchant that accepts tokens from a c
 | createdBy         | {% dt CRN %}                              | The identity that created the activity.                                             |
 | createdAt         | {% dt Timestamp %}                        | Timestamp at which the token collection was created.                                |
 
-### Token Expires After
 <a name="tokenExpiresAfter">
+### Token Expires After **EXPERIMENTAL**
 
 |  Field   |  Type  |                          Description                           |
 | :------- | :----- | :------------------------------------------------------------- |
 | period   | String | Supported values are `hour`, `day`, `week`,`month` and `year`. |
 | duration | String | Number of `period` until token expiration.                     |
 
-### Redemption Condition
+### Redemption Condition **EXPERIMENTAL**
 {% h4 Fields %}
 
 |      Field      |                      Type                      |                                                 Description                                                 |
 | :-------------- | :--------------------------------------------- | :---------------------------------------------------------------------------------------------------------- |
 | merchantId      | String                                         | The identifier of the merchant that is accepting the collection.                                            |
-| allowedProducts | [Allowed Products](#allowedproducts) {% opt %} | List of allowed products, required for collections of type `product`                                        |
+| allowedProducts | [Allowed Products](#allowedProducts) {% opt %} | List of allowed products, required for collections of type `product`                                        |
 | id              | String                                         | The redemption condition id                                                                                 |
 | collectionId    | String                                         | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
 | createdBy       | {% dt CRN %}                                   | The identity that created the activity.                                                                     |
 | createdAt       | {% dt Timestamp %}                             | Timestamp at which the redemption condition was created.                                                    |
 
-### Allowed Products
 <a name="allowedProducts">
+### Allowed Products **EXPERIMENTAL**
 
 |  Field   |       Type        |                       Description                       |
 | :------- | :---------------- | :------------------------------------------------------ |

--- a/legacy/src/api/assets/tokens.md
+++ b/legacy/src/api/assets/tokens.md
@@ -114,6 +114,40 @@ Token value may be set in multiple currencies and is the same for all tokens in 
 }
 {% endjson %}  
 
+### List Token Collections for Account **EXPERIMENTAL**
+
+{% reqspec %}
+  GET '/api/accounts/{accountId}/collections'
+  auth 'api-key'
+  path_param 'accountId', 'T3y6hogYA4d612BExypWYH'
+{% endreqspec %}
+
+{% h4 Example response payload %}
+
+{% json %}
+{
+  "nextPageKey": "Collection#E9eXsErwA444qFDoZt5iLA|#Collection",
+	"items": [{
+		"id": "Xv990BzkgfoDS7bBls50pd",
+		"name": "Bread",
+		"accountId": 'T3y6hogYA4d612BExypWYH',
+		"tokenExpiresAfter": {
+	    "period": 'month',
+	    "duration": '1',
+	  },
+		"maxValue": {
+			"currency": "NZD",
+			"amount": "400",
+		},
+		"test": true,
+		"type": "product",
+		"status": "active",
+		"createdBy": "crn::user:b657195e-dc2f-11ea-8566-e7710d592c99",
+		"createdAt": "2021-05-12T04:30:11.001Z",
+	}]
+}
+{% endjson %}
+
 ### Create Redemption Condition **EXPERIMENTAL**
 
 {% reqspec %}

--- a/legacy/src/api/assets/tokens.md
+++ b/legacy/src/api/assets/tokens.md
@@ -9,14 +9,11 @@ permalink: /api/tokens
 # Tokens
 {:.no_toc}
 
-Tokens are assets which can be spent only once. They are usually tied to a
-small set of merchants and have an expiry date.
+Tokens are assets which can only be spent in full.
 
-Every token is associated with a collection, which sets the guidelines for redeeming the tokens and establishes their unique branding.
+Every token is associated with a collection, which defines the branding and general rules for the tokens, such as active duration.
 
-A redemption condition outlines the specific details regarding the products that can be exchanged in return for the tokens. It provides information on the eligible items that can be redeemed.
-
-
+A redemption condition is created for each merchant that accepts tokens from a collection, and contains additional conditions specific to that merchant, such as redeemable product identifiers.
 
 ## Contents
 {:.no_toc .text-delta}
@@ -30,23 +27,21 @@ A redemption condition outlines the specific details regarding the products that
 <a name="token-collection">
 {% h4 Fields %}
 
-|       Field       |                  Type                   |                                     Description                                     |
-| :---------------- | :-------------------------------------- | :---------------------------------------------------------------------------------- |
-| name              | String                                  | The display name of the collection.                                                 |
-| accountId         | String                                  | The account that will own the collection.                                           |
-| tokenExpiresAfter | [TokenExpiresAfter](#tokenexpiresafter) | The active duration of all tokens created from this collection.                     |
-| type              | String                                  | The type of value exchanged when redeeming tokens, can be `product`                 |
-| maxValue          | {% dt Monetary %} {% opt %}             | The maximum agreed value that any merchants will be settled for a token redemption. |
-| id                | String                                  | The token collection id                                                             |
-| test              | Boolean                                 | `true` if the token collection is for testing purposes only.                        |
-| status            | String                                  | The status of the token collection. Valid values include 'active'.                  |
-| createdBy         | {% dt CRN %}                            | The identity that created the activity.                                             |
-| createdAt         | {% dt Timestamp %}                      | Timestamp at which the token collection was created.                                |
+|       Field       |                   Type                    |                                     Description                                     |
+| :---------------- | :---------------------------------------- | :---------------------------------------------------------------------------------- |
+| name              | String                                    | The display name of the collection.                                                 |
+| accountId         | String                                    | The account that will own the collection.                                           |
+| tokenExpiresAfter | [Token Expires After](#tokenexpiresafter) | The active duration of all tokens created from this collection.                     |
+| type              | String                                    | The type of value exchanged when redeeming tokens, can be `product`                 |
+| maxValue          | {% dt Monetary %} {% opt %}               | The maximum agreed value that any merchants will be settled for a token redemption. |
+| id                | String                                    | The token collection id                                                             |
+| test              | Boolean                                   | `true` if the token collection is for testing purposes only.                        |
+| status            | String                                    | The status of the token collection. Valid values include 'active'.                  |
+| createdBy         | {% dt CRN %}                              | The identity that created the activity.                                             |
+| createdAt         | {% dt Timestamp %}                        | Timestamp at which the token collection was created.                                |
 
-### TokenExpiresAfter
+### Token Expires After
 <a name="tokenExpiresAfter">
-
-TokenExpiresAfter is the active duration of all tokens created from a collection.
 
 |  Field   |  Type  |                          Description                           |
 | :------- | :----- | :------------------------------------------------------------- |
@@ -56,44 +51,23 @@ TokenExpiresAfter is the active duration of all tokens created from a collection
 ### Redemption Condition
 {% h4 Fields %}
 
-|      Field      |                     Type                      |                                                 Description                                                 |
-| :-------------- | :-------------------------------------------- | :---------------------------------------------------------------------------------------------------------- |
-| merchantId      | String                                        | The identifier of the merchant that is accepting the collection.                                            |
-| allowedProducts | [AllowedProducts](#allowedproducts) {% opt %} | List of allowed products, required for collections of type `product`                                        |
-| id              | String                                        | The redemption condition id                                                                                 |
-| collectionId    | String                                        | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
-| createdBy       | {% dt CRN %}                                  | The identity that created the activity.                                                                     |
-| createdAt       | {% dt Timestamp %}                            | Timestamp at which the redemption condition was created.                                                    |
+|      Field      |                      Type                      |                                                 Description                                                 |
+| :-------------- | :--------------------------------------------- | :---------------------------------------------------------------------------------------------------------- |
+| merchantId      | String                                         | The identifier of the merchant that is accepting the collection.                                            |
+| allowedProducts | [Allowed Products](#allowedproducts) {% opt %} | List of allowed products, required for collections of type `product`                                        |
+| id              | String                                         | The redemption condition id                                                                                 |
+| collectionId    | String                                         | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
+| createdBy       | {% dt CRN %}                                   | The identity that created the activity.                                                                     |
+| createdAt       | {% dt Timestamp %}                             | Timestamp at which the redemption condition was created.                                                    |
 
-### AllowedProducts
+### Allowed Products
 <a name="allowedProducts">
-
-AllowedProducts include a list of products that can be redeemed for.
 
 |  Field   |       Type        |                       Description                       |
 | :------- | :---------------- | :------------------------------------------------------ |
 | sku      | String            | The SKU of the product that is to be accepted.          |
 | name     | String            | Display name of the product                             |
 | maxValue | {% dt Monetary %} | The maximum value that the product can be redeemed for. |
-
-### Token
-{% h4 Fields %}
-
-|     Field      |        Type        |                                                 Description                                                 |
-| :------------- | :----------------- | :---------------------------------------------------------------------------------------------------------- |
-| collectionId   | String             | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
-| idempotencyKey | String             | Client-supplied identifier that prevents double creation.                                                   |
-| id             | String             | The token id                                                                                                |
-| accountId      | String             | The account that owns the collection.                                                                       |
-| collectionId   | String             | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
-| createdBy      | {% dt CRN %}       | The identity that created the activity.                                                                     |
-| createdAt      | {% dt Timestamp %} | Timestamp at which the token was created.                                                                   |
-| category       | String             | Asset category ("money", "giftcard", "token").                                                              |
-| status         | String             | The status of the token.                                                                                    |
-| liveness       | String             | Indicates liveness of tokens that are created. Values are “main” o“test”.                                   |
-| description    | String             | A brief and informative depiction that captures the characteristics of a token                              |
-| type           | String             | An [Asset Type](/api/asset-types) reference.                                                                                |
-| issuer         | String             | The identifier for the issuer of the token                                                                  |
 
 ## Operations
 ### Create Token Collection **EXPERIMENTAL**

--- a/legacy/src/api/assets/tokens.md
+++ b/legacy/src/api/assets/tokens.md
@@ -12,10 +12,11 @@ permalink: /api/tokens
 Tokens are assets which can be spent only once. They are usually tied to a
 small set of merchants and have an expiry date.
 
-Tokens belong to a collection. A collection defines the redemption rules and
-branding for all tokens under the collection.
+Every token is associated with a collection, which sets the guidelines for redeeming the tokens and establishes their unique branding.
 
-Token value may be set in multiple currencies and is the same for all tokens in the same collection.
+A redemption condition outlines the specific details regarding the products that can be exchanged in return for the tokens. It provides information on the eligible items that can be redeemed.
+
+
 
 ## Contents
 {:.no_toc .text-delta}
@@ -36,9 +37,16 @@ Token value may be set in multiple currencies and is the same for all tokens in 
 | tokenExpiresAfter | [TokenExpiresAfter](#tokenexpiresafter) | The active duration of all tokens created from this collection.                     |
 | type              | String                                  | The type of value exchanged when redeeming tokens, can be `product`                 |
 | maxValue          | {% dt Monetary %} {% opt %}             | The maximum agreed value that any merchants will be settled for a token redemption. |
+| id                | String                                  | The token collection id                                                             |
+| test              | Boolean                                 | `true` if the token collection is for testing purposes only.                        |
+| status            | String                                  | The status of the token collection. Valid values include 'active'.                  |
+| createdBy         | {% dt CRN %}                            | The identity that created the activity.                                             |
+| createdAt         | {% dt Timestamp %}                      | Timestamp at which the token collection was created.                                |
 
 ### TokenExpiresAfter
 <a name="tokenExpiresAfter">
+
+TokenExpiresAfter is the active duration of all tokens created from a collection.
 
 |  Field   |  Type  |                          Description                           |
 | :------- | :----- | :------------------------------------------------------------- |
@@ -48,14 +56,19 @@ Token value may be set in multiple currencies and is the same for all tokens in 
 ### Redemption Condition
 {% h4 Fields %}
 
-|      Field      |                     Type                      |                             Description                              |
-| :-------------- | :-------------------------------------------- | :------------------------------------------------------------------- |
-| merchantId      | String                                        | The identifier of the merchant that is accepting the collection.     |
-| allowedProducts | [AllowedProducts](#allowedproducts) {% opt %} | List of allowed products, required for collections of type `product` |
-
+|      Field      |                     Type                      |                                                 Description                                                 |
+| :-------------- | :-------------------------------------------- | :---------------------------------------------------------------------------------------------------------- |
+| merchantId      | String                                        | The identifier of the merchant that is accepting the collection.                                            |
+| allowedProducts | [AllowedProducts](#allowedproducts) {% opt %} | List of allowed products, required for collections of type `product`                                        |
+| id              | String                                        | The redemption condition id                                                                                 |
+| collectionId    | String                                        | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
+| createdBy       | {% dt CRN %}                                  | The identity that created the activity.                                                                     |
+| createdAt       | {% dt Timestamp %}                            | Timestamp at which the redemption condition was created.                                                    |
 
 ### AllowedProducts
 <a name="allowedProducts">
+
+AllowedProducts include a list of products that can be redeemed for.
 
 |  Field   |       Type        |                       Description                       |
 | :------- | :---------------- | :------------------------------------------------------ |
@@ -66,10 +79,21 @@ Token value may be set in multiple currencies and is the same for all tokens in 
 ### Token
 {% h4 Fields %}
 
-|     Field      |  Type  |                                                 Description                                                 |
-| :------------- | :----- | :---------------------------------------------------------------------------------------------------------- |
-| collectionId   | String | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
-| idempotencyKey | String | Client-supplied identifier that prevents double creation.                                                   |
+|     Field      |        Type        |                                                 Description                                                 |
+| :------------- | :----------------- | :---------------------------------------------------------------------------------------------------------- |
+| collectionId   | String             | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
+| idempotencyKey | String             | Client-supplied identifier that prevents double creation.                                                   |
+| id             | String             | The token id                                                                                                |
+| accountId      | String             | The account that owns the collection.                                                                       |
+| collectionId   | String             | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
+| createdBy      | {% dt CRN %}       | The identity that created the activity.                                                                     |
+| createdAt      | {% dt Timestamp %} | Timestamp at which the token was created.                                                                   |
+| category       | String             | Asset category ("money", "giftcard", "token").                                                              |
+| status         | String             | The status of the token.                                                                                    |
+| liveness       | String             | Indicates liveness of tokens that are created. Values are “main” o“test”.                                   |
+| description    | String             | A brief and informative depiction that captures the characteristics of a token                              |
+| type           | String             | An [Asset Type](/api/asset-types) reference.                                                                                |
+| issuer         | String             | The identifier for the issuer of the token                                                                  |
 
 ## Operations
 ### Create Token Collection **EXPERIMENTAL**
@@ -189,6 +213,13 @@ Token value may be set in multiple currencies and is the same for all tokens in 
     "idempotencyKey": "payment-de32dd90-b46c-11ea-93c3-83a333b86e7b"
   })
 {% endreqspec %}
+
+{% h4 Fields %}
+
+|     Field      |        Type        |                                                 Description                                                 |
+| :------------- | :----------------- | :---------------------------------------------------------------------------------------------------------- |
+| collectionId   | String             | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
+| idempotencyKey | String             | Client-supplied identifier that prevents double creation.                                                   |
 
 {% h4 Example response payload %}
 

--- a/legacy/src/api/assets/tokens.md
+++ b/legacy/src/api/assets/tokens.md
@@ -40,10 +40,10 @@ Token value may be set in multiple currencies and is the same for all tokens in 
 ### TokenExpiresAfter
 <a name="tokenExpiresAfter">
 
-|  Field   |  Type  |                        Description                        |
-| :------- | :----- | :-------------------------------------------------------- |
-| period   | String | Supported values are `hour`, `day`, `week`, and `month` . |
-| duration | String | Number of `period` until token expiration.                |
+|  Field   |  Type  |                          Description                           |
+| :------- | :----- | :------------------------------------------------------------- |
+| period   | String | Supported values are `hour`, `day`, `week`,`month` and `year`. |
+| duration | String | Number of `period` until token expiration.                     |
 
 ### Redemption Condition
 {% h4 Fields %}

--- a/legacy/src/api/assets/tokens.md
+++ b/legacy/src/api/assets/tokens.md
@@ -80,7 +80,7 @@ Token value may be set in multiple currencies and is the same for all tokens in 
     "name": "Bread",
 		"accountId": "T3y6hogYA4d612BExypWYH",
 		"tokenExpiresAfter": {
-			"period": "months",
+			"period": "month",
 			"duration": "1"
 		},
 		"maxValue": {
@@ -105,7 +105,7 @@ Token value may be set in multiple currencies and is the same for all tokens in 
 
 |     Field      |  Type  |                                      Description                                       |
 | :------------- | :----- | :------------------------------------------------------------------------------------- |
-| period | String | The unit of time to measure the duration until token expiration. It can be `hours`, `days`, `weeks`, and `months` .|
+| period | String | The unit of time to measure the duration until token expiration. It can be `hour`, `day`, `week`, and `month` .|
 | duration | String | The length of time for the token to remain valid before expiration. |
 
 {% h4 Example response payload %}
@@ -116,7 +116,7 @@ Token value may be set in multiple currencies and is the same for all tokens in 
 	"accountId": "T3y6hogYA4d612BExypWYH",
 	"img": "https://static.centrapay.com/assets/media-uploads/{mediaUploadId}.png",
   "tokenExpiresAfter": {
-    "period": "months",
+    "period": "month",
     "duration": "1",
   },
   "maxValue": {

--- a/legacy/src/api/assets/tokens.md
+++ b/legacy/src/api/assets/tokens.md
@@ -100,7 +100,6 @@ Token value may be set in multiple currencies and is the same for all tokens in 
 | tokenExpiresAfter   | String | The active duration of all tokens created from this collection. |
 | type | String | Supported values: <br> - `product`: tokens for this collection will be exchanged for one product. |
 | maxValue | {% dt Monetary %} {% opt %} | The maximum agreed value that any merchants will be settled for a token redemption. |
-| mediaUploadId | String {% opt %} | The id of the media upload image used for all tokens that are created from this collection. |
 
 {% h4 TokenExpiresAfter %}
 

--- a/legacy/src/api/auth.md
+++ b/legacy/src/api/auth.md
@@ -152,6 +152,7 @@ if there is a flag associated to it then at least one of them must be met.
 | {% break : business:update %}                    |       ✅      |               |                   |                         |         |
 | {% break : business:read %}                      |       ✅      |               |                   |                         |         |
 | {% break : collections:create 🪙 %}              |       ✅      |               |                   |                         |         |
+| {% break : collections:list 🪙 %}                |       ✅      |               |                   |                         |         |
 | {% break : external-assets:create 👤 🧀 %}       |       ✅      |               |                   |            ✅           |         |
 | {% break : external-assets:update %}             |       ✅      |               |                   |            ✅           |         |
 | {% break : integration-requests:configure %}     |               |               |                   |                         |         |

--- a/legacy/src/api/auth.md
+++ b/legacy/src/api/auth.md
@@ -152,7 +152,7 @@ if there is a flag associated to it then at least one of them must be met.
 | {% break : business:update %}                    |       ✅      |               |                   |                         |         |
 | {% break : business:read %}                      |       ✅      |               |                   |                         |         |
 | {% break : collections:create 🪙 %}              |       ✅      |               |                   |                         |         |
-| {% break : collections:list 🪙 %}                |       ✅      |               |                   |                         |         |
+| {% break : collections:read 🪙 %}                |       ✅      |               |                   |                         |         |
 | {% break : external-assets:create 👤 🧀 %}       |       ✅      |               |                   |            ✅           |         |
 | {% break : external-assets:update %}             |       ✅      |               |                   |            ✅           |         |
 | {% break : integration-requests:configure %}     |               |               |                   |                         |         |
@@ -184,6 +184,7 @@ if there is a flag associated to it then at least one of them must be met.
 | {% break : quotas:read %}                        |       ✅      |               |                   |                         |         |
 | {% break : redemption-conditions:create 🪙 %}    |       ✅      |               |                   |                         |         |
 | {% break : scanned-code:decode %}                |       ✅      |               |         ✅        |                         |    ✅   |
+| {% break : tokens:create 🪙 %}                   |       ✅      |               |                   |                         |         |
 | {% break : topups:create 👤 %}                   |       ✅      |               |                   |                         |         |
 | {% break : topups:read %}                        |       ✅      |               |                   |                         |         |
 | {% break : wallets:create %}                     |       ✅      |               |                   |                         |         |

--- a/legacy/src/api/auth.md
+++ b/legacy/src/api/auth.md
@@ -126,6 +126,7 @@ if there is a flag associated to it then at least one of them must be met.
 | 👤      | A trusted user flag on the individual account, obtained by verifying a NZ phone number.          |
 | 🧀      | An external-asset-issuer subscription on the targeted Account, obtained by contacting centrapay. |
 | 🗄      | The targeted account must be of type org.                                                        |
+| 🪙      | A collection-manager subscription on the targeted Account, obtained by contacting centrapay. |
 
 ### Permissions
 
@@ -150,6 +151,7 @@ if there is a flag associated to it then at least one of them must be met.
 | {% break : business:create %}                    |       ✅      |               |                   |                         |         |
 | {% break : business:update %}                    |       ✅      |               |                   |                         |         |
 | {% break : business:read %}                      |       ✅      |               |                   |                         |         |
+| {% break : collections:create 🪙 %}              |       ✅      |               |                   |                         |         |
 | {% break : external-assets:create 👤 🧀 %}       |       ✅      |               |                   |            ✅           |         |
 | {% break : external-assets:update %}             |       ✅      |               |                   |            ✅           |         |
 | {% break : integration-requests:configure %}     |               |               |                   |                         |         |
@@ -179,6 +181,7 @@ if there is a flag associated to it then at least one of them must be met.
 | {% break : payment-requests:confirm 🗄 %}        |       ✅      |               |         ✅        |                         |    ✅   |
 | {% break : quotas:read %}                        |       ✅      |               |                   |                         |         |
 | {% break : quotas:read %}                        |       ✅      |               |                   |                         |         |
+| {% break : redemption-conditions:create 🪙 %}    |       ✅      |               |                   |                         |         |
 | {% break : scanned-code:decode %}                |       ✅      |               |         ✅        |                         |    ✅   |
 | {% break : topups:create 👤 %}                   |       ✅      |               |                   |                         |         |
 | {% break : topups:read %}                        |       ✅      |               |                   |                         |         |


### PR DESCRIPTION

To help potential digital asset issuer to get set up quickly so that they can better manage collections and tokens on the Centrapay system, the API reference section of Centrapay doc needs to be updated.

**Changes made in this PR:**
- Add `create token collection` endpoint
- Add `create redemption condition` endpoint
- Add a new symbol for `collection-manager` subscription