### PR TITLE
Add pagintation to List Token Collections endpoint

### DIFF
--- a/legacy/src/api/assets/assets.md
+++ b/legacy/src/api/assets/assets.md
@@ -116,7 +116,7 @@ Tokens have the following fields along with the base asset fields.
 
 |     Field      |             Type             |                                                 Description                                                 |
 | :------------- | :--------------------------- | :---------------------------------------------------------------------------------------------------------- |
-| collectionId   | String                       | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
+| collectionId   | String                       | The [token collection][] that will govern the branding and redemption rules for the token. |
 | createdBy      | {% dt CRN %}                 | The identity that created the activity.                                                                     |
 | value          | Array {% opt %}              | The [Monetary Amounts][] representing the token's nominal value in its supported currencies. **DEPRECATED** |
 | activeFrom     | {% dt Timestamp %} {% opt %} | The date when the asset becomes spendable.                                                                  |
@@ -355,3 +355,4 @@ Archive supported asset types by asset id. Currently only gift cards may be arch
 [Asset Transfers]: {% link api/assets/asset-transfers.md %}
 [paginated]: {% link api/pagination.md %}
 [Settlements]: {% link api/assets/wallets.md %}#settlement-wallets
+[token collection]: {% link api/assets/tokens.md %}#token-collection

--- a/legacy/src/api/assets/tokens.md
+++ b/legacy/src/api/assets/tokens.md
@@ -23,8 +23,9 @@ A redemption condition is created for each merchant that accepts tokens from a c
 
 ## Models
 
-### Token Collection **EXPERIMENTAL**
 <a name="token-collection">
+### Token Collection **EXPERIMENTAL**
+
 {% h4 Fields %}
 
 |       Field       |                   Type                    |                                     Description                                     |
@@ -114,11 +115,20 @@ A redemption condition is created for each merchant that accepts tokens from a c
 
 ### List Token Collections for Account **EXPERIMENTAL**
 
+Returns a [paginated][] list of token collections for an account.
+
 {% reqspec %}
   GET '/api/accounts/{accountId}/collections'
   auth 'api-key'
   path_param 'accountId', 'T3y6hogYA4d612BExypWYH'
+	query_param 'pageKey', 'Collection#2G5bXm4dnuDHnnKY8WeCPm|#Collection|8vq4kn03o0g1grrihk7ooloizpqt2y'
 {% endreqspec %}
+
+{% h4 Fields %}
+
+|  Field  |       Type       |               Description                |
+| ------- | ---------------- | ---------------------------------------- |
+| pageKey | String {% opt %} | Used to retrieve the next page of items. |
 
 {% h4 Example response payload %}
 
@@ -230,3 +240,5 @@ A redemption condition is created for each merchant that accepts tokens from a c
 | :----- | :-------------------- | :----------------------------------------------------------------------- |
 | 403    | TOKEN_ALREADY_CREATED | Token with supplied parameters already exists.                           |
 | 403    | LIVENESS_MISMATCH     | The account is test and the collection's liveness is main or vice versa. |
+
+[paginated]: {% link api/pagination.md %}

--- a/legacy/src/api/pagination.md
+++ b/legacy/src/api/pagination.md
@@ -33,6 +33,19 @@ bring support to GET endpoints for listing, these conventions will be followed.
 
 ### Example
 
+A GET endpoint for listing with a `pageKey`
+{% reqspec %}
+  GET '/api/examples'
+  auth 'api-key'
+  query_param 'pageKey', 'Example#E9eXsErwA444qFDoZt5iLA|Activity#000000000000001|614161c4c4d3020073bd4ce8'
+{% endreqspec %}
+
+{% h4 Fields %}
+
+|  Field  |       Type       |               Description                |
+| ------- | ---------------- | ---------------------------------------- |
+| pageKey | String {% opt %} | Used to retrieve the next page of items. |
+
 A page with more content
 
 {% json %}


### PR DESCRIPTION
As we have implemented pagination for the List Token Collections endpoint, this change should reflect in the Centrapay Public doc.

Changes made in this PR:
- Add `pageKey` as a query parameter for the curl in List Token Collections endpoint
- Fix the link to `token-collection` in `assets.md`
- Add a curl example in `pagination.md`