### PR TITLE
Add a note for pageKey to be URL-encoded

### DIFF
--- a/legacy/src/api/assets/tokens.md
+++ b/legacy/src/api/assets/tokens.md
@@ -130,6 +130,8 @@ Returns a [paginated][] list of token collections for an account.
 | ------- | ---------------- | ---------------------------------------- |
 | pageKey | String {% opt %} | Used to retrieve the next page of items. |
 
+Note: The `pageKey` value, if provided, needs to be URL-encoded.
+
 {% h4 Example response payload %}
 
 {% json %}

--- a/legacy/src/api/pagination.md
+++ b/legacy/src/api/pagination.md
@@ -14,6 +14,8 @@ usage and speed up page rendering.
 To retrieve the next page, a `pageKey` can be supplied. Typically this will be the `nextPageKey`
 returned from your previous query.
 
+Please note that when making a request, the values of `pageKey` must be URL-encoded. This ensures proper handling of special characters and encoding requirements.
+
 Some of our endpoints have been designed to be forwards compatible with pagination. When we do
 bring support to GET endpoints for listing, these conventions will be followed.
 

--- a/legacy/src/api/payment-requests/payment-requests.md
+++ b/legacy/src/api/payment-requests/payment-requests.md
@@ -1350,6 +1350,7 @@ descending activity created date.
 | --------- | ------ | ---------------------------------------- |
 | pageKey   | String | Used to retrieve the next page of items. |
 
+Note: The `pageKey` value, if provided, needs to be URL-encoded.
 
 {% h4 Example response payload %}
 {% json %}


### PR DESCRIPTION
Currently, when we execute the curl command with the query parameter `pageKey`, we encounter a 403 status error accompanied by the message `"INVALID_PAGE_KEY."` This issue arises due to the presence of special characters, such as `#` and `|`, within the `pageKey` value.  The problem primarily stems from the absence of proper URL encoding when passing the parameter. 
This pull request includes information regarding the necessity of URL encoding the `pageKey`. 
```
curl -G -v https://service.cp42.click/api/accounts/RstQWWgw3mbWUwNLrirhiY/collections \
  -H "X-Api-Key: $api_key" \
  -d "pageKey=Collection#NrGVyeHm2Mucmv4g34XAiz|#Collection|RstQWWgw3mbWUwNLrirhiY"
```
