### PR TITLE
Add externalId field and update example for create token

### DIFF
--- a/legacy/src/api/assets/assets.md
+++ b/legacy/src/api/assets/assets.md
@@ -114,17 +114,18 @@ Tokens have the following fields along with the base asset fields.
 
 {% h4 Fields %}
 
-|     Field      |             Type             |                                                 Description                                                 |
-| :------------- | :--------------------------- | :---------------------------------------------------------------------------------------------------------- |
-| collectionId   | String                       | The [token collection][] that will govern the branding and redemption rules for the token. |
-| createdBy      | {% dt CRN %}                 | The identity that created the activity.                                                                     |
-| value          | Array {% opt %}              | The [Monetary Amounts][] representing the token's nominal value in its supported currencies. **DEPRECATED** |
-| activeFrom     | {% dt Timestamp %} {% opt %} | The date when the asset becomes spendable.                                                                  |
-| expiresAt      | {% dt Timestamp %} {% opt %} | The date when the asset expires.                                                                            |
-| img            | String {% opt %}             | The img URL of the token.                                                                                   |
-| issuer         | String {% opt %}             | The identifier for the issuer of the token.                                                                 |
-| issuerWebsite  | String {% opt %}             | The URL of the issuer of the token.                                                                         |
-| issuerImg      | String {% opt %}             | The img URL of the issuer that the token belongs to.                                                        |
+|     Field     |             Type             |                                                 Description                                                 |
+| :------------ | :--------------------------- | :---------------------------------------------------------------------------------------------------------- |
+| collectionId  | String                       | The [token collection][] that will govern the branding and redemption rules for the token.                  |
+| createdBy     | {% dt CRN %}                 | The identity that created the activity.                                                                     |
+| value         | Array {% opt %}              | The [Monetary Amounts][] representing the token's nominal value in its supported currencies. **DEPRECATED** |
+| activeFrom    | {% dt Timestamp %} {% opt %} | The date when the asset becomes spendable.                                                                  |
+| expiresAt     | {% dt Timestamp %} {% opt %} | The date when the asset expires.                                                                            |
+| img           | String {% opt %}             | The img URL of the token.                                                                                   |
+| issuer        | String {% opt %}             | The identifier for the issuer of the token.                                                                 |
+| issuerWebsite | String {% opt %}             | The URL of the issuer of the token.                                                                         |
+| issuerImg     | String {% opt %}             | The img URL of the issuer that the token belongs to.                                                        |
+| externalId    | String {% opt %}             | The asset identifier from the issuing system.                                                               |
 
 ## Operations
 

--- a/legacy/src/api/assets/tokens.md
+++ b/legacy/src/api/assets/tokens.md
@@ -201,18 +201,30 @@ Note: The `pageKey` value, if provided, needs to be URL-encoded.
 {% reqspec %}
   POST '/api/tokens'
   auth 'api-key'
-  body ({
+	example {
+    title 'Create a token'
+		body ({
     "collectionId": "Jaim1Cu1Q55uooxSens6yk",
-    "idempotencyKey": "payment-de32dd90-b46c-11ea-93c3-83a333b86e7b"
-  })
+    "idempotencyKey": "payment-de32dd90-b46c-11ea-93c3-83a333b86e7b",
+  	})
+  }
+  example {
+    title 'Creae a token with externalId'
+    body ({
+    "collectionId": "Jaim1Cu1Q55uooxSens6yk",
+    "idempotencyKey": "payment-de32dd90-b46c-11ea-93c3-83a333b86e7b",
+		"externalId": "23403283262",
+  	})
+  }
 {% endreqspec %}
 
 {% h4 Fields %}
 
-|     Field      |        Type        |                                                 Description                                                 |
-| :------------- | :----------------- | :---------------------------------------------------------------------------------------------------------- |
-| collectionId   | String             | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
-| idempotencyKey | String             | Client-supplied identifier that prevents double creation.                                                   |
+|     Field      |       Type       |                                                 Description                                                 |
+| :------------- | :--------------- | :---------------------------------------------------------------------------------------------------------- |
+| collectionId   | String           | The [token collection](#token-collection) that will govern the branding and redemption rules for the token. |
+| idempotencyKey | String           | Client-supplied identifier that prevents double creation.                                                   |
+| externalId     | String {% opt %} | The asset identifier from the issuing system.                                                               |
 
 {% h4 Example response payload %}
 
@@ -233,7 +245,8 @@ Note: The `pageKey` value, if provided, needs to be URL-encoded.
 	"img": "https://static.centrapay.com/assets/brands/centraperk/cafe-token.png",
   "issuer": "Centraperk Cafe",
   "issuerWebsite": "www.centraperk-cafe.com",
-	"type": "centrapay.token.test"
+	"type": "centrapay.token.test",
+	"externalId": "23403283262",
 }
 {% endjson %}
 

--- a/legacy/src/api/assets/tokens.md
+++ b/legacy/src/api/assets/tokens.md
@@ -209,7 +209,7 @@ Note: The `pageKey` value, if provided, needs to be URL-encoded.
   	})
   }
   example {
-    title 'Creae a token with externalId'
+    title 'Create a token with externalId'
     body ({
     "collectionId": "Jaim1Cu1Q55uooxSens6yk",
     "idempotencyKey": "payment-de32dd90-b46c-11ea-93c3-83a333b86e7b",


### PR DESCRIPTION
We want to include `externalId` field to tokens so that asset issuers can add their own external references and map to key values in their systems.