### PR TITLE
docs: update merchant location description

### DIFF
--- a/legacy/src/api/merchants/merchants.md
+++ b/legacy/src/api/merchants/merchants.md
@@ -43,12 +43,12 @@ which define the payment methods available for a Payment Request.
 
 {% h4 Optional Fields %}
 
-|         Field          |                  Type                   |                                                                        Description                                                                         |
-| :--------------------- | :-------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| test                   | Boolean                                 | **EXPERIMENTAL** Flag indicating merchant is for testing.                                                                                                  |
-| settlementConfig       | [Settlement Config](#settlement-config) | **EXPERIMENTAL** Merchant settlement config.                                                                                                               |
-| location               | {% dt Location %}                       | **EXPERIMENTAL** Physical Location of Merchant.                                                                                                            |
-| onboardingStatusReason | String                                  | The reason associated with the [Onboarding Status](#onboarding-statuses). See [Onboarding Status Reasons](#onboarding-status-reasons) for possible values. |
+|         Field          |                  Type                   |                                                                                                                     Description                                                                                                                     |
+| :--------------------- | :-------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| test                   | Boolean                                 | **EXPERIMENTAL** Flag indicating merchant is for testing.                                                                                                                                                                                           |
+| settlementConfig       | [Settlement Config](#settlement-config) | **EXPERIMENTAL** Merchant settlement config.                                                                                                                                                                                                        |
+| location               | {% dt Location %}                       | **EXPERIMENTAL** Physical Location of Merchant. It is highly recommended that you provide this otherwise, users won't be able to find you with our [Merchant Search](#search-merchants-experimental) API if they perform a origin + distance query. |
+| onboardingStatusReason | String                                  | The reason associated with the [Onboarding Status](#onboarding-statuses). See [Onboarding Status Reasons](#onboarding-status-reasons) for possible values.                                                                                          |
 
 <a name="onboarding-statuses">
 {% h4 Onboarding Statuses %}


### PR DESCRIPTION
## Description

Updated the description of the location field on the merchant model recommending users to provide the location of the merchant when creating them, otherwise risk not appearing in the results when users search for merchants.


| Before | After |
|--------|--------|
| ![Screen Shot 2023-09-04 at 15 41 10](https://github.com/centrapay/centrapay-docs/assets/34535571/7415b4a9-259a-43df-9b16-753a7bb28633) | ![Screen Shot 2023-09-04 at 15 40 47](https://github.com/centrapay/centrapay-docs/assets/34535571/aba45c65-d289-47fb-8694-97417205890c) | 