### PR TITLE
Upgrade to Node 18

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -22,9 +22,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-v2
       - run: gem install bundler
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 18
       - run: yarn install --frozen-lock-file
       - run: ./build.sh http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com
       - name: Configure AWS Credentials

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,9 +21,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-v2
       - run: gem install bundler
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 18
       - run: yarn install --frozen-lock-file
       - run: yarn lint
       - run: yarn test

--- a/.github/workflows/pull-request-notification.yml
+++ b/.github/workflows/pull-request-notification.yml
@@ -16,9 +16,9 @@ jobs:
     if: github.event.action == 'opened'
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 18
       - run: |
           curl -X POST "${{ secrets.NEW_PR_SLACK_HOOK_URL }}" \
           --data "$(

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,9 +22,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gems-v2
       - run: gem install bundler
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: 18
       - run: yarn install --frozen-lock-file
       - run: yarn lint
       - run: yarn test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,12 @@ version: "3"
 
 services:
   app:
-    image: node:16
+    image: node:18-alpine
     init: true
     working_dir: /work
     volumes: [ ".:/work" ]
     command:
-      - bash
+      - sh
       - -c
       - yarn dev --host 0.0.0.0
     ports: [ "3000:3000", "24678:24678" ]
@@ -21,13 +21,13 @@ services:
     command: "bundle exec jekyll serve --livereload --host=0.0.0.0"
     ports: [ "4000:4000", "35729:35729" ]
   script:
-    image: node:16
+    image: node:18-alpine
     init: true
     working_dir: /work
     stop_signal: SIGKILL
     volumes: [ ".:/work" ]
     command:
-      - bash
+      - sh
       - -c
       - |
         echo "


### PR DESCRIPTION
Upgrade to Node 18 so that we can ultimately upgrade to Astro v3.0. See https://docs.astro.build/en/guides/upgrade-to/v3/#removed-support-for-node-16

Using the alpine image in our compose configuration keeps the image size small and downloads faster. Note that the alpine image does not have bash installed.

See our dev environment for a live preview - http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com

Test plan:
- Confirm that the local dev server runs
- Confirm that local static builds and previews render the site correctly
- Confirm the CI/CD pipelines work
- Confirm that page loads work