### PR TITLE
docs: update description of the "lat" and the "lng" fields

### DIFF
--- a/legacy/src/api/data-types.md
+++ b/legacy/src/api/data-types.md
@@ -67,13 +67,13 @@ by locality.
 
 {% h4 Optional Fields %}
 
-|   Name   |  Type  |                     Description                      |
-| -------- | ------ | ---------------------------------------------------- |
-| lat      | Number | Absolute latitude coordinate                         |
-| lng      | Number | Absolute longitude coordinate                        |
-| suburb   | String | Suburb of location                                   |
-| postCode | String | Post or Zip code of location                         |
-| state    | String | The state or region of the location (eg. "Auckland") |
+|   Name   |  Type  |                                                  Description                                                  |
+| -------- | ------ | ------------------------------------------------------------------------------------------------------------- |
+| lat      | Number | Absolute latitude coordinate. If you don't provide this, we will automatically infer this from your address.  |
+| lng      | Number | Absolute longitude coordinate. If you don't provide this, we will automatically infer this from your address. |
+| suburb   | String | Suburb of location                                                                                            |
+| postCode | String | Post or Zip code of location                                                                                  |
+| state    | String | The state or region of the location (eg. "Auckland")                                                          |
 
 
 ## PhoneNumber


### PR DESCRIPTION
## Description

Our `CreateMerchant` and `UpdateMerchant` endpoints now automatically infer the merchant's `lat` and `lng` information from their address if they don't provide it.

This PR updates the descriptions of these fields to make this explicit to the user.

| Before | After |
|--------|--------|
| ![Screen Shot 2023-09-12 at 15 27 32](https://github.com/centrapay/centrapay-docs/assets/34535571/07b4f190-b5ab-4209-9d89-cd1dc50ae3ed) | ![Screen Shot 2023-09-12 at 15 25 26](https://github.com/centrapay/centrapay-docs/assets/34535571/920dc060-df07-44d8-bb35-9797d670275b) |
