### PR TITLE
Remove the last Jekyll guide

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -43,5 +43,8 @@ export default defineConfig({
     plugins: [
       flexsearchPlugin(),
     ]
-  }
+  },
+  redirects: {
+    '/guides/merchant-terminals/': '/guides/payment-flows/',
+  },
 });

--- a/legacy/src/guides/merchant-terminals.md
+++ b/legacy/src/guides/merchant-terminals.md
@@ -1,4 +1,0 @@
----
-permalink: /guides/merchant-terminals
-redirect_to: /guides/payment-flows
----


### PR DESCRIPTION
Astro now supports redirects so we can move our existing redirect out of the Jekyll site and manage them with the Astro config instead.

[See our dev environment for a live preview here](http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/)

Test plan:
- Dev: Confirm https://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/guides/merchant-terminals redirects to https://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/guides/payment-flows/
- Prod: Confirm https://docs.centrapay.com/guides/merchant-terminals redirects to https://docs.centrapay.com/guides/payment-flows/