### PR TITLE
remove merchant:search permission from permissions list

### DIFF
--- a/legacy/src/api/auth.md
+++ b/legacy/src/api/auth.md
@@ -167,7 +167,6 @@ if there is a flag associated to it then at least one of them must be met.
 | {% break : merchants:list 🗄 %}                  |       ✅      |               |                   |                         |    ✅   |
 | {% break : merchants:read 🗄 %}                  |       ✅      |               |                   |                         |    ✅   |
 | {% break : merchants:update 🗄 %}                |       ✅      |               |                   |                         |         |
-| {% break : merchants:search %}                   |       ✅      |               |                   |                         |         |
 | {% break : patron-codes:create %}                |       ✅      |               |                   |                         |         |
 | {% break : patron-codes:read %}                  |       ✅      |               |         ✅        |                         |    ✅   |
 | {% break : payment-activities:read %}            |       ✅      |               |         ✅        |                         |    ✅   |

--- a/legacy/src/api/merchants/merchants.md
+++ b/legacy/src/api/merchants/merchants.md
@@ -296,6 +296,8 @@ Returns a [paginated][] list of Merchants attached to an Account.
 
 Returns a [paginated][] response of [merchant search results](#merchant-search-result) that match the search query
 
+This endpoint does not require [Auth][]
+
 {% reqspec %}
   GET '/api/merchants/search'
   auth 'api-key'
@@ -435,3 +437,4 @@ Returns a [paginated][] list of Merchants which belong to the authenticated subj
 [paginated]: {% link api/pagination.md %}
 [Account]: {% link api/accounts/accounts.md %}
 [AssetType]: {% link api/assets/asset-types.md %}
+[Auth]: {% link api/auth.md %}


### PR DESCRIPTION
The merchant:search permission is being removed. This updates the docs to reflect that