### PR TITLE
Draft page

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: 18
       - run: yarn install --frozen-lock-file
-      - run: ./build.sh http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com
+      - run: ./build.sh
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,7 @@ jobs:
       - run: yarn install --frozen-lock-file
       - run: yarn lint
       - run: yarn test
-      - run: ./build.sh
+      - run: ./build.sh --prod
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.JEKYLL_PAT }}

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,17 @@
 
 set -euo pipefail
 
-url="${1:-}"
+mode="development"
+
+while [ $# -gt 0 ]; do
+  case $1 in
+    --prod)
+      shift
+      mode="production"
+    ;;
+  esac
+  shift
+done
 
 cd legacy
 
@@ -11,8 +21,8 @@ bundle exec jekyll build
 
 cd ../
 
-if [[ -n "$url" ]]; then
-  yarn build --site "$url"
+if [ "$mode" == "development" ]; then
+  yarn build --mode "$mode" --site "http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com"
 else
   yarn build
 fi

--- a/src/content/api/introduction.mdx
+++ b/src/content/api/introduction.mdx
@@ -1,0 +1,20 @@
+---
+title: API Introduction
+description: Introduction to the API Reference
+nav:
+  path: API/Getting Started
+  order: 1
+---
+
+The Centrapay API is an [RMM](https://en.wikipedia.org/wiki/Richardson_Maturity_Model)
+level 2 RESTful web service which expresses operations in terms of HTTP verbs on
+resource-oriented URLs. API endpoint definitions in these docs are grouped by resource
+type along with definitions for the associated resource types.
+
+Most API calls require [authentication](https://docs.centrapay.com/api/auth) using an API key or
+JWT. HTTP requests and responses usually have JSON payloads and use
+"application/json" as the content type.
+
+Some API features may be flagged as **EXPERIMENTAL**. These API features may be
+removed or changed without warning and should not be relied on in a production
+setting.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,10 +1,11 @@
 import { z, defineCollection } from 'astro:content';
 
-const guidesCollection = defineCollection({
+const collection = defineCollection({
   schema: z.object({
     title: z.string(),
     description: z.string(),
     img: z.string().optional(),
+    draft: z.boolean().optional().default(false),
     nav: z.object({
       title: z.string().optional(),
       path: z.string(),
@@ -14,6 +15,7 @@ const guidesCollection = defineCollection({
 });
 
 export const collections = {
-  'guides': guidesCollection,
-  'connections': guidesCollection,
+  'guides': collection,
+  'connections': collection,
+  'api': collection
 };

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,7 +4,7 @@ import MessagesBubbleDouble from '../components/icons/MessagesBubbleDouble.vue';
 import Footer from '../components/Footer.vue';
 import '../assets/css/tailwind.css';
 import '@fontsource/inter';
-import { getCollection } from 'astro:content';
+import { getCollection } from '../utils/getCollection';
 import Navigation from '../navigation/Navigation';
 import sideNavConfig from '../navigation/sideNavConfig'
 
@@ -26,6 +26,7 @@ const metaTitle = title ? title + ' - Centrapay Docs' : 'Centrapay Docs';
 const content = await Promise.all([
   ...await getCollection('guides'),
   ...await getCollection('connections'),
+  ...await getCollection('api')
 ])
 const navigation = Navigation.create({ nav: sideNavConfig, content });
 ---

--- a/src/navigation/sideNavConfig.js
+++ b/src/navigation/sideNavConfig.js
@@ -18,4 +18,12 @@ export default [
       { title: 'Farmlands' },
     ]
   },
+  import.meta.env.MODE === 'development' && {
+    title: 'API',
+    subTitle: 'For developers',
+    icon: 'Settings',
+    children: [
+      { title: 'Getting Started' },
+    ]
+  },
 ];

--- a/src/pages/api/[...slug].astro
+++ b/src/pages/api/[...slug].astro
@@ -6,8 +6,8 @@ import BaseLayout from '../../layouts/BaseLayout.astro';
 import customComponents from '../../utils/customComponents';
 
 export async function getStaticPaths() {
-  const guides = await getCollection('guides');
-  return guides.map(entry => ({
+  const api = await getCollection('api');
+  return api.map(entry => ({
     params: { slug: entry.slug },
     props: { entry },
   }));
@@ -15,25 +15,13 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const { Content, headings } = await entry.render();
-const coverImage = entry.data.img || '/default-cover.svg';
-const previewImg = entry.data.img || '/default-cover.jpg';
 const { title, description } = entry.data;
 ---
-<BaseLayout title={title} description={description} img={previewImg}>
-  <div class="flex items-center max-h-72 overflow-hidden">
-    <img
-      src={coverImage}
-      aria-hidden="true"
-      class="object-cover m-0 w-full h-24 md:h-full"
-    >
-  </div>
+<BaseLayout title={title} description={description}>
   <div class="relative mx-auto desktop-gutters flex justify-center">
     <div class="min-w-0 max-w-2xl flex-auto px-8 pb-16 pt-8 xl:pt-16 lg:max-w-none">
       <article>
         <header class="mb-9 space-y-1" >
-          <p class="type-overline text-content-primary" >
-            Guides
-          </p>
           <h1
             class="font-display text-3xl tracking-tight text-slate-900"
           >

--- a/src/pages/connections/[...slug].astro
+++ b/src/pages/connections/[...slug].astro
@@ -1,5 +1,5 @@
 ---
-import { getCollection } from 'astro:content';
+import { getCollection } from '../../utils/getCollection';
 import customComponents from '../../utils/customComponents';
 
 export async function getStaticPaths() {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,7 +2,7 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import FeaturedGuideCard from '../components/FeaturedGuideCard.astro';
 import FeaturedContentCard from '../components/FeaturedContentCard.astro';
-import { getCollection } from 'astro:content';
+import { getCollection } from '../utils/getCollection';
 import Prose from '../components/Prose.vue';
 
 export async function getStaticPaths() {

--- a/src/utils/getCollection.js
+++ b/src/utils/getCollection.js
@@ -1,0 +1,7 @@
+import { getCollection as get } from 'astro:content';
+
+export async function getCollection(collection) {
+  return await get(collection, ({ data }) => {
+    return import.meta.env.MODE !== 'production' || !data.draft;
+  });
+}


### PR DESCRIPTION
Created a wrapper function for getCollection which does not return any draft pages when in production. This allows us to incrementally migrate the legacy API reference.

**Ticket:** https://www.notion.so/centrapay/Create-a-draft-Astro-page-b39e82f4a15a41ef8b34c41fa45d54d3?pvs=4

**Test Plan:**
- [ ] Navigate to docs.centrapay.com/guides/draft - This should route you to the legacy Jekyll 404 page
- [ ] Assert that the http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/guides/draft is visible and does not redirect to 404 page

**The draft page shows up in DEV mode**
![image](https://github.com/centrapay/centrapay-docs/assets/70119888/3c411c76-6199-43b7-b4e1-329ecb487882)


