### PR TITLE
[⏰ 10% time] 🧹 Tidy `mailto:` links

### DIFF
--- a/src/content/guides/farmlands-card-partner-support.mdx
+++ b/src/content/guides/farmlands-card-partner-support.mdx
@@ -16,7 +16,7 @@ If you are a Farmlands Card Partner needing extra support this is the guide for 
 
 1. If you require assistance with Portal functionality, contact Centrapay at support@centrapay.com or Farmlands at card.specialist@farmlands.co.nz
 You can also use the Support window inside the Portal.
-2. If you are needing to add a new branch/location please contact your Card Portfolio manager or Card.Specialist@farmlands.co.nz as Farmlands will need to complete the setup of the branch/location within our system prior to this being enabled in the Portal.
+2. If you are needing to add a new branch/location please contact your Card Portfolio manager or card.specialist@farmlands.co.nz as Farmlands will need to complete the setup of the branch/location within our system prior to this being enabled in the Portal.
 
 ### Trouble Shooting
 

--- a/src/content/guides/farmlands-portal.mdx
+++ b/src/content/guides/farmlands-portal.mdx
@@ -104,7 +104,7 @@ The Centrapay Business Portal provides a real-time authorisation of a Farmlands 
 
 ### **Invoicing & Settlement**
 
-Once an approved authorisation has been provided, a full GST invoice must be submitted to Farmlands at vendor.invoices@farmlands,co.nz. The Short Code shown on the Approval screen must be copied and clearly displayed in the PO field of the invoice or where previously confirmed with the Farmlands Team. The Farmlands 9-digit Card number can be provided in addition to the Short Code in another field. Settlement will be completed as per agreed payment terms.
+Once an approved authorisation has been provided, a full GST invoice must be submitted to Farmlands at vendor.invoices@farmlands.co.nz. The Short Code shown on the Approval screen must be copied and clearly displayed in the PO field of the invoice or where previously confirmed with the Farmlands Team. The Farmlands 9-digit Card number can be provided in addition to the Short Code in another field. Settlement will be completed as per agreed payment terms.
 
 ![Payment Authorization approved on the Centrapay business portal](/farmlands-payment-authorisation-approved.png)
 

--- a/src/content/guides/farmlands-portal.mdx
+++ b/src/content/guides/farmlands-portal.mdx
@@ -177,7 +177,7 @@ If the the Account Owner want their business to be able to accept different Cent
 
 This area relates to the management of new and existing Branches/Locations used for Centrapay’s other payment types e.g gift cards (i.e not Farmlands). Additional merchants added through the Merchants area will not be able to accept Farmlands Card until they are setup by Farmlands.
 
-If you are needing to add a new branch/location, please contact your Card Portfolio Manager or Card.Specialist@farmlands.co.nz as Farmlands will need to complete the setup of the branch/location within our system prior to this being enabled in the Portal.
+If you are needing to add a new branch/location, please contact your Card Portfolio Manager or card.specialist@farmlands.co.nz as Farmlands will need to complete the setup of the branch/location within our system prior to this being enabled in the Portal.
 
 ![Centrapay business portal merchants page](/centrapay-portal-merchants.png)
 
@@ -185,7 +185,7 @@ If you are needing to add a new branch/location, please contact your Card Portfo
 
 This function is only available to businesses who wish to use other Centrapay supported payment methods other than Farmlands Cards. (e.g. Gift Cards or NZD).
 
-Farmlands Card transactions are settled through the existing settlement methods. If you need to update you settlement details please contact your Card Portfolio Manager or Card.Specialist@farmlands.co.nz.
+Farmlands Card transactions are settled through the existing settlement methods. If you need to update you settlement details please contact your Card Portfolio Manager or card.specialist@farmlands.co.nz.
 
 ![Centrapay business portal bank accounts page](/centrapay-portal-bank-accounts.png)
 
@@ -339,4 +339,4 @@ On the Settings page, you can change your business information. Please note this
 
 The Support button opens up a form that will allow you to send a support request directly to Centrapay if you have any issues regarding the Centrapay Business Portal.
 
-Alternatively email [support@centrapay.com](mailto:support@centrapay.com) for issues regarding the portal. Please refer Cardholders to Farmlands if they have a query on a declined transaction, **0800 200 600** or [ask@farmlands.co.nz](mailto:ask@farmlands.co.nz)
+Alternatively email support@centrapay.com for issues regarding the portal. Please refer Cardholders to Farmlands if they have a query on a declined transaction, **0800 200 600** or ask@farmlands.co.nz.

--- a/src/content/guides/farmlands-pos-integration.mdx
+++ b/src/content/guides/farmlands-pos-integration.mdx
@@ -339,7 +339,7 @@ curl https://service.centrapay.com/api/account-memberships \
   -H "X-Api-Key: $api_key"
 ```
 
-> Contact [integrations@centrapay.com](mailto:integrations@centrapay.com) to be issued with your API keys.
+> Contact integrations@centrapay.com to be issued with your API keys.
 
 ### Basic Requirements
 
@@ -990,5 +990,5 @@ The Certification Process includes checking that Farmlands POS integrators are m
 
 ## Next Steps
 
-1. Processing Farmlands Card transactions through the Centrapay platform is only available to existing Farmlands Card Partners. Existing Card Partners who are interested in integrating with Centrapay should contact their Card Partnership Manager or the Card Specialist team at [card.specialist@farmlands.co.nz](mailto:card.specialist@farmlands.co.nz) to work through the onboarding process.
-2. Reach out to [integrations@centrapay.com](mailto:integrations@centrapay.com) to get your API keys and a copy of Centrapay’s Certification Process.
+1. Processing Farmlands Card transactions through the Centrapay platform is only available to existing Farmlands Card Partners. Existing Card Partners who are interested in integrating with Centrapay should contact their Card Partnership Manager or the Card Specialist team at card.specialist@farmlands.co.nz to work through the onboarding process.
+2. Reach out to integrations@centrapay.com to get your API keys and a copy of Centrapay’s Certification Process.

--- a/src/content/guides/loading-and-sending-assets.mdx
+++ b/src/content/guides/loading-and-sending-assets.mdx
@@ -12,7 +12,7 @@ nav:
 
 You can load Giftcards by calling our [External Assets](https://docs.centrapay.com/api/external-assets) endpoint. You will need to use the giftcard number for the `externalId` field. The `pin`, the `issuer` and the `type` need to be on hand too.
 
-If your asset type is not included on the list, contact [integrations@centrapay.com](mailto:integrations@centrapay.com).
+If your asset type is not included on the list, contact integrations@centrapay.com.
 
 ## Sending Assets
 

--- a/src/content/guides/merchant-integration-error-handling.mdx
+++ b/src/content/guides/merchant-integration-error-handling.mdx
@@ -31,4 +31,4 @@ When faced with an unknown error while checking the status of a Payment Request,
 
 ## Resolving Persistent Errors
 
-For issues that cannot be resolved, please reach out to Centrapay Support at [integrations@centrapay.com](mailto:integrations@centrapay.com).
+For issues that cannot be resolved, please reach out to Centrapay Support at integrations@centrapay.com.

--- a/src/content/guides/point-of-sale.mdx
+++ b/src/content/guides/point-of-sale.mdx
@@ -33,6 +33,6 @@ Our payment protocol supports several optional extensions. Please review the ext
 
 ## Contact Us
 
-Contact [integrations@centrapay.com](mailto:integrations@centrapay.com) to get started with API keys.
+Contact integrations@centrapay.com to get started with API keys.
 
 Once you have confirmed your integration needs we will then provide you with a customized integration checklist for certification.

--- a/src/content/guides/third-party-application-payments.mdx
+++ b/src/content/guides/third-party-application-payments.mdx
@@ -20,7 +20,7 @@ minimize the risk of API keys being compromised.
 
 Separate API keys will be used for test and live payments.
 
-> Contact [integrations@centrapay.com](mailto:integrations@centrapay.com) to be issued your API keys.
+> Contact integrations@centrapay.com to be issued your API keys.
 
 ## Payment Flow Overview
 


### PR DESCRIPTION
TIL that you don't need to explicitly define the `mailto:` tag in Astro MDX files, it is automatically generated.

Changes:
* Fix invalid email address `vendor.invoices@farmlands,co.nz` ➡️ `vendor.invoices@farmlands.co.nz`.
* Make all instances of `card.specialist@farmlands.co.nz` consistent casing.
* Remove redundant `mailto:` tags.

[See our dev environment for a live preview here](http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/)

Test plan: Expect can still click emails and email will automatically open.