### PR TITLE
♻️ Migrate API Key Reference

### DIFF
--- a/src/components/TocNav.vue
+++ b/src/components/TocNav.vue
@@ -1,6 +1,6 @@
 <template>
   <nav
-    v-if="headings && headings.length"
+    v-if="visibleHeadings && visibleHeadings.length"
     aria-labelledby="on-this-page-title"
     class="w-56"
   >
@@ -12,7 +12,7 @@
     </h2>
     <ol class="mt-4 text-sm">
       <li
-        v-for="heading in headings"
+        v-for="heading in visibleHeadings"
         :key="heading.slug"
         :class="heading.depth === 3 ? 'pl-5' : ''"
       >
@@ -48,6 +48,7 @@ const props = defineProps({
 });
 
 const visibleHeadingId = ref('');
+const visibleHeadings = props.headings.filter(heading => heading.depth <= 3);
 let observer = null;
 
 onMounted(() => {

--- a/src/content/api/api-keys.mdx
+++ b/src/content/api/api-keys.mdx
@@ -1,0 +1,102 @@
+---
+title: API Keys
+description: Introduction to API Keys
+draft: true
+nav:
+  path: API
+  order: 6
+---
+
+API keys provide enduring access to a single Centrapay [Account](https://docs.centrapay.com/api/accounts).
+
+## Models
+
+### API Key
+
+#### Required Fields
+
+|   Field   |                  Type                  |                                                          Description                                                          |
+| :-------- | :------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| accountId | String                                 | The id of the Centrapay [Account](https://docs.centrapay.com/api/accounts) the API Key is scoped to.                          |
+| name      | String                                 | The alphanumeric name of the API key, must be unique within the account.                                                      |
+| role      | String                                 | Supported roles are: "account-owner" and "merchant-terminal". See [Auth Permissions](/api/auth#permissions) for role details. |
+| enabled   | Boolean                                | Flag indicating the API Key is usable for authentication.                                                                     |
+| createdAt | [Timestamp](/api/data-types#timestamp) | When the API Key was created.                                                                                                 |
+
+## Operations
+
+### Create an API Key
+
+```bash [Request]
+curl -X POST https://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk/api-keys \
+  -H "X-Api-Key: $api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "MyAPIkey",
+    "role": "merchant-terminal"
+  }'
+```
+
+```bash [Response]
+{
+  "name": "MyAPIkey",
+  "createdAt": "2020-06-01T22:32:56.631Z",
+  "enabled": true,
+  "role": "merchant-terminal",
+  "accountId": "Jaim1Cu1Q55uooxSens6yk",
+  "secret": "EoaEL7skkedBBy9MzrBSyxG95vUAKjYkiFvWEfiAx"
+}
+```
+
+### List API Keys
+
+```bash [Request]
+curl -X GET https://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk/api-keys \
+  -H "X-Api-Key: $api_key"
+```
+
+```bash [Response]
+[
+  {
+    "accountId": "Jaim1Cu1Q55uooxSens6yk",
+    "name": "MyOtherAPIkey",
+    "createdAt": "2020-06-01T21:57:25.888Z",
+    "enabled": false,
+    "role": "merchant-terminal"
+  },
+  {
+    "accountId": "Jaim1Cu1Q55uooxSens6yk",
+    "name": "MyAPIkey",
+    "createdAt": "2020-06-01T22:34:31.308Z",
+    "enabled": true,
+    "role": "merchant-terminal"
+  }
+]
+```
+
+### Update an API Key
+
+```bash [Request]
+curl -X PUT https://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk/api-keys/MyAPIkey \
+  -H "X-Api-Key: $api_key" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "enabled": false
+  }'
+```
+
+#### Required Fields
+
+| Field   | Type    | Description            |
+| :------ | :------ | :--------------------- |
+| enabled | Boolean | Enable/Disable API key |
+
+```bash [Response]
+{
+  "accountId": "Jaim1Cu1Q55uooxSens6yk",
+  "name": "MyAPIkey",
+  "createdAt": "2020-06-01T22:34:31.308Z",
+  "enabled": false,
+  "role": "merchant-terminal"
+}
+```


### PR DESCRIPTION
Change to migrate api keys reference guide to the new site. Currently using guide styling while awaiting UI input.

📖 Migrate API Reference Guides: https://www.notion.so/centrapay/Migrate-API-Reference-Guides-13d91fa1f0a443c7b1d5c64aa353151c?pvs=4

Test plan: 
* Expect to see in dev site draft mode.
* Expect table of contents in guides to appear unchanged.


<img width="1728" alt="image" src="https://github.com/centrapay/centrapay-docs/assets/64108933/58e3d7d9-dcd7-440c-a87a-3386081cf120">
