### PR TITLE
404 Page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,39 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+---
+
+<BaseLayout>
+  <div class="px-16 py-8 flex flex-col items-center space-y-6 h-full justify-center">
+    <div class="flex flex-col items-center space-y-2">
+      <p class="text-content-accent type-body-2 font-bold">
+        404
+      </p>
+      <h1 class="type-headline-2 text-gray-900">
+        Page not found
+      </h1>
+      <p class="type-body-2 text-content-tertiary text-center">
+        Sorry, we couldn’t find the page you’re looking for.
+      </p>
+    </div>
+    <div class="flex space-x-2 items-center">
+      <a href="/">
+        <div
+          class="btn bg-interactive-primary border rounded-md"
+        >
+          <span class="type-caption-2 text-content-inverse-primary">
+            Go back home
+          </span>
+        </div>
+      </a>
+      <button
+        id="freshdesk"
+        type="button"
+        class="btn bg-interactive-tertiary border rounded-md"
+      >
+        <span class="type-caption-2 text-content-tertiary">
+          Contact support
+        </span>
+      </button>
+    </div>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
404 Page as per the Figma design https://www.figma.com/file/IgRlQWJTyGoZhlF4fVKD6B/Centrapay-Docs-(Tailwind)?type=design&node-id=636-5747&mode=design&t=a1A4fYhOc8PuRO7Y-0

Reworded the text to match the [Tailwind UI Protocol](https://protocol.tailwindui.com/fedd)

**Test Plan:**
- [ ] Go to docs.centrapay.com/fjeirjerij and assert the 404 page appears
- [ ] Assert the Contact support button opens the support widget
- [ ] Assert the Go back home button routes to the homepage

<img width="1413" alt="image" src="https://github.com/centrapay/centrapay-docs/assets/70119888/b0b7e1fa-abee-4752-aa16-f772c108f887">
