### PR TITLE
🐞 Fix digital token headings

### DIFF
--- a/src/content/guides/creating-digital-tokens.mdx
+++ b/src/content/guides/creating-digital-tokens.mdx
@@ -9,7 +9,7 @@ nav:
 Digital tokens are assets that can be exchanged for specific products or deals. Think a "Free coffee" coupon or a "50% off" voucher.
 Unlike assets such as gift cards or currency, tokens can only be spent in their entirety, all at once.
 
-### Token Collection
+## Token Collection
 
 A collection is a grouping of tokens that share the same attributes and redemption conditions, e.g.
 
@@ -18,7 +18,7 @@ A collection is a grouping of tokens that share the same attributes and redempti
 - Expiry period
 - Maximum redemption value
 
-### Redemption Conditions
+## Redemption Conditions
 
 A redemption condition allows a [Merchant](https://docs.centrapay.com/api/merchants) to accept tokens from a token collection.
 It contains redemption details specific to that merchant, e.g. redeemable product SKUs.


### PR DESCRIPTION
The existing HTML was invalid as you cannot have H1 > H3.
See current invalid table of contents: https://docs.centrapay.com/guides/creating-digital-tokens/

Test plan: Expect to see H2 and table of contents to have linear nesting.