### PR TITLE
♻️ Make TOC line all one level

### DIFF
--- a/src/components/TocNav.vue
+++ b/src/components/TocNav.vue
@@ -10,25 +10,28 @@
     >
       On this page
     </h2>
-    <ol class="mt-4 text-sm">
+    <ol class="mt-4">
       <li
         v-for="heading in visibleHeadings"
         :key="heading.slug"
-        :class="heading.depth === 3 ? 'pl-5' : ''"
       >
         <a
           :href="`#${heading.slug}`"
+          class="flex border-l-2 text-sm p-squish-2 truncate hover:text-content-primary hover:border-content-primary"
+          :class="[
+            visibleHeadingId === heading.slug ?
+              'text-content-primary border-brand-accent':
+              'text-content-tertiary'
+          ]"
           @click="handleTocClick(heading.slug)"
         >
-          <h3
-            class="border-l-2 p-squish-2 hover:text-content-primary hover:border-content-primary"
-            :class="[
-              visibleHeadingId === heading.slug ? 'text-content-primary border-brand-accent': 'font-normal text-content-tertiary',
-              heading.depth === 3 ? 'pl-5' : ''
-            ]"
+          <span
+            :class="{
+              'pl-4': heading.depth === 3,
+            }"
           >
             {{ heading.text }}
-          </h3>
+          </span>
         </a>
       </li>
     </ol>


### PR DESCRIPTION
Make the line for the table of contents all on one level. 

Related thread for design review: https://centrapay.slack.com/archives/C04B93QUDSM/p1697156730162259a 
Story: https://www.notion.so/centrapay/Migrate-API-Documentation-c6d64de29a2245358a5e9b7eed5edbcc?pvs=4

Test plan: Expect to see the table of contents as per the screenshot.

<img width="220" alt="image" src="https://github.com/centrapay/centrapay-docs/assets/64108933/cf95a099-88d6-4a14-bc26-ca145ba97a6e">