### PR TITLE
Migrate asset types page

### DIFF
--- a/src/content/api/asset-types.mdx
+++ b/src/content/api/asset-types.mdx
@@ -1,0 +1,36 @@
+---
+title: Asset Types
+description: Asset types supported for payment
+draft: true
+nav:
+  path: API
+  order: 10
+---
+
+The following table describes the Asset Types supported for payments.
+
+The Category column refers to the Centrapay asset type representation if
+applicable. When blank, the Asset is not managed by a Centrapay Account.
+
+|   Asset Type    |                Description                |                          Category                                  |           Currencies          |    Flags    |
+| :---------------|:----------------------------------------- | :----------------------------------------------------------------- | :---------------------------- | :---------- |
+| bitcoin         | [Bitcoin](https://bitcoin.org/en/)        |                                                                    | `NZD` `AUD`                   | ⚡️          |
+| cca.coke        | Coke tokens                               | [Token](https://docs.centrapay.com/api/assets#tokens-experimental) | `NZD`                         | ⚡️ 🧪 🚫    |
+| centrapay.nzd   | Centrapay NZD wallet                      | [Money](https://docs.centrapay.com/api/assets#money)               | `NZD`                         | ⚡️ 🧪       |
+| centrapay.token | Centrapay tokens                          | [Token](https://docs.centrapay.com/api/assets#tokens-experimental) | `NZD`                         | ⚡️ 🧪       |
+| epay.nzd        | EPay NZ giftcards                         | [Giftcard](https://docs.centrapay.com/api/assets#gift-cards)       | `NZD`                         | ⚡️ 🧪       |
+| farmlands.nzd   | [Farmlands](https://www.farmlands.co.nz/) | [Money](https://docs.centrapay.com/api/assets#money)               | `NZD`                         | ⚡️ 🧪 💸 💼 |
+| paypal          | [PayPal](https://www.paypal.com/)         |                                                                    | `USD`                         | ⚡️ 🧪 💸    |
+| quartz.nzd      | Quartz NZD asset                          |                                                                    | `NZD`                         | ⚡️ 🧪       |
+| venmo           | [Venmo](https://venmo.com/)               |                                                                    | `USD`                         | ⚡️ 🧪 💸    |
+| uplinkapi       | Uplink API Test asset                     |                                                                    | `NZD`                         | 🧪       |
+| stadius         | [Stadius](https://stadius.io)             |                                                                    | `NZD` `AUD` `USD` `CAD` `EUR` | ⚡️ 🧪       |
+
+
+### Flags
+
+ * ⚡️ : **Supports Live Assets** -- Add `.main` to the Asset Type e.g. `centrapay.nzd.main`.
+ * 🧪 : **Supports Test Assets** -- Add `.test` to the Asset Type e.g. `centrapay.nzd.test`.
+ * 🚫 : **Restricted Asset** -- Cannot be used to pay for "restricted" [Line Items](https://docs.centrapay.com/api/payment-requests#line-item).
+ * 💸 : **Supports Quick Pay** -- Can be used to quick pay a [Payment Request](https://docs.centrapay.com/api/payment-requests).
+ * 💼 : **Requires Tax Number** -- [Tax Number](https://docs.centrapay.com/api/businesses#tax-number) must exist on the Merchant's Business to transact this asset type.


### PR DESCRIPTION
This PR migrates the asset types page.
I have also updated the table to remove the test assets and instead replaced with a flag on for assets that support test. LMK what you think.