### PR TITLE
🐛 Fix inline code styling

### DIFF
--- a/src/assets/css/components/code.css
+++ b/src/assets/css/components/code.css
@@ -1,0 +1,17 @@
+@layer components {
+
+  *:not(pre) > code {
+    @apply
+      rounded-md
+      bg-surface-secondary
+      border
+      border-outline-opaque
+      px-[3px]
+      py-[1px]
+      text-content-primary
+      text-sm
+      font-normal
+    ;
+  }
+
+}

--- a/src/assets/css/components/index.css
+++ b/src/assets/css/components/index.css
@@ -1,3 +1,4 @@
 @import "./buttons";
 @import "./cards";
+@import "./code.css";
 @import "./icons";


### PR DESCRIPTION
I had removed this styling as it was affecting code blocks. 
This was needed for inline code styling.
Change to add styling back and change styling to leave code blocks unaffected.