### PR TITLE
Document new multi-asset-payment mode

### DIFF
--- a/src/content/api/payment-requests.mdx
+++ b/src/content/api/payment-requests.mdx
@@ -608,7 +608,7 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
       Used to authorize an external transaction.
     </Property>
     <Property name="mode" type="string">
-      The mode of payment. Valid values: `partial-payment`.
+      The mode of payment. Valid values are `partial-payment` and `multi-asset-payment`.
     </Property>
     <Property name="amount" type="string">
       The value required to pay using the canonical units for the Asset Type.


### PR DESCRIPTION
This PR only documents that the multi-asset-payment mode exists. 
Documentation about how to use multi-asset-payment will come in a follow up PR.