### PR TITLE
Don't add attribute and error headings to search index

### DIFF
--- a/src/plugins/flexsearch.js
+++ b/src/plugins/flexsearch.js
@@ -56,6 +56,9 @@ async function createFlexsearchIndexData() {
     const vfile = await processor.process(content);
     // Add all other headings and their descriptions to the index
     vfile.data.sections.forEach(({ title, description }) => {
+      if([ 'Attributes', 'Errors' ].includes(title)) {
+        return;
+      }
       indexData[id++] = {
         path,
         title,


### PR DESCRIPTION
This PR makes it so the attributes and errors headings aren't added to the search index.

Testing:
* Deploy to dev
* Search for attributes assert that there are no attributes headings displayed
* Search for errors assert that there are no errors headings displayed