### PR TITLE
Nav order

### DIFF
--- a/src/content/api/account-memberships.mdx
+++ b/src/content/api/account-memberships.mdx
@@ -3,8 +3,8 @@ title: Account Memberships
 description: Account Memberships model and related endpoints
 draft: true
 nav:
-  path: API
-  order: 8
+  path: API/Accounts
+  order: 2
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/accounts.mdx
+++ b/src/content/api/accounts.mdx
@@ -3,8 +3,8 @@ title: Accounts
 description: Account model and related endpoints
 draft: true
 nav:
-  path: API
-  order: 7
+  path: API/Accounts
+  order: 1
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/asset-transfers.mdx
+++ b/src/content/api/asset-transfers.mdx
@@ -3,8 +3,8 @@ title: Asset Transfers
 description: Asset transfer lifecycle and related endpoints
 draft: true
 nav:
-  path: API
-  order: 11
+  path: API/Assets
+  order: 2
 ---
 
 import Badge from '../../components/Badge.astro';

--- a/src/content/api/asset-types.mdx
+++ b/src/content/api/asset-types.mdx
@@ -3,8 +3,8 @@ title: Asset Types
 description: Asset types supported for payment
 draft: true
 nav:
-  path: API
-  order: 12
+  path: API/Assets
+  order: 3
 ---
 
 The following table describes the Asset Types supported for payments.

--- a/src/content/api/assets.mdx
+++ b/src/content/api/assets.mdx
@@ -3,8 +3,8 @@ title: Assets
 description: Asset models and related endpoints
 draft: true
 nav:
-  path: API
-  order: 10
+  path: API/Assets
+  order: 1
 ---
 
 import Badge from '../../components/Badge.astro';

--- a/src/content/api/bank-account-approvals.mdx
+++ b/src/content/api/bank-account-approvals.mdx
@@ -3,8 +3,8 @@ title: Bank Account Approvals
 description: Bank Account Approval model and related endpoints
 draft: true
 nav:
-  path: API
-  order: 17
+  path: API/Bank Accounts
+  order: 2
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/bank-account-connection-intents.mdx
+++ b/src/content/api/bank-account-connection-intents.mdx
@@ -3,8 +3,8 @@ title: Bank Account Connection Intents
 description: Bank Account Connection Intent model and related endpoints
 draft: true
 nav:
-  path: API
-  order: 18
+  path: API/Bank Accounts
+  order: 3
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/bank-accounts.mdx
+++ b/src/content/api/bank-accounts.mdx
@@ -3,8 +3,8 @@ title: Bank Accounts
 description: Bank Account model and related endpoints
 draft: true
 nav:
-  path: API
-  order: 16
+  path: API/Bank Accounts
+  order: 1
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/batches.mdx
+++ b/src/content/api/batches.mdx
@@ -4,7 +4,7 @@ description: Batch model and related endpoints
 draft: true
 nav:
   path: API
-  order: 20
+  order: 10
 ---
 
 import Properties from '../../components/Properties.astro';

--- a/src/content/api/businesses.mdx
+++ b/src/content/api/businesses.mdx
@@ -3,8 +3,8 @@ title: Businesses
 description: Business model and related endpoints.
 draft: true
 nav:
-  path: API
-  order: 9
+  path: API/Accounts
+  order: 3
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/external-assets.mdx
+++ b/src/content/api/external-assets.mdx
@@ -3,8 +3,8 @@ title: External Assets
 description: External Assets endpoint documentation
 draft: true
 nav:
-  path: API
-  order: 13
+  path: API/Assets
+  order: 4
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/funds-transfers.mdx
+++ b/src/content/api/funds-transfers.mdx
@@ -3,8 +3,8 @@ title: Funds Transfers
 description: Endpoints for managing Funds Transfers
 draft: true
 nav:
-  path: API
-  order: 19
+  path: API/Bank Accounts
+  order: 4
 ---
 
 import Properties from '../../components/Properties.astro';

--- a/src/content/api/integration-requests.mdx
+++ b/src/content/api/integration-requests.mdx
@@ -3,8 +3,8 @@ title: Integration Requests
 description: Integration Request models and related endpoints
 draft: true
 nav:
-  path: API
-  order: 22
+  path: API/Integrations
+  order: 2
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/integrations.mdx
+++ b/src/content/api/integrations.mdx
@@ -3,8 +3,8 @@ title: Integrations
 description: Centrapay Integration documentation
 draft: true
 nav:
-  path: API
-  order: 21
+  path: API/Integrations
+  order: 1
 ---
 
 An Integration is a configured connection between a Centrapay Account and a third party. An Integration can be created as an [Integration Request](/api/integration-requests/), as a [Managed Integration](https://docs.centrapay.com/api/managed-integrations), or directly by Centrapay administrators.

--- a/src/content/api/invitations.mdx
+++ b/src/content/api/invitations.mdx
@@ -4,7 +4,7 @@ description: Invitation model and related endpoints
 draft: true
 nav:
   path: API
-  order: 24
+  order: 12
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/legacy-payment-requests.mdx
+++ b/src/content/api/legacy-payment-requests.mdx
@@ -3,8 +3,8 @@ title: Legacy Payment Requests
 description: Legacy Payment Request models and related endpoints (deprecated)
 draft: true
 nav:
-  path: API
-  order: 29
+  path: API/Payment Requests
+  order: 2
 ---
 
 import Properties from '../../components/Properties.astro';

--- a/src/content/api/managed-integrations.mdx
+++ b/src/content/api/managed-integrations.mdx
@@ -3,8 +3,8 @@ title: Managed Integrations
 description: Managed Integration model and related endpoints
 draft: true
 nav:
-  path: API
-  order: 23
+  path: API/Integrations
+  order: 3
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/media-uploads.mdx
+++ b/src/content/api/media-uploads.mdx
@@ -4,7 +4,7 @@ description: Media Uploads API Reference
 draft: true
 nav:
   path: API
-  order: 25
+  order: 13
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/merchant-configs.mdx
+++ b/src/content/api/merchant-configs.mdx
@@ -3,8 +3,8 @@ title: Merchant Configs
 description: Merchant Config model and related endpoints
 draft: true
 nav:
-  path: API
-  order: 27
+  path: API/Merchants
+  order: 2
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/merchants.mdx
+++ b/src/content/api/merchants.mdx
@@ -3,8 +3,8 @@ title: Merchants
 description: Merchant models and related endpoints
 draft: true
 nav:
-  path: API
-  order: 26
+  path: API/Merchants
+  order: 1
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/patron-codes.mdx
+++ b/src/content/api/patron-codes.mdx
@@ -3,8 +3,8 @@ title: Patron Codes
 description: Patron Code model and related endpoints
 draft: true
 nav:
-  path: API
-  order: 33
+  path: API/Scanned Codes
+  order: 2
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/payment-requests.mdx
+++ b/src/content/api/payment-requests.mdx
@@ -3,8 +3,8 @@ title: Payment Requests
 description: Payment request models and related endpoints
 draft: true
 nav:
-  path: API
-  order: 28
+  path: API/Payment Requests
+  order: 1
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/profiles.mdx
+++ b/src/content/api/profiles.mdx
@@ -4,7 +4,7 @@ description: Profile model and related endpoints
 draft: true
 nav:
   path: API
-  order: 30
+  order: 16
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/quotas.mdx
+++ b/src/content/api/quotas.mdx
@@ -4,7 +4,7 @@ description: Quota model and related endpoints
 draft: true
 nav:
   path: API
-  order: 31
+  order: 17
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/scanned-codes.mdx
+++ b/src/content/api/scanned-codes.mdx
@@ -3,8 +3,8 @@ title: Scanned Codes
 description: Scanned Code model and related endpoints
 draft: true
 nav:
-  path: API
-  order: 32
+  path: API/Scanned Codes
+  order: 1
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/settlements.mdx
+++ b/src/content/api/settlements.mdx
@@ -4,7 +4,7 @@ description: Settlement models and related endpointss
 draft: true
 nav:
   path: API
-  order: 34
+  order: 19
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/tokens.mdx
+++ b/src/content/api/tokens.mdx
@@ -3,8 +3,8 @@ title: Tokens
 description: Token models and related endpoints
 draft: true
 nav:
-  path: API
-  order: 14
+  path: API/Assets
+  order: 5
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/content/api/wallets.mdx
+++ b/src/content/api/wallets.mdx
@@ -3,8 +3,8 @@ title: Wallets
 description: Wallet models and related endpoints
 draft: true
 nav:
-  path: API
-  order: 15
+  path: API/Assets
+  order: 6
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';

--- a/src/navigation/Navigation.js
+++ b/src/navigation/Navigation.js
@@ -2,6 +2,7 @@ import Page from './Page';
 
 class NavGroup {
   constructor(props) {
+    this.order = props.order,
     this.title = props.title;
     this.subTitle = props.subTitle;
     this.children = props.children;
@@ -25,10 +26,11 @@ class NavGroup {
       subTitle: nav.subTitle,
       icon: nav.icon,
       href: nav.href,
+      order: nav.order || 0,
       children: [
         ...childPages,
         ...childNavGroups,
-      ],
+      ].sort((a, b) => a.order - b.order),
     });
   }
 }

--- a/src/navigation/__tests__/Navigation.test.js
+++ b/src/navigation/__tests__/Navigation.test.js
@@ -28,6 +28,7 @@ describe('Navigation', () => {
         items: [
           {
             title: 'API',
+            order: 0,
             children: [],
           },
         ],
@@ -56,6 +57,7 @@ describe('Navigation', () => {
         items: [
           {
             title: 'API',
+            order: 0,
             children: [
               expect.objectContaining({
                 nav: {
@@ -110,6 +112,7 @@ describe('Navigation', () => {
         items: [
           {
             title: 'API',
+            order: 0,
             children: [
               expect.objectContaining({
                 title: 'content 1',
@@ -121,6 +124,7 @@ describe('Navigation', () => {
           },
           {
             title: 'Reference',
+            order: 0,
             children: [
               expect.objectContaining({
                 title: 'content 2',
@@ -177,9 +181,11 @@ describe('Navigation', () => {
         items: [
           {
             title: 'API',
+            order: 0,
             children: [
               {
                 title: 'API Guide',
+                order: 0,
                 children: [
                   expect.objectContaining({
                     nav: {
@@ -190,6 +196,7 @@ describe('Navigation', () => {
               },
               {
                 title: 'API Integration',
+                order: 0,
                 children: [
                   expect.objectContaining({
                     nav: {
@@ -253,9 +260,11 @@ describe('Navigation', () => {
         items: [
           {
             title: 'API',
+            order: 0,
             children: [
               {
                 title: 'API Guide',
+                order: 0,
                 children: [
                   expect.objectContaining({
                     nav: {
@@ -266,6 +275,7 @@ describe('Navigation', () => {
               },
               {
                 title: 'API Integration',
+                order: 0,
                 children: [
                   expect.objectContaining({
                     nav: {
@@ -274,6 +284,7 @@ describe('Navigation', () => {
                   }),
                   {
                     title: 'Merchants',
+                    order: 0,
                     children: [
                       expect.objectContaining({
                         nav: {
@@ -321,9 +332,11 @@ describe('Navigation', () => {
         items: [
           {
             title: 'Reference',
+            order: 0,
             children: [
               {
                 title: 'Merchant Integrations',
+                order: 0,
                 children: [
                   expect.objectContaining({
                     nav: {
@@ -357,9 +370,119 @@ describe('Navigation', () => {
         items: [
           {
             title: 'API',
+            order: 0,
             href: 'https://www.example.com',
             icon: 'api-icon',
             children: [],
+          },
+        ],
+      });
+    });
+
+    test('Nav group ordering', () => {
+      expect(
+        Navigation.create({
+          nav: [
+            {
+              title: 'API',
+              children: [
+                {
+                  title: 'Guides',
+                  order: 3
+                },
+                {
+                  title: 'Integrations',
+                  order: 2
+                },
+              ],
+            },
+          ],
+          content: [
+            {
+              data: {
+                title: 'API 1',
+                nav: {
+                  path: 'API',
+                  order: 1
+                },
+              },
+            },
+            {
+              data: {
+                title: 'Guide 2',
+                nav: {
+                  path: 'API/Guides',
+                  order: 2
+                },
+              },
+            },
+            {
+              data: {
+                title: 'Guide 1',
+                nav: {
+                  path: 'API/Guides',
+                  order: 1
+                },
+              },
+            },
+            {
+              data: {
+                title: 'Integration 1',
+                nav: {
+                  path: 'API/Integrations',
+                  order: 1,
+                },
+              },
+            },
+          ],
+        })
+      ).toEqual({
+        items: [
+          {
+            title: 'API',
+            order: 0,
+            children: [
+              expect.objectContaining({
+                title: 'API 1',
+                nav: {
+                  path: 'API',
+                  order: 1,
+                },
+              }),
+              {
+                title: 'Integrations',
+                order: 2,
+                children: [
+                  expect.objectContaining({
+                    title: 'Integration 1',
+                    nav: {
+                      order: 1,
+                      path: 'API/Integrations',
+                    },
+                  }),
+                ],
+              },
+              {
+                title: 'Guides',
+                order: 3,
+                children: [
+                  expect.objectContaining({
+                    title: 'Guide 1',
+                    nav: {
+                      order: 1,
+                      path: 'API/Guides',
+                    },
+                  }),
+                  expect.objectContaining({
+                    title: 'Guide 2',
+                    nav: {
+                      order: 2,
+                      path: 'API/Guides',
+                    },
+                  }),
+                ],
+              },
+            ],
           },
         ],
       });

--- a/src/navigation/sideNavConfig.js
+++ b/src/navigation/sideNavConfig.js
@@ -25,6 +25,15 @@ if (import.meta.env.MODE === 'development') {
     title: 'API',
     subTitle: 'For developers',
     icon: 'Settings',
+    children: [
+      { title: 'Accounts', order: 7 },
+      { title: 'Assets', order: 8 },
+      { title: 'Bank Accounts', order: 9 },
+      { title: 'Integrations', order: 11 },
+      { title: 'Merchants', order: 14 },
+      { title: 'Payment Requests', order: 15 },
+      { title: 'Scanned Codes', order: 18 },
+    ]
   });
 }
 


### PR DESCRIPTION
**Ticket Link:** https://www.notion.so/centrapay/Lanterns-d784e8a5f9fa44328a5d0ae1fd85d37e?p=c6d64de29a2245358a5e9b7eed5edbcc&pm=s

**Test Plan:**
- [ ] Assert the nav is rendered correctly and pages/anchors are accessible by clicking the nav items.

**Notes:**
- Some legacy nav groups (e.g. Settlements) only had one page in them so these have been removed.
- I don't like how the nav order is determined by both the pages and the sideNavConfig. This works for now but I think it needs revisiting in the follow up epic.

**Legacy Nav:**

![image](https://github.com/centrapay/centrapay-docs/assets/70119888/00458f24-67bd-4561-aaae-52b61bbbfe47)


**New Nav:**

![image](https://github.com/centrapay/centrapay-docs/assets/70119888/819690a9-2db8-455c-9344-feac85050036)
