### PR TITLE
Add deprecated badge to properties that are deprecated

### DIFF
--- a/src/components/Property.astro
+++ b/src/components/Property.astro
@@ -2,7 +2,7 @@
 ---
 import Badge from '../components/Badge.astro';
 
-const { name, type, required, experimental, error } = Astro.props;
+const { name, type, required, experimental, deprecated } = Astro.props;
 const customDataTypes = ['timestamp', 'bignumber', 'monetary', 'crn', 'location', 'phonenumber'];
 const formattedType = type.toLowerCase();
 const link = customDataTypes.includes(formattedType) ? '/api/data-types#' + formattedType :undefined;
@@ -18,7 +18,7 @@ const link = customDataTypes.includes(formattedType) ? '/api/data-types#' + form
     </dd>
     <dt class="sr-only">Type</dt>
     <dd>
-      <Badge text={ error ? type : formattedType} link={link}>
+      <Badge text={formattedType} link={link}>
     </dd>
     { required &&
       <dt class="sr-only">Required</dt>
@@ -26,6 +26,9 @@ const link = customDataTypes.includes(formattedType) ? '/api/data-types#' + form
     { experimental &&
       <dt class="sr-only">Experimental</dt>
       <dd> <Badge type="experimental"> </dd> }
+    { deprecated &&
+      <dt class="sr-only">Deprecated</dt>
+      <dd> <Badge type="deprecated"> </dd> }
     <dt class="sr-only">
       Description
     </dt>


### PR DESCRIPTION
**Ticket Link:** https://www.notion.so/centrapay/Lanterns-d784e8a5f9fa44328a5d0ae1fd85d37e?p=c6d64de29a2245358a5e9b7eed5edbcc&pm=s

**Test Plan:**
- [ ] Assert appName property at https://docs.centrapay.com/api/patron-codes has the deprecated badge as below


![image](https://github.com/centrapay/centrapay-docs/assets/70119888/d6eb0e10-0bcf-4786-a6e6-d9735e52b518)
