### PR TITLE
Underline links in badges

### DIFF
--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -25,10 +25,12 @@ const inverseColoursMap = {
 }
 
 const map = inverse ? inverseColoursMap : coloursMap;
-const badgeClass =`${map[type]} type-caption-2 px-2 py-0.5 rounded-full border self-center`
+const badgeClass =`${map[type]} type-caption-2 px-2 py-0.5 rounded-full border`;
 
 ---
-{link ?
-  <a class={badgeClass} href={link}>{badgeText}</a> :
-  <span class={badgeClass}>{badgeText}</span>
-}
+<span class="not-prose flex items-center">
+  {link ?
+    <a class={badgeClass + ' underline'} href={link}>{badgeText}</a> :
+    <span class={badgeClass}>{badgeText}</span>
+  }
+</span>


### PR DESCRIPTION
**Ticket Link:** https://www.notion.so/centrapay/Lanterns-d784e8a5f9fa44328a5d0ae1fd85d37e?p=03bdab510ae84937894da06bb1b5b457&pm=s

**Test Plan:**
- [ ] Assert badges with links in them are underlined and still link to the relevant data type.


![image](https://github.com/centrapay/centrapay-docs/assets/70119888/c8c9e590-eb26-41ce-beb2-0e57f70e2de3)
