### PR TITLE
Specify attributes and errors in search index

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "tailwindcss": "^3.1.8",
     "unified": "^10.1.2",
     "unist-util-find-after": "^4.0.1",
+    "unist-util-find-before": "^4.0.0",
     "unist-util-visit": "^4.1.2",
     "vitest": "^0.28.3",
     "vue": "^3.2.47"

--- a/src/content/api/asset-transfers.mdx
+++ b/src/content/api/asset-transfers.mdx
@@ -22,7 +22,7 @@ their phone number.
 After an asset transfer is completed the recipientAlias, lastSentTo and
 message fields are scrubbed to avoid storing PII.
 
-## Model
+## Asset Transfer Model
 
 ### Attributes
 <Properties>

--- a/src/content/api/settlements.mdx
+++ b/src/content/api/settlements.mdx
@@ -18,7 +18,7 @@ Settlements can only be created if the Merchant has a [Settlement Config](/api/m
 
 ---
 
-## Model
+## Settlement Model
 
 ### Attributes
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6369,6 +6369,14 @@ unist-util-find-after@^4.0.1:
     "@types/unist" "^2.0.0"
     unist-util-is "^5.0.0"
 
+unist-util-find-before@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/unist-util-find-before/-/unist-util-find-before-4.0.0.tgz#f5c028e7eab5e59616f3624ac25931ff6b9c17d2"
+  integrity sha512-bdXFv1xM0O19Gn8B7mJjXuVOyVSdE7eQZs4Ulo4EWOBb8OihHLpCDhOLwDGjrpMZCRPlmpUhxMMqlDohvswEsA==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-is "^6.0.0"
+
 unist-util-generated@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/unist-util-generated/-/unist-util-generated-2.0.0.tgz#86fafb77eb6ce9bfa6b663c3f5ad4f8e56a60113"


### PR DESCRIPTION
This PR appends the context to the attribute and error titles in the search index.

Testing:

- [ ] Search for attributes in the docs site and see that they all have the model or route appended
- [ ] Search for errors in the docs site and see that they all have the route appended