### PR TITLE
Add page context to search

### DIFF
--- a/src/plugins/flexsearch.js
+++ b/src/plugins/flexsearch.js
@@ -27,12 +27,14 @@ function formatSearch({ node, root }) {
     return {
       title: `${parentHeading} ${nodeString}`,
       anchor: nodeString,
+      pageContext: parentHeading,
     };
   case 'Errors':
     const headingNode = stripBadge(toString(findBefore(root, findBefore(root, node, 'heading'), 'heading')));
     return {
       title: `${headingNode} ${nodeString}`,
       anchor: nodeString,
+      pageContext: headingNode,
     };
   default:
     return {
@@ -82,9 +84,9 @@ async function createFlexsearchIndexData() {
     const vfile = await processor.process(content);
 
     // Add all other headings and their descriptions to the index
-    vfile.data.sections.forEach(({ title, description, anchor }) => {
+    vfile.data.sections.forEach(({ title, description, anchor, pageContext }) => {
       indexData[id++] = {
-        path,
+        path: pageContext ? path.concat(pageContext) : path,
         title,
         description,
         href: `${href}#${slugify(anchor)}`,


### PR DESCRIPTION
This PR adds the page context to the search results
![image](https://github.com/centrapay/centrapay-docs/assets/85718272/7dfd44a1-2db1-4b3d-b2b8-7f9b34989a79)
becomes
![image](https://github.com/centrapay/centrapay-docs/assets/85718272/e4d9e0a6-2c4d-459a-afb7-d6e28066ea9f)
