### PR TITLE
Fix duplicated search results

### DIFF
--- a/src/components/CommandPalette.vue
+++ b/src/components/CommandPalette.vue
@@ -54,8 +54,8 @@
                     Nothing found.
                   </div>
                   <ComboboxOption
-                    v-for="result in results"
-                    :key="result.href"
+                    v-for="(result, resultIndex) in results"
+                    :key="resultIndex"
                     v-slot="{ active }"
                     as="template"
                     :value="result"


### PR DESCRIPTION
This PR fixes the duplicated search results. We were using the result.href as the index but with the api pages this can be duplicated so when the results were updating vue didn't realise which indexes needed updating.