### PR TITLE
Add inline flex class to badge

### DIFF
--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -28,7 +28,7 @@ const map = inverse ? inverseColoursMap : coloursMap;
 const badgeClass =`${map[type]} type-caption-2 px-2 py-0.5 rounded-full border`;
 
 ---
-<span class="not-prose flex items-center align-text-top">
+<span class="not-prose flex items-center align-text-top inline-flex">
   {link ?
     <a class={badgeClass + ' underline'} href={link}>{badgeText}</a> :
     <span class={badgeClass}>{badgeText}</span>


### PR DESCRIPTION
On introduction page the experimental badge is not inline. The pr fixes that.

Testing:

- [ ] Navigate to API introduction page and see that the experimental badge is inline