### PR TITLE
🔧 Fix styling of badge

### DIFF
--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -28,7 +28,7 @@ const map = inverse ? inverseColoursMap : coloursMap;
 const badgeClass =`${map[type]} type-caption-2 px-2 py-0.5 rounded-full border`;
 
 ---
-<span class="not-prose flex items-center align-text-top">
+<span class="not-prose self-center">
   {link ?
     <a class={badgeClass + ' underline'} href={link}>{badgeText}</a> :
     <span class={badgeClass}>{badgeText}</span>


### PR DESCRIPTION
Flex styling was causing line breaks within paragraph tags.

Test plan: Expect https://docs.centrapay.com/api/introduction/ to have badge inline with paragraph.