### PR TITLE
Fix badge alignment

### DIFF
--- a/src/components/Badge.astro
+++ b/src/components/Badge.astro
@@ -28,7 +28,7 @@ const map = inverse ? inverseColoursMap : coloursMap;
 const badgeClass =`${map[type]} type-caption-2 px-2 py-0.5 rounded-full border`;
 
 ---
-<span class="not-prose self-center">
+<span class="not-prose items-center inline-flex">
   {link ?
     <a class={badgeClass + ' underline'} href={link}>{badgeText}</a> :
     <span class={badgeClass}>{badgeText}</span>


### PR DESCRIPTION
Fix to have vertical alignment with h2s.

Test plan: Expect alignment for headings and paragraphs.

<img width="1120" alt="image" src="https://github.com/centrapay/centrapay-docs/assets/64108933/7d3b4820-52e7-4113-83ff-f8c7c7866493">

<img width="1159" alt="image" src="https://github.com/centrapay/centrapay-docs/assets/64108933/578b9992-6745-4ef9-a602-9c0d1786b0e7">
