### PR TITLE
Document INVALID_ASSET_TYPE error message

### DIFF
--- a/src/content/api/asset-transfers.mdx
+++ b/src/content/api/asset-transfers.mdx
@@ -178,6 +178,10 @@ Asset Transfer goes through different lifecycle stages.
     <Error code="403" message="RECIPIENT_MISSING">
       The asset must be transferred with a recipient supplied.
     </Error>
+
+    <Error code="403" message="INVALID_ASSET_TYPE">
+      The [asset's type](/api/asset-types/) does not support transfers.
+    </Error>
   </Properties>
 
   <CodePanel slot="code-examples" title="Request" method="POST" path="/api/assets/asset-transfers">


### PR DESCRIPTION
INVALID_ASSET_TYPE is now a publicly exposed error message for asset transfers. The PR updates our documentation to reflect this.