### PR TITLE
Update the guide for sending assets

### DIFF
--- a/src/content/api/asset-transfers.mdx
+++ b/src/content/api/asset-transfers.mdx
@@ -16,7 +16,7 @@ import Error from '../../components/Error.astro';
 An asset transfer is an asynchronous exchange of an asset or an amount to a recipient.
 
 A recipient is an existing Centrapay user or someone who can create an account to claim the asset transfer by verifying
-their phone number.
+their phone number or email.
 
 After an asset transfer is completed the recipientAlias, lastSentTo and
 message fields are scrubbed to avoid storing PII.
@@ -184,7 +184,7 @@ Asset Transfer goes through different lifecycle stages.
     </Error>
   </Properties>
 
-  <CodePanel slot="code-examples" title="Request" method="POST" path="/api/assets/asset-transfers">
+  <CodePanel slot="code-examples" title="Request" method="POST" path="/api/asset-transfers">
   ```bash
   curl -X POST https://service.centrapay.com/api/asset-transfers \
     -H "X-Api-Key: $api_key" \

--- a/src/content/guides/loading-and-sending-assets.mdx
+++ b/src/content/guides/loading-and-sending-assets.mdx
@@ -8,19 +8,83 @@ nav:
 
 import CodePanel from '../../components/CodePanel.astro';
 
-[Assets](/api/assets) such as Giftcards or Tokens can be issued by a Centrapay Account and then distributed to another Centrapay user’s phone number via SMS.
+[Assets](/api/assets) such as Giftcards or Tokens can be issued by a Centrapay Account. They can then be sent to another Centrapay account using one of the methods described below.
+
+## Sending Assets
+
+You can send Assets such as Tokens and Giftcards by calling our [Create Asset Transfers](/api/asset-transfers/#create-an-asset-transfer) endpoint.
+
+For any asset transfer that is not claimed within 2 weeks, the sent asset will be returned to the sender.
+
+### Sending to Alias
+Provide the recipient’s phone number or email in the `recipientAlias` field when creating the asset transfer.
+The recipient will be notified via the provided channel.
+
+Use the recipient's phone number for the `recipientAlias` field
+
+<CodePanel title="Request" method="POST" path="/api/asset-transfers">
+    ```bash
+    curl -X POST https://service.centrapay.com/api/asset-transfers \
+      -H "X-Api-Key: $api_key" \
+      -H "Content-Type: application/json" \
+      -d '{
+      "assetId": "YGRo6TYYSxH3js7",
+      "recipientAlias": "+642212312"
+      }'
+    ```
+  </CodePanel>
+
+Use the recipient’s email for the `recipientAlias` field.
+
+
+    <CodePanel title="Request" method="POST" path="/api/asset-transfers">
+    ```bash
+    curl -X POST https://service.centrapay.com/api/asset-transfers \
+      -H "X-Api-Key: $api_key" \
+      -H "Content-Type: application/json" \
+      -d '{
+      "assetId": "YGRo6TYYSxH3js7",
+       "recipientAlias": "john.doe@centrapay.com"
+      }'
+    ```
+    </CodePanel>
+
+### Sending via Link
+If a `recipientAlias` isn’t provided when creating the asset transfer, a link will be returned in the `url` field, which can then be shared via whichever channel you prefer.
+Clicking on the link will open a page to view and claim the asset transfer.
+
+<CodePanel title="Request" method="POST" path="/api/asset-transfers">
+    ```bash
+    curl -X POST https://service.centrapay.com/api/asset-transfers \
+      -H "X-Api-Key: $api_key" \
+      -H "Content-Type: application/json" \
+      -d '{
+      "assetId": "YGRo6TYYSxH3js7"
+      }'
+    ```
+</CodePanel>
+
+<CodePanel title="Response">
+    ```json
+    {
+      "id": "EL49tYKmAAkp2njVMs39mrP",
+      "status": "created",
+      "assetId": "YGRo6TYYSxH3js7",
+      "assetType": "centrapay.token.main",
+      "senderAccountId": "6ZfBR4jls3nR2mpFJQJ6Qg",
+      "createdAt": "2023-11-20T05:01:31.634Z",
+      "updatedAt": "2023-11-20T05:01:31.634Z",
+      "suppressNotifications": false,
+      "url": "https://app.centrapay.com/transfer/EL49tYKmAAkp2njVMs39mrP"
+    }
+    ```
+    </CodePanel>
 
 ## Loading Giftcards
 
 You can load Giftcards by calling our [External Assets](/api/external-assets) endpoint. You will need to use the giftcard number for the `externalId` field. The `pin`, the `issuer` and the `type` need to be on hand too.
 
 If your asset type is not included on the list, contact integrations@centrapay.com.
-
-## Sending Assets
-
-You can send Assets such as Tokens and Giftcards by calling our [Asset Transfers](/api/asset-transfers/#create-an-asset-transfer) endpoint. You will need to have the recipient’s phone number for `recipientAlias` to identify the reciever.
-
-If the `recipientAlias` doesn’t end up creating a Centrapay account within 2 weeks, then it will be sent back to you.
 
 ## Example: Bulk distribution of Giftcards
 

--- a/src/content/guides/loading-and-sending-assets.mdx
+++ b/src/content/guides/loading-and-sending-assets.mdx
@@ -22,63 +22,62 @@ The recipient will be notified via the provided channel.
 
 Use the recipient's phone number for the `recipientAlias` field
 
-<CodePanel title="Request" method="POST" path="/api/asset-transfers">
-    ```bash
-    curl -X POST https://service.centrapay.com/api/asset-transfers \
-      -H "X-Api-Key: $api_key" \
-      -H "Content-Type: application/json" \
-      -d '{
+  <CodePanel title="Request" method="POST" path="/api/asset-transfers">
+  ```bash
+  curl -X POST https://service.centrapay.com/api/asset-transfers \
+    -H "X-Api-Key: $api_key" \
+    -H "Content-Type: application/json" \
+    -d '{
       "assetId": "YGRo6TYYSxH3js7",
       "recipientAlias": "+642212312"
-      }'
-    ```
+    }'
+  ```
   </CodePanel>
 
 Use the recipient’s email for the `recipientAlias` field.
 
-
-    <CodePanel title="Request" method="POST" path="/api/asset-transfers">
-    ```bash
-    curl -X POST https://service.centrapay.com/api/asset-transfers \
-      -H "X-Api-Key: $api_key" \
-      -H "Content-Type: application/json" \
-      -d '{
+  <CodePanel title="Request" method="POST" path="/api/asset-transfers">
+  ```bash
+  curl -X POST https://service.centrapay.com/api/asset-transfers \
+    -H "X-Api-Key: $api_key" \
+    -H "Content-Type: application/json" \
+    -d '{
       "assetId": "YGRo6TYYSxH3js7",
-       "recipientAlias": "john.doe@centrapay.com"
-      }'
-    ```
-    </CodePanel>
+      "recipientAlias": "john.doe@centrapay.com"
+    }'
+  ```
+  </CodePanel>
 
 ### Sending via Link
 If a `recipientAlias` isn’t provided when creating the asset transfer, a link will be returned in the `url` field, which can then be shared via whichever channel you prefer.
 Clicking on the link will open a page to view and claim the asset transfer.
 
-<CodePanel title="Request" method="POST" path="/api/asset-transfers">
-    ```bash
-    curl -X POST https://service.centrapay.com/api/asset-transfers \
-      -H "X-Api-Key: $api_key" \
-      -H "Content-Type: application/json" \
-      -d '{
+  <CodePanel title="Request" method="POST" path="/api/asset-transfers">
+  ```bash
+  curl -X POST https://service.centrapay.com/api/asset-transfers \
+    -H "X-Api-Key: $api_key" \
+    -H "Content-Type: application/json" \
+    -d '{
       "assetId": "YGRo6TYYSxH3js7"
-      }'
-    ```
-</CodePanel>
+    }'
+  ```
+  </CodePanel>
 
-<CodePanel title="Response">
-    ```json
-    {
-      "id": "EL49tYKmAAkp2njVMs39mrP",
-      "status": "created",
-      "assetId": "YGRo6TYYSxH3js7",
-      "assetType": "centrapay.token.main",
-      "senderAccountId": "6ZfBR4jls3nR2mpFJQJ6Qg",
-      "createdAt": "2023-11-20T05:01:31.634Z",
-      "updatedAt": "2023-11-20T05:01:31.634Z",
-      "suppressNotifications": false,
-      "url": "https://app.centrapay.com/transfer/EL49tYKmAAkp2njVMs39mrP"
-    }
-    ```
-    </CodePanel>
+  <CodePanel title="Response">
+  ```json
+  {
+    "id": "EL49tYKmAAkp2njVMs39mrP",
+    "status": "created",
+    "assetId": "YGRo6TYYSxH3js7",
+    "assetType": "centrapay.token.main",
+    "senderAccountId": "6ZfBR4jls3nR2mpFJQJ6Qg",
+    "createdAt": "2023-11-20T05:01:31.634Z",
+    "updatedAt": "2023-11-20T05:01:31.634Z",
+    "suppressNotifications": false,
+    "url": "https://app.centrapay.com/transfer/EL49tYKmAAkp2njVMs39mrP"
+  }
+  ```
+  </CodePanel>
 
 ## Loading Giftcards
 


### PR DESCRIPTION
This change updates the section - **Sending Assets** in the Loading and Sending Assets guide:
- Include sending assets via Link
- Add curls

[Story](https://www.notion.so/centrapay/Update-Guides-with-latest-Token-features-67c76cad9f604b5da02a144d9f75e9d8?pvs=4)

[Design doc](https://www.notion.so/centrapay/Loading-and-Sending-Assets-32cf93bb7771478983e8114c98cdb78b?pvs=4)

[Dev preview](http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/guides/loading-and-sending-assets/)