### PR TITLE
update types for bank account consent and connection intents

### DIFF
--- a/src/content/api/bank-account-approvals.mdx
+++ b/src/content/api/bank-account-approvals.mdx
@@ -68,7 +68,7 @@ that allows access to a third-party system. See [Bank Account Approval Types](#b
   </Property>
 
   <Property name="refreshToken" type="string">
-    A long lived access token for access to a third-party system. Required for type `account-consent` and `payment-consent`.
+    A long lived access token for access to a third-party system. Required for type `account-information-consent` and `enduring-payment-consent`.
   </Property>
 
   <Property name="consentId" type="string">
@@ -78,11 +78,11 @@ that allows access to a third-party system. See [Bank Account Approval Types](#b
 
 ### Bank Account Approval Types
 
-|      Name       |                                                                                                                                      description                                                                                                                                      |
-| :-------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| settlement      | An `approved` Bank Account Approval of type `settlement` is required for the funds in a [Settlement Wallet](/api/wallets#settlement-wallets) to be released. A [Media Upload](/api/media-uploads) is uploaded by the user to provide evidence of ownership of the [Bank Account](/api/bank-accounts) to be approved. |
-| account-consent | An `approved` Bank Account Approval of type `account-consent` provides an access token to read account details from a third-party.                                                                                                                                                    |
-| payment-consent | An `approved` Bank Account Approval of type `payment-consent` provides an access token for creating payments with a third-party.                                                                                                                                                      |
+|      Name                    |                                                                                                                                      description                                                                                                                                      |
+| :--------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| settlement                   | An `approved` Bank Account Approval of type `settlement` is required for the funds in a [Settlement Wallet](/api/wallets#settlement-wallets) to be released. A [Media Upload](/api/media-uploads) is uploaded by the user to provide evidence of ownership of the [Bank Account](/api/bank-accounts) to be approved. |
+| account--information-consent | An `approved` Bank Account Approval of type `account-information-consent` provides an access token to read account details from a third-party.                                                                                                                                                    |
+| enduring-payment-consent     | An `approved` Bank Account Approval of type `enduring-payment-consent` provides an access token for creating payments with a third-party.                                                                                                                                                      |
 
 ---
 
@@ -202,7 +202,7 @@ that allows access to a third-party system. See [Bank Account Approval Types](#b
       "id": "bbab9a768921019cb856",
       "bankAccountId": "WRhAxxWpTKb5U7pXyxQjjY",
       "accountId": "Jaim1Cu1Q55uooxSens6yk",
-      "type": "account-consent",
+      "type": "account-information-consent",
       "status": "approved",
       "createdAt": "2021-11-08T21:52:39.915Z",
       "createdBy": "crn:WIj211vFs9cNACwBb04vQw:api-key:MyApiKey",
@@ -335,7 +335,7 @@ that allows access to a third-party system. See [Bank Account Approval Types](#b
           "accountId": "TEZiZWAtX6v1hJucU4fGKx",
           "createdBy": "crn::user:7c0a034a-c36e-4645-b12b-57dec339ab47",
           "modifiedBy": "crn::user:7c0a034a-c36e-4645-b12b-57dec339ab47",
-          "type": "account-consent",
+          "type": "account-information-consent",
           "status": "approved",
           "refreshToken": "tXC4dFm3yNAQbLrm4JxY6pynGoEG8vSJ",
           "consentId": "fFAoo-CoWZLea8-4dFm3yNAoWZLe"
@@ -348,7 +348,7 @@ that allows access to a third-party system. See [Bank Account Approval Types](#b
           "accountId": "TEZiZWAtX6v1hJucU4fGKx",
           "createdBy": "crn::user:7c0a034a-c36e-4645-b12b-57dec339ab47",
           "modifiedBy": "crn::user:7c0a034a-c36e-4645-b12b-57dec339ab47",
-          "type": "payment-consent",
+          "type": "enduring-payment-consent",
           "status": "approved",
           "refreshToken": "dAGLl8AfnNCGEKEmBm1FryaDyW1JBh28",
           "consentId": "4KYUx-ncFPg4a8-Ll8AfnNCcFPg4"
@@ -361,7 +361,7 @@ that allows access to a third-party system. See [Bank Account Approval Types](#b
           "accountId": "TEZiZWAtX6v1hJucU4fGKx",
           "createdBy": "crn::user:7c0a034a-c36e-4645-b12b-57dec339ab47",
           "modifiedBy": "crn::user:7c0a034a-c36e-4645-b12b-57dec339ab47",
-          "type": "account-consent",
+          "type": "account-information-consent",
           "status": "declined",
           "refreshToken": "rX3MNTxFwKIU2lhyZOrq87Aw74ASSHUM",
           "consentId": "rknrd-kYbBuBa8-MNTxFwKIYbBuB"

--- a/src/content/api/bank-account-connection-intents.mdx
+++ b/src/content/api/bank-account-connection-intents.mdx
@@ -62,10 +62,10 @@ A Bank Account Connection Intent facilitates user authorization of access to Ban
 
 ### Bank Account Connection Intent Types
 
-|      Name       |                                                                                               description                                                                                                |
-| :-------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| quartz-accounts | Initiates an authorization flow for authorizing access to bank account details. After a Bank Account Connection Intent has been authorized, one or more Centrapay Bank Account resources may be created. |
-| quartz-payment  | Initiates an authorization flow for authorizing access to create payments.                                                                                                                               |
+|      Name                   |                                                                                               description                                                                                                |
+| :-------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| account-information-consent | Initiates an authorization flow for authorizing access to bank account details. After a Bank Account Connection Intent has been authorized, one or more Centrapay Bank Account resources may be created. |
+| enduring-payment-consent    | Initiates an authorization flow for authorizing access to create payments.                                                                                                                               |
 
 ---
 
@@ -88,7 +88,7 @@ A Bank Account Connection Intent facilitates user authorization of access to Ban
     </Property>
 
     <Property name="bankAccountId" type="string">
-      The id of the associated [Bank Account](/api/bank-accounts/). Required if type is `quartz-payment`.
+      The id of the associated [Bank Account](/api/bank-accounts/). Required if type is `enduring-payment-consent`.
     </Property>
 
     <Property name="test" type="boolean">
@@ -110,7 +110,7 @@ A Bank Account Connection Intent facilitates user authorization of access to Ban
       -H "Content-Type: application/json" \
       -d '{
         "accountId": "uooxSens6ykJaim1Cu1Q55",
-        "type": "quartz-accounts",
+        "type": "account-information-consent",
         "test": true
       }'
     ```
@@ -121,7 +121,7 @@ A Bank Account Connection Intent facilitates user authorization of access to Ban
     {
       "id": "3KVjuKW2CZCJeJVqPxwkX7",
       "accountId": "B4u4WZCu3joZFVWT3XjWW3",
-      "type": "quartz-accounts",
+      "type": "account-information-consent",
       "status": "created",
       "createdAt": "2022-03-31 02:56:29 UTC",
       "createdBy": "crn:B4u4WZCu3joZFVWT3XjWW3:api-key:MyApiKey",

--- a/src/content/api/bank-accounts.mdx
+++ b/src/content/api/bank-accounts.mdx
@@ -358,7 +358,7 @@ The Bank Account balance, retrieved using Open Banking flows. The supported Bank
       "modifiedAt": "2022-07-18T02:26:39.477Z",
       "approvals": [
           {
-            "type": "account-consent",
+            "type": "account-information-consent",
             "status": "approved",
             "updatedAt": "2021-11-08T21:52:39.915Z"
           }


### PR DESCRIPTION
bank account connection intents and bank account approvals were changed to use types `enduring-payment-consent` and `account-information-consent` this updates the docs to reflect this
Previous:
![image](https://github.com/centrapay/centrapay-docs/assets/69737582/bb717fab-59d8-465a-a451-aa5ac6a11b3b)
New:
![image](https://github.com/centrapay/centrapay-docs/assets/69737582/5e0777c8-7121-4cd3-94b3-1bad1155aca4)
