### PR TITLE
Expandable Attributes

### DIFF
--- a/src/assets/css/components/buttons.css
+++ b/src/assets/css/components/buttons.css
@@ -1,7 +1,6 @@
 @layer components {
 
-  .btn,
-  button {
+  .btn {
     @apply
       rounded-full
       p-squish-2

--- a/src/components/AppShell.vue
+++ b/src/components/AppShell.vue
@@ -62,7 +62,7 @@
 
         <div class="flex items-center">
           <button
-            class="flex items-center md:w-80 md:mr-4 text-left space-x-3 py-0 px-0 md:px-4 md:pr-0 h-10 bg-white md:border border-gray-300 focus:outline-none ring-0 focus:ring-0 md:shadow-sm rounded-none md:rounded-lg overflow-hidden"
+            class="btn flex items-center md:w-80 md:mr-4 text-left space-x-3 py-0 px-0 md:px-4 md:pr-0 h-10 bg-white md:border border-gray-300 focus:outline-none ring-0 focus:ring-0 md:shadow-sm rounded-none md:rounded-lg overflow-hidden"
             @click="openCommandPalette"
           >
             <SearchLogo class="w-6 h-6 md:w-4 md:h-4" />
@@ -78,7 +78,7 @@
             </kbd>
           </button>
           <button
-            class="flex items-center pr-6 md:hidden focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
+            class="btn flex items-center pr-6 md:hidden focus:outline-none focus:ring-2 focus:ring-inset ring-focus-ring"
             @click="mainMenuOpen = !mainMenuOpen"
           >
             <span class="sr-only">Open Main Menu</span>

--- a/src/components/CodePanel.astro
+++ b/src/components/CodePanel.astro
@@ -39,17 +39,7 @@ import Badge from "./Badge.astro";
 </div>
 
 <script>
-  function getElement(
-    selector,
-    Constructor,
-    parent: ParentNode = document,
-  ) {
-    const element = parent.querySelector(selector);
-    if (!(element instanceof Constructor)) {
-      throw new Error(`Element is not of type ${Constructor.name}: ${selector}`);
-    }
-    return element;
-  }
+  import getElement from '../utils/getElement';
 
   for (const codeBlock of document.querySelectorAll('[data-code-block]')) {
     const code = getElement('[data-code]', HTMLElement, codeBlock);

--- a/src/components/CodePanel.astro
+++ b/src/components/CodePanel.astro
@@ -31,7 +31,7 @@ import Badge from "./Badge.astro";
     <button
       id="copy-button"
       data-copy-button
-      class="type-overline py-2 px-3 bg-interactive-secondary hover:bg-interactive-secondary-hover text-content-inverse-primary transition hover:scale-105 active:scale-100 active:transition-none"
+      class="btn type-overline py-2 px-3 bg-interactive-secondary hover:bg-interactive-secondary-hover text-content-inverse-primary transition hover:scale-105 active:scale-100 active:transition-none"
     >
       Copy
     </button>

--- a/src/components/Error.astro
+++ b/src/components/Error.astro
@@ -4,12 +4,12 @@ import Badge from '../components/Badge.astro';
 const { code, message } = Astro.props;
 ---
 
-<li class="not-prose m-0 p-0 flex flex-col py-4 first:pt-0 space-y-2 type-content-primary">
+<li class="not-prose m-0 p-0 flex flex-col py-4 first:pt-0 type-content-primary">
   <div class="flex flex-row items-center space-x-3">
     <h4 class="font-mono" id={message}>{message}</h4>
     <Badge text={code}></Badge>
   </div>
-  <div data-expandable-slot class="hidden">
+  <div data-expandable-slot class="transition-opacity duration-500 collapsed">
     <slot />
   </div>
 </li>

--- a/src/components/Error.astro
+++ b/src/components/Error.astro
@@ -4,10 +4,12 @@ import Badge from '../components/Badge.astro';
 const { code, message } = Astro.props;
 ---
 
-<li class="not-prose m-0 p-0 flex flex-col py-4 space-y-2 type-content-primary">
+<li class="not-prose m-0 p-0 flex flex-col py-4 first:pt-0 space-y-2 type-content-primary">
   <div class="flex flex-row items-center space-x-3">
     <h4 class="font-mono" id={message}>{message}</h4>
     <Badge text={code}></Badge>
   </div>
-  <slot />
+  <div data-expandable-slot class="hidden">
+    <slot />
+  </div>
 </li>

--- a/src/components/Properties.astro
+++ b/src/components/Properties.astro
@@ -5,7 +5,7 @@ const { heading = 'Attributes' } = Astro.props;
 <div data-attributes class="my-6">
   <div class="flex justify-between items-center not-prose py-2">
     <h3 class="type-subtitle-1">{ heading }</h3>
-    <button data-expand-button class="text-content-tertiary type-overline">
+    <button data-expand-button class="text-content-tertiary type-overline hover:text-content-secondary">
       Expand all
     </button>
   </div>
@@ -28,12 +28,32 @@ const { heading = 'Attributes' } = Astro.props;
       button.textContent = button.innerText === 'EXPAND ALL' ? 'COLLAPSE ALL' : 'EXPAND ALL';
       const expandables = attributeList.querySelectorAll('[data-expandable-slot]');
       for (const expandable of expandables) {
-        if (expandable.classList.contains('hidden')) {
-          expandable.classList.remove('hidden');
+        if (expandable.classList.contains('collapsed')) {
+          expandable.classList.remove('collapsed');
+          expandable.classList.add('expanded');
         } else {
-          expandable.classList.add('hidden');
+          expandable.classList.remove('expanded');
+          expandable.classList.add('collapsed');
         }
       }
     });
   }
 </script>
+
+<style is:global>
+  .expanded {
+    @apply
+      pt-2
+      opacity-100
+      scale-y-100
+    ;
+  }
+
+  .collapsed {
+    @apply
+      h-0
+      opacity-0
+      scale-y-0
+    ;
+  }
+</style>

--- a/src/components/Properties.astro
+++ b/src/components/Properties.astro
@@ -1,8 +1,49 @@
-<div class="my-6">
+---
+const { heading = 'Attributes' } = Astro.props;
+---
+
+<div data-attributes class="my-6">
+  <div class="flex justify-between items-center not-prose py-2">
+    <h3 class="scroll-mt-10 type-subtitle-1">{ heading }</h3>
+    <button data-expand-button class="text-content-tertiary type-overline">
+      Expand all
+    </button>
+  </div>
   <ul
+    data-attribute-list
     role="list"
-    class="m-0 list-none divide-y divide-zinc-900/5 p-0"
+    class="m-0 list-none border-y border-zinc-900/5 divide-y divide-zinc-900/5 p-0 pt-4"
   >
     <slot />
   </ul>
 </div>
+
+<script>
+  function getElement(
+    selector,
+    Constructor,
+    parent: ParentNode = document,
+  ) {
+    const element = parent.querySelector(selector);
+    if (!(element instanceof Constructor)) {
+      throw new Error(`Element is not of type ${Constructor.name}: ${selector}`);
+    }
+    return element;
+  }
+
+  for (const attributesSection of document.querySelectorAll('[data-attributes]')) {
+    const button = getElement('[data-expand-button]', HTMLButtonElement, attributesSection);
+    const attributeList = getElement('[data-attribute-list]', HTMLUListElement, attributesSection);
+    button.addEventListener('click', () => {
+      button.textContent = button.innerText === 'EXPAND ALL' ? 'COLLAPSE ALL' : 'EXPAND ALL';
+      const expandables = attributeList.querySelectorAll('[data-expandable-slot]');
+      for (const expandable of expandables) {
+        if (expandable.classList.contains('hidden')) {
+          expandable.classList.remove('hidden');
+        } else {
+          expandable.classList.add('hidden');
+        }
+      }
+    });
+  }
+</script>

--- a/src/components/Properties.astro
+++ b/src/components/Properties.astro
@@ -4,7 +4,7 @@ const { heading = 'Attributes' } = Astro.props;
 
 <div data-attributes class="my-6">
   <div class="flex justify-between items-center not-prose py-2">
-    <h3 class="scroll-mt-10 type-subtitle-1">{ heading }</h3>
+    <h3 class="type-subtitle-1">{ heading }</h3>
     <button data-expand-button class="text-content-tertiary type-overline">
       Expand all
     </button>
@@ -12,24 +12,14 @@ const { heading = 'Attributes' } = Astro.props;
   <ul
     data-attribute-list
     role="list"
-    class="m-0 list-none border-y border-zinc-900/5 divide-y divide-zinc-900/5 p-0 pt-4"
+    class="m-0 list-none border-y border-outline-transparent divide-y divide-outline-transparent p-0 pt-4"
   >
     <slot />
   </ul>
 </div>
 
 <script>
-  function getElement(
-    selector,
-    Constructor,
-    parent: ParentNode = document,
-  ) {
-    const element = parent.querySelector(selector);
-    if (!(element instanceof Constructor)) {
-      throw new Error(`Element is not of type ${Constructor.name}: ${selector}`);
-    }
-    return element;
-  }
+  import getElement from '../utils/getElement';
 
   for (const attributesSection of document.querySelectorAll('[data-attributes]')) {
     const button = getElement('[data-expand-button]', HTMLButtonElement, attributesSection);

--- a/src/components/Property.astro
+++ b/src/components/Property.astro
@@ -8,7 +8,7 @@ const formattedType = type.toLowerCase();
 const link = customDataTypes.includes(formattedType) ? '/api/data-types#' + formattedType :undefined;
 ---
 
-<li class="m-0 px-0 py-4 first:pt-0 last:pb-0 space-y-2">
+<li class="m-0 px-0 py-4 first:pt-0 space-y-2">
   <div class="m-0 flex flex-wrap items-center gap-x-3">
     <h4 class="my-0" id={name}>{name}</h4>
     <Badge text={formattedType} link={link} />
@@ -16,7 +16,7 @@ const link = customDataTypes.includes(formattedType) ? '/api/data-types#' + form
     { experimental && <Badge type="experimental" /> }
     { deprecated && <Badge type="deprecated" /> }
   </div>
-  <div class="w-full flex-none [&>:first-child]:mt-0 [&>:last-child]:mb-0">
+  <div data-expandable-slot class="w-full flex-none [&>:first-child]:mt-0 [&>:last-child]:mb-0 hidden">
     <slot />
   </div>
 </li>

--- a/src/components/Property.astro
+++ b/src/components/Property.astro
@@ -8,7 +8,7 @@ const formattedType = type.toLowerCase();
 const link = customDataTypes.includes(formattedType) ? '/api/data-types#' + formattedType :undefined;
 ---
 
-<li class="m-0 px-0 py-4 first:pt-0 space-y-2">
+<li class="m-0 px-0 py-4 first:pt-0">
   <div class="m-0 flex flex-wrap items-center gap-x-3">
     <h4 class="my-0" id={name}>{name}</h4>
     <Badge text={formattedType} link={link} />
@@ -16,7 +16,7 @@ const link = customDataTypes.includes(formattedType) ? '/api/data-types#' + form
     { experimental && <Badge type="experimental" /> }
     { deprecated && <Badge type="deprecated" /> }
   </div>
-  <div data-expandable-slot class="w-full flex-none [&>:first-child]:mt-0 [&>:last-child]:mb-0 hidden">
+  <div data-expandable-slot class="w-full flex-none [&>:first-child]:mt-0 [&>:last-child]:mb-0 transition-opacity duration-500 collapsed">
     <slot />
   </div>
 </li>

--- a/src/content/api/account-memberships.mdx
+++ b/src/content/api/account-memberships.mdx
@@ -20,7 +20,6 @@ some or all of the operations and resources within the account.
 
 A Member contains extended information about a user's access to an account.
 
-### Attributes
 
 <Properties>
   <Property name="accountId" type="string">
@@ -90,7 +89,6 @@ A Member contains extended information about a user's access to an account.
 
   This endpoint allows you to add or update the membership of a user to an account.
 
-  ### Attributes
   <Properties>
     <Property name="userId" type="string" required>
       The id of the user the Membership belongs to.
@@ -139,8 +137,6 @@ A Member contains extended information about a user's access to an account.
 
   This endpoint allows you to retrieve the list memberships to an account.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/accounts/{accountId}/members">
     ```bash
@@ -189,11 +185,8 @@ A Member contains extended information about a user's access to an account.
 
   This endpoint allows you to revoke a users membership to an account.
 
-  ### Attributes
-  No attributes.
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="LAST_OWNER_NOT_REVOKABLE">
       The last remaining membership to an account cannot be revoked.
     </Error>
@@ -217,8 +210,6 @@ A Member contains extended information about a user's access to an account.
 
   This endpoint allows you to retrieve the accounts that the authenticated subject is a member of.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/account-memberships">
     ```bash
@@ -251,8 +242,6 @@ A Member contains extended information about a user's access to an account.
 
   This endpoint allows you to retrieve the accounts that a user is a member of.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/users/{userId}/account-memberships">
     ```bash

--- a/src/content/api/accounts.mdx
+++ b/src/content/api/accounts.mdx
@@ -20,8 +20,6 @@ individual account.
 
 ## Account Model
 
-### Attributes
-
 <Properties>
   <Property name="id" type="string">
     The unique identifier.
@@ -64,9 +62,9 @@ individual account.
   </Property>
 </Properties>
 
-## Subscription Model
+---
 
-### Attributes
+## Subscription Model
 
 <Properties>
   <Property name="name" type="string">
@@ -84,7 +82,6 @@ individual account.
 
   This endpoint allows you to create an Account.
 
-  ### Attributes
   <Properties>
     <Property name="name" type="string" required>
       The name of the Account.
@@ -148,9 +145,6 @@ individual account.
 
   This endpoint allows you to retrieve an Account.
 
-  ### Attributes
-  No attributes.
-
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/accounts/{accountId}">
     ```bash
     curl https://service.centrapay.com/api/accounts/Jaim1Cu1Q55uooxSens6yk \
@@ -187,7 +181,6 @@ individual account.
 
   This endpoint allows you to update an account.
 
-  ### Attributes
   <Properties>
     <Property name="name" type="string" required>
       The name of the Account.
@@ -234,7 +227,6 @@ individual account.
 
   This endpoint allows you to update the subscriptions on an account.
 
-  ### Attributes
   <Properties>
     <Property name="subscriptions" type="array" required>
       The list of subscriptions to assign to the account.
@@ -262,8 +254,7 @@ individual account.
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INVALID_ACCOUNT_ID">
       The account does not exist.
     </Error>

--- a/src/content/api/api-keys.mdx
+++ b/src/content/api/api-keys.mdx
@@ -14,7 +14,6 @@ API keys provide enduring access to a single Centrapay [Account](/api/accounts).
 
 ## API Key Model
 
-### Attributes
 
 <Properties>
   <Property name="accountId" type="string">
@@ -64,7 +63,6 @@ API keys provide enduring access to a single Centrapay [Account](/api/accounts).
 
   This endpoint allows you to create an API key.
 
-  ### Attributes
 
   <Properties>
     <Property name="name" type="string" required>
@@ -117,8 +115,6 @@ API keys provide enduring access to a single Centrapay [Account](/api/accounts).
 
   This endpoint allows you to list all API Keys for an Account.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/accounts/{accountId}/api-keys">
     ```bash
@@ -168,7 +164,6 @@ API keys provide enduring access to a single Centrapay [Account](/api/accounts).
 
   This endpoint allows you to enable or disable an API key.
 
-  ### Attributes
   <Properties>
     <Property name="enabled" type="boolean" required>
       Flag indicating the API Key is usable for authentication.

--- a/src/content/api/asset-transfers.mdx
+++ b/src/content/api/asset-transfers.mdx
@@ -23,7 +23,6 @@ message fields are scrubbed to avoid storing PII.
 
 ## Asset Transfer Model
 
-### Attributes
 <Properties>
   <Property name="id" type="string">
     The unique identifier.
@@ -130,7 +129,6 @@ Asset Transfer goes through different lifecycle stages.
   Some assets can be transferred without supplying a recipient. A `url` field will be
   returned in these cases. The `url` will link to a page to claim the asset.
 
-  ### Attributes
   <Properties>
     <Property name="assetId" type="string" required>
       Id of a discrete asset to transfer or wallet to draw from.
@@ -161,8 +159,7 @@ Asset Transfer goes through different lifecycle stages.
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INSUFFICIENT_WALLET_BALANCE">
       The value of the asset-transfer exceeds the balance on the wallet.
     </Error>
@@ -226,8 +223,6 @@ Asset Transfer goes through different lifecycle stages.
 >
   ## Get an Asset Transfer
 
-  ### Attributes
-  No Attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/assets/asset-transfers/{assetTransferId}">
   ```bash
@@ -266,8 +261,6 @@ Asset Transfer goes through different lifecycle stages.
 >
   ## Get Asset Transfer Summary
 
-  ### Attributes
-  No Attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/assets/asset-transfers/{assetTransferId}/summary">
   ```bash
@@ -300,11 +293,8 @@ Asset Transfer goes through different lifecycle stages.
 
   Claim the asset transfer for the caller's authorised account.
 
-  ### Attributes
-  No Attributes.
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="ASSET_TRANSFER_INVALID_RECIPIENT">
       The asset transfer already has a recipient defined through the `recipientAlias` field and cannot be claimed with this API.
     </Error>
@@ -356,8 +346,6 @@ Asset Transfer goes through different lifecycle stages.
 
   New accounts should call this endpoint to allocate assets that you've been sent.
 
-  ### Attributes
-  No Attributes.
 
   <CodePanel slot="code-examples" title="Request" method="POST" path="/api/me/resolve-claimable-assets">
     ```bash
@@ -384,7 +372,6 @@ Asset Transfer goes through different lifecycle stages.
 
   Returns a [paginated](/api/pagination/) list of Asset Transfers.
 
-  ### Attributes
   <Properties>
     <Property name="recipientAccountId" type="string">
       The Centrapay Account id of the recipient.
@@ -437,11 +424,7 @@ Asset Transfer goes through different lifecycle stages.
 >
   ## Cancel an Asset Transfer
 
-  ### Attributes
-  No attributes
-
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INVALID_ASSET_TRANSFER_STATUS">
       The asset transfer status is invalid and cannot be cancelled.
     </Error>

--- a/src/content/api/assets.mdx
+++ b/src/content/api/assets.mdx
@@ -28,7 +28,6 @@ All assets have the following fields along with the additional fields that are
 specific to its category. Assets which don't have a category are considered <Badge type="experimental" />
  and the model may change.
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -78,7 +77,6 @@ and does not expire.
 
 Money assets have the following attributes along with the base asset fields.
 
-### Attributes
 
 <Properties>
   <Property name="currency" type="string">
@@ -109,7 +107,6 @@ entirety.
 
 Gift cards have the following attributes along with the base asset fields.
 
-### Attributes
 
 <Properties>
   <Property name="issuer" type="string">
@@ -177,7 +174,6 @@ Tokens are assets which can only be spent in full. Every token is associated wit
 
 Tokens have the following attributes along with the base asset fields.
 
-### Attributes
 
 <Properties>
   <Property name="collectionId" type="string">
@@ -229,7 +225,6 @@ The `otherParty` is optionally provided only on transactions of type
 `increment-balance` and `decrement-balance`. Values may include bank account
 number.
 
-### Attributes
 
 <Properties>
   <Property name="ref" type="string">
@@ -289,8 +284,6 @@ number.
 >
   ## Get Asset
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/assets/{assetId}">
   ```bash
@@ -330,8 +323,6 @@ number.
 >
   ## Get Asset Summary
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/assets/{assetId}/summary">
     ```bash
@@ -363,7 +354,6 @@ number.
 
   Returns a [paginated](/api/pagination) list of Assets for an account. This will not return archived assets.
 
-  ### Attributes
   <Properties>
     <Property name="externalId" type="string">
       The asset identifier from the issuing system.
@@ -440,8 +430,6 @@ number.
 
   Returns a [paginated](/api/pagination) list of [Asset Transactions](#asset-transaction-model). This endpoint is currently only supported for `quartz` asset types.
 
-  ### Attributes
-  No Attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/assets/{assetId}/transactions">
     ```bash
@@ -515,8 +503,6 @@ number.
 
   Archive supported asset types by asset id. Currently only gift cards may be archived.
 
-  ### Attributes
-  No Attributes.
 
   <CodePanel slot="code-examples" title="Request" method="POST" path="/api/assets/{assetId}/archive">
     ```bash
@@ -545,8 +531,7 @@ number.
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="UNSUPPORTED_ASSET_TYPE">
       Asset type can not be archived
     </Error>

--- a/src/content/api/bank-account-approvals.mdx
+++ b/src/content/api/bank-account-approvals.mdx
@@ -20,7 +20,6 @@ that allows access to a third-party system. See [Bank Account Approval Types](#b
 
 ## Bank Account Approval Model
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -88,7 +87,6 @@ that allows access to a third-party system. See [Bank Account Approval Types](#b
 
 ## Bank Account Approval Activity Model
 
-### Attributes
 
 <Properties>
   <Property name="activityNumber" type="number">
@@ -122,7 +120,6 @@ that allows access to a third-party system. See [Bank Account Approval Types](#b
 
   This endpoint allows you to request a Bank Account Approval.
 
-  ### Attributes
   <Properties>
     <Property name="mediaUploadId" type="string" required>
       The id of the associated [Media Upload](/api/media-uploads).
@@ -137,8 +134,7 @@ that allows access to a third-party system. See [Bank Account Approval Types](#b
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="APPROVAL_ALREADY_IN_PROGRESS">
       There is already a Bank Account Approval in progress that is awaiting review from Centrapay.
     </Error>
@@ -186,8 +182,6 @@ that allows access to a third-party system. See [Bank Account Approval Types](#b
 
   This endpoint allows you to retrieve a Bank Account Approval.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/bank-account-approvals/{bankAccountApprovalId}">
     ```bash
@@ -226,15 +220,13 @@ that allows access to a third-party system. See [Bank Account Approval Types](#b
 
   This endpoint allows you to accept a Bank Account Approval.
 
-  ### Attributes
   <Properties>
     <Property name="reason" type="string">
       The reason for accepting the Bank Account Approval.
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="APPROVAL_ALREADY_REVIEWED">
       The Bank Account Approval has already been accepted or declined.
     </Error>
@@ -269,15 +261,13 @@ that allows access to a third-party system. See [Bank Account Approval Types](#b
 
   This endpoint allows you to decline a Bank Account Approval.
 
-  ### Attributes
   <Properties>
     <Property name="reason" type="string" required>
       The reason for declining the Bank Account Approval.
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="APPROVAL_ALREADY_REVIEWED">
       The Bank Account Approval has already been accepted or declined.
     </Error>
@@ -312,8 +302,6 @@ that allows access to a third-party system. See [Bank Account Approval Types](#b
 
   This endpoint allows you to list the Bank Account Approvals for a Bank Account.
 
-  ### Attributes
-  No attributes.
 
 
     <CodePanel slot="code-examples" title="Request" method="GET" path="/api/bank-accounts/{bankAccountId}/approvals">

--- a/src/content/api/bank-account-connection-intents.mdx
+++ b/src/content/api/bank-account-connection-intents.mdx
@@ -77,7 +77,6 @@ A Bank Account Connection Intent facilitates user authorization of access to Ban
 
   This endpoint allows you to create a Bank Account Connection Intent.
 
-  ### Attributes
   <Properties>
     <Property name="accountId" type="string" required>
       The id of the owning [Account](/api/accounts/).
@@ -96,8 +95,7 @@ A Bank Account Connection Intent facilitates user authorization of access to Ban
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="LIVENESS_MISMATCH">
       Only Bank Account Connection Intents with the `test` flag can be associated with test [Bank Accounts](/api/bank-accounts/), and vice versa.
     </Error>
@@ -144,7 +142,6 @@ A Bank Account Connection Intent facilitates user authorization of access to Ban
 
   This endpoint allows you to authorize a Bank Account Connection Intent.
 
-  ### Attributes
   <Properties>
     <Property name="code" type="string" required>
       Authorization code returned from third-party.

--- a/src/content/api/bank-accounts.mdx
+++ b/src/content/api/bank-accounts.mdx
@@ -23,7 +23,6 @@ bank transaction can be used to verify a bank account.
 
 ## Bank Account Model
 
-### Attributes
 <Properties>
   <Property name="id" type="string">
     The Bank Account's unique identifier.
@@ -110,7 +109,6 @@ Types of bank accounts to allow access to different [Asset Types](/api/asset-typ
 A summary of the [Bank Account Approvals](/api/bank-account-approvals) for a Bank Account.
 There is one object per type of Bank Account Approval, which provides a summary of the approval status.
 
-### Attributes
 <Properties>
   <Property name="type" type="string">
     The type of Bank Account Approval Summary.
@@ -131,7 +129,6 @@ There is one object per type of Bank Account Approval, which provides a summary 
 
 The Bank Account balance, retrieved using Open Banking flows. The supported Bank Account type is `quartz`.
 
-### Attributes
 <Properties>
   <Property name="bankAccountId" type="string">
     The unique identifier of the Centrapay Bank Account.
@@ -160,7 +157,6 @@ The Bank Account balance, retrieved using Open Banking flows. The supported Bank
 
   `phone`, `fullName` and `emailAddress` are all required to create a direct-debit authority. This is required to be able to Top Up a Bank Account.
 
-  ### Attributes
   <Properties>
     <Property name="accountId" type="string" required>
       The id of the owning Centrapay [Account](/api/accounts).
@@ -195,8 +191,7 @@ The Bank Account balance, retrieved using Open Banking flows. The supported Bank
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="BANK_ACCOUNT_LIMIT_EXCEEDED">
       The Centrapay account already has the max amount of directDebitAuthorized enabled Bank Accounts.
     </Error>
@@ -260,7 +255,6 @@ The Bank Account balance, retrieved using Open Banking flows. The supported Bank
 
   By using this endpoint, the user accepts our [Direct Debit terms](https://centrapay.com/directdebit-termsandconditions/) and has authority to operate this account.
 
-  ### Attributes
   <Properties>
     <Property name="phoneNumber" type="string" required>
     The user's phone number.
@@ -275,8 +269,7 @@ The Bank Account balance, retrieved using Open Banking flows. The supported Bank
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="DIRECT_DEBIT_ALREADY_AUTHORIZED">
       This bank authority cannot be changed as all fields have been set.
     </Error>
@@ -331,8 +324,6 @@ The Bank Account balance, retrieved using Open Banking flows. The supported Bank
 
   This endpoint allows you to retrieve information about a Bank Account.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/bank-accounts/{bankAccountId}">
     ```bash
@@ -381,11 +372,8 @@ The Bank Account balance, retrieved using Open Banking flows. The supported Bank
 
   This endpoint allows you to retrieve the [balance](#bank-account-balance-model) of a Bank Account.
 
-  ### Attributes
-  No attributes.
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="BANK_BALANCE_NOT_SUPPORTED">
       The [Bank Account Type](#bank-account-type) does not support retrieval of a balance using Open Banking flows.
     </Error>
@@ -424,15 +412,13 @@ The Bank Account balance, retrieved using Open Banking flows. The supported Bank
 
   Verification codes show up on statements when a user makes withdrawals and deposits. To verify an account, you need to direct the user to make a Top Up or Withdrawal and then check their statement.
 
-  ### Attributes
   <Properties>
     <Property name="verificationCode" type="string" required>
     	The code on the user’s bank statement.
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="BANK_ACCOUNT_ALREADY_VERIFIED">
       The bank account is already verified.
     </Error>
@@ -481,15 +467,13 @@ The Bank Account balance, retrieved using Open Banking flows. The supported Bank
 
   If you're creating new interfaces, please work with [Verify Bank Account](#verify-bank-account).
 
-  ### Attributes
   <Properties>
     <Property name="verificationCode" type="string" required>
     	The code on the user’s bank statement.
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="BANK_ACCOUNT_ALREADY_VERIFIED">
       The bank account is already verified.
     </Error>
@@ -538,8 +522,6 @@ The Bank Account balance, retrieved using Open Banking flows. The supported Bank
 
   This endpoint allows you to list the Bank Accounts for an account.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/accounts/{accountId}/bank-accounts">
     ```bash
@@ -608,8 +590,6 @@ The Bank Account balance, retrieved using Open Banking flows. The supported Bank
 
   If you're creating new interfaces, please work with [List Bank Accounts](#list-bank-accounts).
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/bank-authorities">
     ```bash
@@ -669,7 +649,6 @@ The Bank Account balance, retrieved using Open Banking flows. The supported Bank
 
   Creating a Bank Authority both creates a new Bank Account and a direct debit authority. By using this endpoint, the user accepts our [Direct Debit terms](https://centrapay.com/directdebit-termsandconditions/) and has authority to operate this account.
 
-  ### Attributes
   <Properties>
     <Property name="accountId" type="string" required>
       The id of the owning Centrapay [Account](/api/accounts).
@@ -696,8 +675,7 @@ The Bank Account balance, retrieved using Open Banking flows. The supported Bank
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="BANK_AUTHORITY_LIMIT_EXCEEDED">
       The account already has the max amount of bank accounts.
     </Error>
@@ -754,11 +732,8 @@ The Bank Account balance, retrieved using Open Banking flows. The supported Bank
 
   If you're creating new interfaces, please work with [Get Bank Account](#get-bank-account).
 
-  ### Attributes
-  No attributes.
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="BANK_AUTHORITY_LIMIT_EXCEEDED">
       The account already has the max amount of bank accounts.
     </Error>

--- a/src/content/api/batch-types/farmlands-external-asset.mdx
+++ b/src/content/api/batch-types/farmlands-external-asset.mdx
@@ -22,7 +22,6 @@ Loads Farmlands Card data into Centrapay as external assets.
 
 Exported Farmlands Account used for importing and updating of a [Centrapay Asset](/api/assets/).
 
-### Attributes
 <Properties>
   <Property name="externalId" type="string">
     Id used for keeping imported Centrapay Asset up to date.
@@ -47,7 +46,6 @@ Exported Farmlands Account used for importing and updating of a [Centrapay Asset
 
 Exported Farmlands Contact and [Card](#card-model) information used for authentication, correspondence and payment.
 
-### Attributes
 <Properties>
   <Property name="externalId" type="string">
     Id used for keeping imported Centrapay Contact details up to date.
@@ -80,7 +78,6 @@ Exported Farmlands Contact and [Card](#card-model) information used for authenti
 
 Exported Farmlands Credit Card information used for importing and updating of a [Patron Code](/api/patron-codes).
 
-### Attributes
 <Properties>
   <Property name="externalId" type="string">
     Farmlands unique identifier for the card.

--- a/src/content/api/batch-types/verifone-terminal-status.mdx
+++ b/src/content/api/batch-types/verifone-terminal-status.mdx
@@ -19,7 +19,6 @@ Performs a bulk update to the current status for connected Verifone NZ payment t
 
 ## Terminal Status
 
-### Attributes
 <Properties>
   <Property name="status" type="string">
     Current terminal status: "active" or "inactive".

--- a/src/content/api/batches.mdx
+++ b/src/content/api/batches.mdx
@@ -17,7 +17,6 @@ Batches enable bulk loading of resource onto the Centrapay platform.
 
 ## Batch Model
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -91,7 +90,6 @@ The following table describes the Batch Types supported for loading.
 
   Initialize loading of entities from a batch file.
 
-  ### Attributes
   <Properties>
     <Property name="type" type="string" required>
       [Batch Type](#batch-types) used to describe the batch content.
@@ -110,8 +108,7 @@ The following table describes the Batch Types supported for loading.
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="LIVENESS_MISMATCH">
       accountId `test` flag is not the same as submitted Batch’s `test` flag.
     </Error>
@@ -160,8 +157,6 @@ The following table describes the Batch Types supported for loading.
 
   This endpoint allows you to retrieve a Batch by id.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/batches/{batchId}">
     ```bash

--- a/src/content/api/businesses.mdx
+++ b/src/content/api/businesses.mdx
@@ -16,7 +16,6 @@ A Business represents a company registered with the New Zealand Companies Office
 
 ## Business Model
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -101,7 +100,6 @@ A Business represents a company registered with the New Zealand Companies Office
 
 ## Tax Number Model
 
-### Attributes
 
 <Properties>
   <Property name="value" type="string">
@@ -123,7 +121,6 @@ A Business represents a company registered with the New Zealand Companies Office
 
   This endpoint allows you to create a new Business. If `accountId` is not provided when creating a Business, then a new org account will be created and associated to the Business.
 
-  ### Attributes
   <Properties>
     <Property name="nzbn" type="string" required>
       The unique NZBN identifier.
@@ -142,8 +139,7 @@ A Business represents a company registered with the New Zealand Companies Office
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INVALID_ACCOUNT">
       Account does not exist, is not authorized, is of the wrong type, or is not in the NZ region.
     </Error>
@@ -203,7 +199,6 @@ A Business represents a company registered with the New Zealand Companies Office
 
   This endpoint allows you to update a Business.
 
-  ### Attributes
   <Properties>
     <Property name="taxNumber" type="object">
       The value-added tax configuration.
@@ -214,8 +209,7 @@ A Business represents a company registered with the New Zealand Companies Office
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INVALID_ACCOUNT">
       Account does not exist, is not authorized, is of the wrong type, or is not in the NZ region.
     </Error>
@@ -275,8 +269,6 @@ A Business represents a company registered with the New Zealand Companies Office
 
   This endpoint allows you to retrieve a Business by account id.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/accounts/{accountId}/business">
     ```bash
@@ -314,8 +306,6 @@ A Business represents a company registered with the New Zealand Companies Office
 
   This endpoint returns a list of companies that match the queried param on company name, nzbn number or company number. Results are [paginated](/api/pagination) and ordered by relevance.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/nzbn-search">
     ```bash
@@ -350,8 +340,6 @@ A Business represents a company registered with the New Zealand Companies Office
 
   This endpoint allows you to retrieve a Business by account id.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/nzbn/{nzbn}">
     ```bash
@@ -402,7 +390,6 @@ A Business represents a company registered with the New Zealand Companies Office
 
   This endpoint returns allows you to set the [onboarding status](#onboarding-statuses) of a Business.
 
-  ### Attributes
   <Properties>
     <Property name="onboardingStatus" type="crn">
       The onboarding status of the Business. See [Onboarding Statuses](#onboarding-statuses) for possible values.

--- a/src/content/api/external-assets.mdx
+++ b/src/content/api/external-assets.mdx
@@ -23,7 +23,6 @@ External assets are [Assets](/api/assets/) which are issued by a third-party.
 
   Load an asset from a supported third-party issuer. Asset details will be obtained from the issuer.
 
-  ### Attributes
   <Properties>
     <Property name="accountId" type="string" required>
       The Centrapay account which will own the asset.
@@ -92,8 +91,7 @@ External assets are [Assets](/api/assets/) which are issued by a third-party.
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="UNKNOWN_ASSET">
       Asset id or PIN is incorrect.
     </Error>

--- a/src/content/api/funds-transfers.mdx
+++ b/src/content/api/funds-transfers.mdx
@@ -25,7 +25,6 @@ A funds transfer represents either a top up to or a withdrawal from a Centrapay 
 
   This endpoint allows you to create a topup.
 
-  ### Attributes
   <Properties>
     <Property name="amount" type="bignumber" required>
       Total amount of the transaction in cents
@@ -40,8 +39,7 @@ A funds transfer represents either a top up to or a withdrawal from a Centrapay 
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="BANK_AUTHORITY_WALLET_MISMATCH">
       The wallet and the bank account for the top up request do not belong to the same account.
     </Error>
@@ -111,8 +109,6 @@ A funds transfer represents either a top up to or a withdrawal from a Centrapay 
 
   This endpoint allows you to retrieve a Top Up by id.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/topups/{topupId}">
     ```bash
@@ -148,8 +144,6 @@ A funds transfer represents either a top up to or a withdrawal from a Centrapay 
 
   This endpoint allows you to list the Top Ups for authorized accounts.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/topups">
     ```bash
@@ -198,8 +192,6 @@ A funds transfer represents either a top up to or a withdrawal from a Centrapay 
 
   This endpoint allows you to list the Top Ups for an account.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/accounts/{accountId}/topups">
     ```bash
@@ -249,7 +241,6 @@ A funds transfer represents either a top up to or a withdrawal from a Centrapay 
 
   This endpoint allows you to create a withdrawal.
 
-  ### Attributes
   <Properties>
     <Property name="amount" type="bignumber" required>
       Total amount of the transaction in cents
@@ -264,8 +255,7 @@ A funds transfer represents either a top up to or a withdrawal from a Centrapay 
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="BANK_AUTHORITY_WALLET_MISMATCH">
       The wallet and the bank account for the withdrawal request do not belong to the same account.
     </Error>
@@ -324,11 +314,8 @@ A funds transfer represents either a top up to or a withdrawal from a Centrapay 
 
   This endpoint allows you to retrieve a Withdrawal by id.
 
-  ### Attributes
-  No attributes.
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="BANK_AUTHORITY_WALLET_MISMATCH">
       The wallet and the bank account for the withdrawal request do not belong to the same account.
     </Error>
@@ -381,8 +368,6 @@ A funds transfer represents either a top up to or a withdrawal from a Centrapay 
 
   This endpoint allows you to list the withdrawals for an Account.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/accounts/{accountId}/withdrawals">
     ```bash
@@ -434,11 +419,8 @@ A funds transfer represents either a top up to or a withdrawal from a Centrapay 
 
   This endpoint allows you to abort a Funds Transfer.
 
-  ### Attributes
-  No attributes.
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="ABORT_WITHDRAWAL_NOT_SUPPORTED">
       Aborting funds transfers of type `withdrawal` is not supported.
     </Error>

--- a/src/content/api/integration-requests.mdx
+++ b/src/content/api/integration-requests.mdx
@@ -16,7 +16,6 @@ An Integration Request allows Centrapay users to request the creation of an [Int
 
 ## Integration Request Model
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -115,7 +114,6 @@ An Integration Request allows Centrapay users to request the creation of an [Int
 
   This endpoint allows you to create an Integration Request.
 
-  ### Attributes
   <Properties>
     <Property name="merchantId" type="string" required>
       The [Merchant](/api/merchants) id for the Integration Request.
@@ -182,8 +180,6 @@ An Integration Request allows Centrapay users to request the creation of an [Int
 
   This endpoint allows you to get an Integration Request.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/integration-requests/{integrationRequestId}">
     ```bash
@@ -285,7 +281,6 @@ An Integration Request allows Centrapay users to request the creation of an [Int
 
   This endpoint allows you to supply configuration values for the Integration Request.
 
-  ### Attributes
   <Properties>
     <Property name="terminalId" type="string">
       Epay terminalId for the Integration Request. Required if type is `epay`.
@@ -335,8 +330,6 @@ An Integration Request allows Centrapay users to request the creation of an [Int
 
   This endpoint allows you to get the configuration values for the Integration Request.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/integration-requests/{integrationRequestId}/configs">
     ```bash
@@ -365,8 +358,6 @@ An Integration Request allows Centrapay users to request the creation of an [Int
 
   This endpoint allows you to activate an Integration Request.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="POST" path="/api/integration-requests/{integrationRequestId}/activate">
     ```bash
@@ -395,8 +386,7 @@ An Integration Request allows Centrapay users to request the creation of an [Int
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INTEGRATION_PARAM_MISSING">
       Integration Request needs updating with the required parameters before activating.
     </Error>
@@ -418,8 +408,6 @@ An Integration Request allows Centrapay users to request the creation of an [Int
 
   This endpoint allows you to delete an Integration Request.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="POST" path="/api/integration-requests/{integrationRequestId}">
     ```bash

--- a/src/content/api/invitations.mdx
+++ b/src/content/api/invitations.mdx
@@ -17,7 +17,6 @@ An Invitation can be used to allow users to claim ownership of a resource on the
 
 ## Invitation Model
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -93,7 +92,6 @@ An Invitation can be used to allow users to claim ownership of a resource on the
 
 ## Params Model
 
-### Attributes
 
 <Properties>
   <Property name="role" type="string">
@@ -115,7 +113,6 @@ An Invitation can be used to allow users to claim ownership of a resource on the
 
   This endpoint allows you to create an Invitation.
 
-  ### Attributes
   <Properties>
     <Property name="type" type="string" required>
       The type of invitation. Supported values are `account-membership`.
@@ -142,8 +139,7 @@ An Invitation can be used to allow users to claim ownership of a resource on the
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INVALID_ACCOUNT_TYPE">
       The resourceId is associated with an account with a non `org` type.
     </Error>
@@ -190,8 +186,6 @@ An Invitation can be used to allow users to claim ownership of a resource on the
 
   This endpoint allows you to retrieve an Invitation by code.
 
-  ### Attributes
-  No attributes.
 
   <RequestCodePanel slot="code-examples" filename="invitations-get-by-code" />
 
@@ -224,8 +218,6 @@ An Invitation can be used to allow users to claim ownership of a resource on the
 
   This endpoint allows you list Invitations for an Account.
 
-  ### Attributes
-  No attributes.
 
   <RequestCodePanel slot="code-examples" filename="invitations-list-by-accountId" />
 
@@ -286,7 +278,6 @@ An Invitation can be used to allow users to claim ownership of a resource on the
 
   This endpoint allows you to accept an Invitation.
 
-  ### Attributes
   <Properties>
     <Property name="code" type="string" required>
       The Invitation code.
@@ -297,8 +288,7 @@ An Invitation can be used to allow users to claim ownership of a resource on the
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INVITATION_EXPIRED">
       The Invitation is expired.
     </Error>
@@ -351,11 +341,7 @@ An Invitation can be used to allow users to claim ownership of a resource on the
 
   This endpoint allows you to revoke an Invitation.
 
-  ### Attributes
-  No attributes
-
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INVITATION_EXPIRED">
       The Invitation is expired.
     </Error>

--- a/src/content/api/legacy-payment-requests.mdx
+++ b/src/content/api/legacy-payment-requests.mdx
@@ -23,7 +23,6 @@ version (documented [Payment Requests](/api/payment-requests)) and the "legacy" 
 
 ## Payment Request Model <Badge type="deprecated"/>
 
-### Attributes
 
 <Properties>
   <Property name="requestId" type="string">
@@ -98,7 +97,6 @@ version (documented [Payment Requests](/api/payment-requests)) and the "legacy" 
 
 ## Payment Options Model <Badge type="deprecated"/>
 
-### Attributes
 
 <Properties>
   <Property name="ledger" type="string">
@@ -122,7 +120,6 @@ version (documented [Payment Requests](/api/payment-requests)) and the "legacy" 
 
 ## Paid By Model <Badge type="deprecated"/>
 
-### Attributes
 
 <Properties>
   <Property name="transactionId" type="string">
@@ -163,7 +160,6 @@ is returned with the payment request info as `payments[].ledger`.
 
   This endpoint allows you to create a Payment Request.
 
-  ### Attributes
   <Properties>
     <Property name="amount" type="number" required>
       The amount in the minimum divisible units of the denominated asset that would satisfy the payment.
@@ -246,8 +242,7 @@ is returned with the payment request info as `payments[].ledger`.
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="400" message="CHECKSUM_FAILED">
       `patronCode` luhn checksum digit doesn’t pass.
     </Error>
@@ -274,7 +269,6 @@ is returned with the payment request info as `payments[].ledger`.
 
   This endpoint allows you to receive Payment Request information.
 
-  ### Attributes
   <Properties>
     <Property name="requestId" type="string" required>
       The payment requestId that is generated when [requests.create](#create-a-payment-request) is called.
@@ -332,7 +326,6 @@ is returned with the payment request info as `payments[].ledger`.
 
   This endpoint allows you to pay a Payment Request.
 
-  ### Attributes
   <Properties>
     <Property name="requestId" type="string" required>
       The payment requestId that is generated when [requests.create](#create-a-payment-request) is called.
@@ -383,8 +376,7 @@ is returned with the payment request info as `payments[].ledger`.
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="REQUEST_EXPIRED">
       Action cannot be completed because the request has expired.
     </Error>
@@ -426,7 +418,6 @@ is returned with the payment request info as `payments[].ledger`.
 
   This endpoint allows you to cancel a Payment Request.
 
-  ### Attributes
   <Properties>
     <Property name="requestId" type="string" required>
       The payment requestId that is generated when [requests.create](#create-a-payment-request) is called.
@@ -460,8 +451,7 @@ is returned with the payment request info as `payments[].ledger`.
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="400" message="REQUEST_NOT_FOUND">
       The provided request doesn’t exist.
     </Error>
@@ -485,7 +475,6 @@ is returned with the payment request info as `payments[].ledger`.
 
   This endpoint allows you to void a Payment Request.
 
-  ### Attributes
   <Properties>
     <Property name="requestId" type="string" required>
       The payment requestId that is generated when [requests.create](#create-a-payment-request) is called.
@@ -510,12 +499,9 @@ is returned with the payment request info as `payments[].ledger`.
     ```
   </CodePanel>
 
-  ### Errors
-
-  Voiding a payment request can cause it to be cancelled or refunded. Therefore, this endpoint can give the same error responses as [requests.cancel](#cancel-a-payment-request) and [transactions.refund](#refund-a-transaction).
+  <Properties heading="Errors">
+    Voiding a payment request can cause it to be cancelled or refunded. Therefore, this endpoint can give the same error responses as [requests.cancel](#cancel-a-payment-request) and [transactions.refund](#refund-a-transaction).
   After 24 hours voiding a payment request will be disallowed, however a refund can still be made against the payment request if it has been paid successfully.
-
-  <Properties>
     <Error code="400" message="REQUEST_NOT_FOUND">
       The provided request doesn’t exist.
     </Error>
@@ -560,7 +546,6 @@ is returned with the payment request info as `payments[].ledger`.
 
   The legacy refund endpoint cannot be used to refund Pre Auth Payment Requests with Confirmations. Please use the [current refund endpoint](/api/payment-requests#refund-a-payment-request) instead.
 
-  ### Attributes
   <Properties>
     <Property name="transactionId" type="string" required>
       The transaction to refund. The transaction id for a payment can be obtained from a webhook notification or from [requests.info](#get-a-payment-request).

--- a/src/content/api/managed-integrations.mdx
+++ b/src/content/api/managed-integrations.mdx
@@ -16,7 +16,6 @@ A Managed Integration is an [Integration](/api/integrations)  which a third part
 
 ## Managed Integration Model
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -90,7 +89,6 @@ A Managed Integration is an [Integration](/api/integrations)  which a third part
 
 A summary of the [Invitation](/api/invitations) for a Managed Integration.
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -132,7 +130,6 @@ A summary of the [Invitation](/api/invitations) for a Managed Integration.
 
   This endpoint allows you to create or update a Managed Integration.
 
-  ### Attributes
   <Properties>
     <Property name="enabled" type="boolean" required>
       Flag indicating whether the Managed Integration should become active or inactive.
@@ -147,8 +144,7 @@ A summary of the [Invitation](/api/invitations) for a Managed Integration.
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="400" message="INVALID_PARAMS">
       Invalid [Params](#params) provided for Managed Integration type.
     </Error>
@@ -213,8 +209,6 @@ A summary of the [Invitation](/api/invitations) for a Managed Integration.
 
   This endpoint allows you to retrieve a Managed Integration by id.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/managed-integrations/{id}">
     ```bash

--- a/src/content/api/media-uploads.mdx
+++ b/src/content/api/media-uploads.mdx
@@ -13,7 +13,6 @@ import CodePanel from '../../components/CodePanel.astro';
 
 ## Media Upload Model
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -63,7 +62,6 @@ import CodePanel from '../../components/CodePanel.astro';
 
   This endpoint allows you to upload a media file to Centrapay. It returns a presigned URL that can be used to download the media file.
 
-  ### Attributes
   <Properties>
     <Property name="accountId" type="string" required>
       The Media Upload's owning Centrapay Account id.
@@ -112,8 +110,6 @@ import CodePanel from '../../components/CodePanel.astro';
 
   This endpoint allows you to retrieve the upload location of a media file.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/media-uploads/{mediaUploadId}/location">
     ```bash

--- a/src/content/api/merchant-configs.mdx
+++ b/src/content/api/merchant-configs.mdx
@@ -16,7 +16,6 @@ A Merchant Config defines the available payment options for paying a [Payment Re
 
 ## Merchant Config Model
 
-### Attributes
 
 <Properties>
   <Property name="paymentOptions" type="array">
@@ -48,7 +47,6 @@ A Merchant Config defines the available payment options for paying a [Payment Re
 
 ## Payment Option Config Model
 
-### Attributes
 <Properties>
   <Property name="type" type="string" required>
     Type of payment method. See supported payment types below.
@@ -97,7 +95,6 @@ See [Asset Types](/api/asset-types) for values that may be present in the `type`
 
   This endpoint allows you to create a Merchant Config for a Merchant.
 
-  ### Attributes
   <Properties>
     <Property name="paymentOptions" type="array" required>
       A list of [Payment Option Configs](#payment-option-config-model).
@@ -108,8 +105,7 @@ See [Asset Types](/api/asset-types) for values that may be present in the `type`
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INVALID_WALLET_TYPE">
       `walletId` does not belong to a [Settlement Wallet](/api/wallets#settlement-wallets).
     </Error>
@@ -182,8 +178,6 @@ See [Asset Types](/api/asset-types) for values that may be present in the `type`
 
   This endpoint allows you to retrieve a Merchant Config by id.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/merchants/{merchantId}/configs/{configId}">
     ```bash
@@ -222,8 +216,6 @@ See [Asset Types](/api/asset-types) for values that may be present in the `type`
 
   This endpoint allows you to retrieve a list of Merchant Configs.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/merchants/{merchantId}/configs">
     ```bash
@@ -277,7 +269,6 @@ See [Asset Types](/api/asset-types) for values that may be present in the `type`
 
   This endpoint allows you to update a Merchant Config.
 
-  ### Attributes
   <Properties>
     <Property name="paymentOptions" type="array" required>
       A list of [Payment Option Configs](#payment-option-config-model).
@@ -288,8 +279,7 @@ See [Asset Types](/api/asset-types) for values that may be present in the `type`
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INVALID_WALLET_TYPE">
       `walletId` does not belong to a [Settlement Wallet](/api/wallets#settlement-wallets).
     </Error>

--- a/src/content/api/merchants.mdx
+++ b/src/content/api/merchants.mdx
@@ -17,7 +17,6 @@ which define the payment methods available for a Payment Request.
 
 ## Merchant Model
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -99,7 +98,6 @@ which define the payment methods available for a Payment Request.
 
 ## Settlement Config Model
 
-### Attributes
 
 <Properties>
   <Property name="bankAccountId" type="string">
@@ -111,7 +109,6 @@ which define the payment methods available for a Payment Request.
 
 ## Merchant Search Result Model
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -135,7 +132,6 @@ which define the payment methods available for a Payment Request.
 
 ## Accepted Asset Model
 
-### Attributes
 
 <Properties>
   <Property name="assetType" type="string">
@@ -151,7 +147,6 @@ which define the payment methods available for a Payment Request.
 
 ## Product Model
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -169,7 +164,6 @@ which define the payment methods available for a Payment Request.
 
   This endpoint allows you to create a Merchant.
 
-  ### Attributes
   <Properties>
     <Property name="accountId" type="string" required>
       Id of Merchant's owning Centrapay account.
@@ -196,8 +190,7 @@ which define the payment methods available for a Payment Request.
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="BANK_ACCOUNT_MISMATCH">
       The bank account in the settlement config does not belong to the same account.
     </Error>
@@ -249,8 +242,6 @@ which define the payment methods available for a Payment Request.
 
   This endpoint allows you to retrieve a Merchant by id.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/merchants/{merchantId}">
     ```bash
@@ -287,8 +278,6 @@ which define the payment methods available for a Payment Request.
 
   This endpoint allows you to retrieve a [paginated](/api/pagination) list of Merchants attached to an Account.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/accounts/{accountId}/merchants">
     ```bash
@@ -341,7 +330,6 @@ which define the payment methods available for a Payment Request.
 
   This endpoint allows you to update a Merchant.
 
-  ### Attributes
   <Properties>
     <Property name="name" type="string">
       Merchant name.
@@ -356,8 +344,7 @@ which define the payment methods available for a Payment Request.
     </Property>
   </Properties>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="BANK_ACCOUNT_MISMATCH">
       The bank account in the settlement config does not belong to the same account.
     </Error>
@@ -422,7 +409,6 @@ which define the payment methods available for a Payment Request.
 
   This endpoint allows you to set the onboarding status of a Merchant.
 
-  ### Attributes
   <Properties>
     <Property name="onboardingStatus" type="string" required>
       The onboarding status of the Merchant. See [Onboarding Statuses](#onboarding-statuses) for possible values.
@@ -569,8 +555,6 @@ which define the payment methods available for a Payment Request.
 
   Returns a [paginated](/api/pagination) list of Merchants which belong to the authenticated subject.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/merchants">
     ```bash

--- a/src/content/api/patron-codes.mdx
+++ b/src/content/api/patron-codes.mdx
@@ -15,7 +15,6 @@ A Patron Code is an alternative to presenting a QR code where that option isn’
 
 ## Patron Code Model
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -101,8 +100,6 @@ be used with Payment Requests that will have a liveness of 'test'. The [Asset Ty
 
   This endpoint allows you to create a Patron Code. You can find payment request information attached to a Patron Code by [polling for the Payment Request](/api/payment-requests#get-a-payment-request-linked-to-a-patron-code) using the transacting APIs.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="POST" path="/api/patron-codes">
     ```bash
@@ -135,8 +132,6 @@ be used with Payment Requests that will have a liveness of 'test'. The [Asset Ty
 
   This endpoint allows you to retrieve a Patron Code by id.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/patron-codes/{patronCodeId}">
     ```bash
@@ -169,11 +164,8 @@ be used with Payment Requests that will have a liveness of 'test'. The [Asset Ty
 
   This endpoint allows you to retrieve a Patron Code by barcode.
 
-  ### Attributes
-  No attributes.
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="400" message="CHECKSUM_FAILED">
       Luhn checksum digit doesn't pass.
     </Error>

--- a/src/content/api/payment-requests.mdx
+++ b/src/content/api/payment-requests.mdx
@@ -31,7 +31,6 @@ Centrapay Payment Requests are serviced via two sets of endpoints; the â€œnextâ€
 
 ## Payment Request Model
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -160,7 +159,6 @@ Centrapay Payment Requests are serviced via two sets of endpoints; the â€œnextâ€
 
 ## Payment Option Model
 
-### Attributes
 
 <Properties>
   <Property name="assetType" type="string">
@@ -189,7 +187,6 @@ Centrapay Payment Requests are serviced via two sets of endpoints; the â€œnextâ€
 If a Payment Request contains a `centrapay.token.*` Payment Option, an array of Accepted Collections will be present inside the `centrapay.token` Payment Option.
 The Accepted Collections returned can be used to determine if a [Centrapay Token](/api/tokens) can be used to pay a Payment Request, and the Line Items able to be purchased using the Token.
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -214,7 +211,6 @@ Payment Request being cancelled.
 Conditions can either be [accepted](#accept-a-payment-condition) or [declined](#decline-a-payment-condition). If a condition is declined,
 the Payment Request will be cancelled.
 
-### Attributes
 
 <Properties>
   <Property name="id" type="bignumber">
@@ -241,7 +237,6 @@ The currency and units for a Line Item price will be consistent with the Payment
 Line items can include a discount amount.
 A discount that applies to multiple Line Items may be represented as a separate Line Item with a negative amount.
 
-### Attributes
 
 <Properties>
   <Property name="name" type="string">
@@ -277,7 +272,6 @@ A discount that applies to multiple Line Items may be represented as a separate 
 
 ## Product Classification
 
-### Attributes
 
 <Properties>
   <Property name="type" type="string">
@@ -305,7 +299,6 @@ A discount that applies to multiple Line Items may be represented as a separate 
 
 The Paid By provides a summary of the transactions after the Payment Request was paid.
 
-### Attributes
 
 <Properties>
   <Property name="assetTotals" type="array">
@@ -315,7 +308,6 @@ The Paid By provides a summary of the transactions after the Payment Request was
 
 ## Asset Totals
 
-### Attributes
 
 <Properties>
   <Property name="type" type="string">
@@ -342,7 +334,6 @@ The Paid By provides a summary of the transactions after the Payment Request was
 A Payment Activity records a transaction that has happened on a Payment Request.
 Payment Activities are created when a Payment Request has been `created`, `paid`, `refunded`, `cancelled`, or `expired`.
 
-### Attributes
 
 <Properties>
   <Property name="type" type="string">
@@ -449,7 +440,6 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
 
   This endpoint allows you to create a Payment Request.
 
-  ### Attributes
   <Properties>
     <Property name="configId" type="string" required>
       The [Merchant Config](/api/merchant-configs) id used to configure the payment options.
@@ -589,8 +579,7 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="400" message="LINE_ITEMS_SUM_CHECK_FAILED">
       The sum value of the line items did not equal the value of the Payment Request.
     </Error>
@@ -623,8 +612,6 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
 
   This endpoint allows you to retrieve a Payment Request.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/payment-requests/{paymentRequestId}">
     ```bash
@@ -721,8 +708,6 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
 
   This endpoint returns the latest Payment Request that matches the given short code.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/payment-requests/short-code/{shortCode}">
     ```bash
@@ -765,8 +750,7 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="400" message="CHECKSUM_FAILED">
       Luhn checksum digit doesn't pass.
     </Error>
@@ -789,8 +773,6 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
   This endpoint should be polled just after a user's Patron Code has been scanned. This will allow
   them to find the Payment Request and proceed to pay.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/me/patron-code-payment-request">
     ```bash
@@ -847,7 +829,6 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
   - Use `transactionId` to verify an external transaction such as a Bitcoin payment.
   - Use `authorization` to authorize an external transaction.
 
-  ### Attributes
   <Properties>
     <Property name="assetType" type="string" required>
       An [Asset Type](/api/asset-types) reference.
@@ -908,8 +889,7 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INVALID_ASSET_TYPE">
       Either the merchant is not configured with the provided asset type or the asset type does not exist.
     </Error>
@@ -954,7 +934,6 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
 
   This endpoint allows you to refund a Payment Request.
 
-  ### Attributes
   <Properties>
     <Property name="value" type="monetary" required>
       The canonical value of the Payment Request. Must be less than 100000000 and positive.
@@ -1015,8 +994,7 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="400" message="LINE_ITEMS_SUM_CHECK_FAILED">
       The sum value of the line items did not equal the value of the refund.
     </Error>
@@ -1067,8 +1045,6 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
 
   Voiding a payment request will cancel the request and trigger any refunds if necessary.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="POST" path="/api/payment-requests/{paymentRequestId}/void">
     ```bash
@@ -1100,8 +1076,7 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="VOID_WINDOW_EXCEEDED">
       The void window is closed 24 hours after the Payment Request `createdAt`. After the void window has closed if the Payment Request is paid, use [Refund](#refund-a-payment-request) endpoint to reverse the payment.
     </Error>
@@ -1142,8 +1117,6 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
   When you call release on a Pre Auth Payment Request any remaining funds that were being held for the authorization are returned to the asset, and a release Payment Activity is returned.
   If the authorization never completed, the Payment Request will instead be cancelled, and a cancellation Payment Activity will be returned.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="POST" path="/api/payment-requests/{paymentRequestId}/release">
     ```bash
@@ -1176,8 +1149,7 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INVALID_PAYMENT_REQUEST_TYPE">
       The Payment Request is not related to a Pre Auth.
     </Error>
@@ -1202,7 +1174,6 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
   If our endpoint does not respond, you must retry until you get back a 200 or 403.
   If we recive 2 requests with the same `idempotencyKey`, we won't process the second and return the first response.
 
-  ### Attributes
   <Properties>
     <Property name="idempotencyKey" type="string" required>
       This is an identifier from your system to enforce uniqueness.
@@ -1299,8 +1270,7 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INVALID_PAYMENT_REQUEST_TYPE">
       The Payment Request is not related to a Pre Auth.
     </Error>
@@ -1334,7 +1304,6 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
   This endpoint allows you to list [Payment Activities](#payment-activity-model) for a Merchant.
   Results are [paginated](/api/pagination/) and ordered by descending activity created date.
 
-  ### Attributes
   <Properties>
     <Property name="merchantId" type="string" required>
       The id of the [Merchant](/api/merchants/) the Payment Request is on behalf of.
@@ -1465,8 +1434,6 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
   This endpoint allows you to list [Payment Activities](#payment-activity-model) for a Payment Request.
   Results are ordered by descending activity created date.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/payment-requests/{paymentRequestId}/activities">
     ```bash
@@ -1549,8 +1516,6 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
   Accept a [Payment Condition](#payment-condition-model) listed in `merchantConditions` with status `awaiting-merchant`.
   Returns a [Payment Activity](#payment-activity-model).
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="POST" path="/api/payment-requests/{paymentRequestId}/conditions/{conditionId}/accept">
     ```bash
@@ -1581,8 +1546,7 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
     ```
   </CodePanel>
 
-    ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="PATRON_NOT_AUTHORIZED">
       The Payment Condition is `awaiting-merchant`, therefore the patron is not authorized to accept the condition.
     </Error>
@@ -1606,8 +1570,6 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
   Decline a [Payment Condition](#payment-condition-model) listed in `merchantConditions` with status `awaiting-merchant`.
   Returns a [Payment Activity](#payment-activity-model).
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="POST" path="/api/payment-requests/{paymentRequestId}/conditions/{conditionId}/decline">
     ```bash
@@ -1638,8 +1600,7 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
     ```
   </CodePanel>
 
-    ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="PATRON_NOT_AUTHORIZED">
       The Payment Condition is `awaiting-merchant`, therefore the patron is not authorized to decline the condition.
     </Error>

--- a/src/content/api/profiles.mdx
+++ b/src/content/api/profiles.mdx
@@ -17,7 +17,6 @@ A profile represents a Centrapay user's attributes.
 
 ## Profile Model
 
-### Attributes
 <Properties>
   <Property name="userId" type="string">
     The Centrapay user id.
@@ -66,7 +65,6 @@ A profile represents a Centrapay user's attributes.
 
   Update a user’s mutable attributes. At least one field must be provided in the request.
 
-  ### Attributes
   <Properties>
     <Property name="givenName" type="string">
       First name.
@@ -128,8 +126,6 @@ A profile represents a Centrapay user's attributes.
 
   This endpoint allows you to retrieve a user's Profile.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/users/{userId}/profile">
     ```bash

--- a/src/content/api/quotas.mdx
+++ b/src/content/api/quotas.mdx
@@ -16,7 +16,6 @@ Centrapay account quotas are enforced on usage types such as spending or topping
 
 ## Quota Model
 
-### Attributes
 
 <Properties>
   <Property name="type" type="string">
@@ -61,8 +60,6 @@ Centrapay account quotas are enforced on usage types such as spending or topping
 
   Retrieve quota limits and usages for the current intervals. Ie, all quotas for the current day, current month and current year as well as any quotas that are not associated with a temporal period.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/accounts/{accountId}/quotas">
     ```bash

--- a/src/content/api/scanned-codes.mdx
+++ b/src/content/api/scanned-codes.mdx
@@ -16,7 +16,6 @@ A scanned code is a barcode that a merchant scans. The code can be used to creat
 
 ## Scanned Code Model
 
-### Attributes
 
 <Properties>
   <Property name="code" type="string">
@@ -50,7 +49,6 @@ A scanned code is a barcode that a merchant scans. The code can be used to creat
 
   This endpoint allows you to decode a scanned code.
 
-  ### Attributes
   <Properties>
     <Property name="code" type="string" required>
       The utf8 representation of data decoded from what was scanned.
@@ -78,8 +76,7 @@ A scanned code is a barcode that a merchant scans. The code can be used to creat
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="UNKNOWN_CODE">
       The code doesn’t exist or is no longer active in our system.
     </Error>

--- a/src/content/api/settlements.mdx
+++ b/src/content/api/settlements.mdx
@@ -19,7 +19,6 @@ Settlements can only be created if the Merchant has a [Settlement Config](/api/m
 
 ## Settlement Model
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -73,8 +72,6 @@ Settlements can only be created if the Merchant has a [Settlement Config](/api/m
 
   This endpoint allows you to list Settlements.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/merchants/{merchantId}/settlements">
     ```bash

--- a/src/content/api/tokens.mdx
+++ b/src/content/api/tokens.mdx
@@ -22,7 +22,6 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
 
 ## Token Collection Model
 
-### Attributes
 
 <Properties>
   <Property name="name" type="string">
@@ -82,7 +81,6 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
 
 ## Token Expires After Model
 
-### Attributes
 
 <Properties>
   <Property name="period" type="string">
@@ -98,7 +96,6 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
 
 ## Redemption Condition Model <Badge type="experimental" />
 
-### Attributes
 
 <Properties>
   <Property name="merchantId" type="string">
@@ -130,7 +127,6 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
 
 ## Allowed Products Model <Badge type="experimental" />
 
-### Attributes
 <Properties>
   <Property name="sku" type="string">
     The SKU of the product that is to be accepted.
@@ -149,7 +145,6 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
 
 ## Token Model <Badge type="experimental" />
 
-### Attributes
 
 <Properties>
   <Property name="collectionId" type="string">
@@ -179,7 +174,6 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
 
   This endpoint allows you to create a [Token Collection](#token-collection-model).
 
-  ### Attributes
   <Properties>
       <Property name="name" type="string" required>
         The display name of the Collection.
@@ -265,7 +259,6 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
 
   Returns a [paginated](/api/pagination/) list of [Token Collections](#token-collection-model) for an Account.
 
-  ### Attributes
   <Properties>
     <Property name="pageKey" type="string">
       Used to retrieve the next page of items.
@@ -322,7 +315,6 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
 
   This endpoint allows you to create a [Redemption Condition](#redemption-condition-model).
 
-  ### Attributes
   <Properties>
     <Property name="merchantId" type="string">
       The identifier of the [Merchant](/api/merchants) that is accepting the collection.
@@ -392,8 +384,7 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="INVALID_AMOUNT">
       One or more of the maxValue amount in the products has exceeded the maxValue amount defined on the collection.
     </Error>
@@ -415,7 +406,6 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
 
   This endpoint allows you to create a Token.
 
-  ### Attributes
 
   <Properties>
   <Property name="collectionId" type="string" required>
@@ -472,9 +462,7 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
     ```
   </CodePanel>
 
-  ### Errors
-
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="TOKEN_ALREADY_CREATED">
       Token with supplied parameters already exists.
     </Error>

--- a/src/content/api/wallets.mdx
+++ b/src/content/api/wallets.mdx
@@ -20,7 +20,6 @@ A Settlement Wallet is a special type of Wallet that can only receive or refund 
 
 ## Wallet Model
 
-### Attributes
 
 <Properties>
   <Property name="id" type="string">
@@ -76,7 +75,6 @@ A Settlement Wallet is a special type of Wallet that can only receive or refund 
 
 ## Wallet Transaction Model
 
-### Attributes
 
 <Properties>
   <Property name="activityNumber" type="BigNumber">
@@ -142,7 +140,6 @@ A Settlement Wallet is a special type of Wallet that can only receive or refund 
 
   This endpoint allows you to create a Wallet.
 
-  ### Attributes
   <Properties>
     <Property name="accountId" type="string" required>
       The Wallets's owning Centrapay [Account](/api/accounts/) id.
@@ -189,8 +186,7 @@ A Settlement Wallet is a special type of Wallet that can only receive or refund 
     ```
   </CodePanel>
 
-  ### Errors
-  <Properties>
+  <Properties heading="Errors">
     <Error code="403" message="ACCOUNT_MAX_WALLETS_REACHED">
       The maximum number of wallets for the given ledger has been reached.
     </Error>
@@ -208,8 +204,6 @@ A Settlement Wallet is a special type of Wallet that can only receive or refund 
 
   This endpoint allows you to list authorized Wallets.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/wallets">
     ```bash
@@ -253,8 +247,6 @@ A Settlement Wallet is a special type of Wallet that can only receive or refund 
 
   This endpoint allows you to list Wallet Transactions.
 
-  ### Attributes
-  No attributes.
 
   <CodePanel slot="code-examples" title="Request" method="GET" path="/api/wallets/{walletId}/transactions">
     ```bash

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -17,13 +17,13 @@ import BaseLayout from '../layouts/BaseLayout.astro';
     </div>
     <div class="flex space-x-2 items-center">
       <a href="/">
-        <div
+        <button
           class="btn bg-interactive-primary border rounded-md"
         >
           <span class="type-caption-2 text-content-inverse-primary">
             Go back home
           </span>
-        </div>
+        </button>
       </a>
       <button
         id="freshdesk-contact-support-button"

--- a/src/utils/getElement.js
+++ b/src/utils/getElement.js
@@ -1,0 +1,11 @@
+export default function getElement(
+  selector,
+  Constructor,
+  parent,
+) {
+  const element = parent.querySelector(selector);
+  if (!(element instanceof Constructor)) {
+    throw new Error(`Element is not of type ${Constructor.name}: ${selector}`);
+  }
+  return element;
+}


### PR DESCRIPTION
Attributes and Error sections are collapsed by default to save space. If the user is interested in an endpoint they can expand these sections to show the descriptions of each entry.

Also removed the default styling from the <button> html tag as per this [pull request](https://bitbucket.org/centrapay/quartz/pull-requests/60?atlOrigin=eyJpIjoiMWRiZjlmZjhkYmE3NDg0Mzk3NWI3ODZhZjczNGQyODQiLCJwIjoiYmItY2hhdHMtaW50ZWdyYXRpb24ifQ).

The first commit is the functional change. The second is just updating existing markdown to adhere to the new format.

**Ticket Link:** https://www.notion.so/centrapay/Lanterns-d784e8a5f9fa44328a5d0ae1fd85d37e?p=8ca71f65a68f4139b5960554cc6bbbff&pm=s

**Test Plan:**
- [ ] Got to docs.centrapay.com/api/accounts and observe the expandable sections work as expected.
- [ ] There should not be any double ups of headings for the same section

**Screenshots:**

- Mobile collapsed

![image](https://github.com/centrapay/centrapay-docs/assets/70119888/7fd83cac-24fb-40ca-be97-d3dfcdcf032a)

- Mobile Expanded

![image](https://github.com/centrapay/centrapay-docs/assets/70119888/72456c24-5fea-4e5a-9e00-47445b64e311)

- Desktop Collapsed

![image](https://github.com/centrapay/centrapay-docs/assets/70119888/56090d58-9d5c-49dc-8594-17c2211a149d)

- Desktop Expanded

![image](https://github.com/centrapay/centrapay-docs/assets/70119888/08cae715-0d28-48f0-bf18-050c94176b92)

- Endpoint

![image](https://github.com/centrapay/centrapay-docs/assets/70119888/70f5dcac-4380-46cc-9fed-a8b9bf8ea802)

- Endpoint with Errors

![image](https://github.com/centrapay/centrapay-docs/assets/70119888/b3443d19-7f71-4495-b25b-4ee26c5d858b)
