### PR TITLE
Individual attributes collapsable

### DIFF
--- a/src/components/Error.astro
+++ b/src/components/Error.astro
@@ -1,15 +1,17 @@
 ---
 import Badge from '../components/Badge.astro';
+import Carat from './icons/Carat.vue';
 
 const { code, message } = Astro.props;
 ---
 
-<li class="not-prose m-0 p-0 flex flex-col py-4 first:pt-0 type-content-primary">
-  <div class="flex flex-row items-center space-x-3">
+<li data-attribute class="group not-prose m-0 p-0 flex flex-col py-4 first:pt-0 type-content-primary">
+  <button class="w-full relative flex flex-row items-center gap-x-3">
+    <Carat class="absolute -left-5 w-3 h-3 text-content-tertiary invisible" id="carat" data-carat />
     <h4 class="font-mono" id={message}>{message}</h4>
     <Badge text={code}></Badge>
-  </div>
-  <div data-expandable-slot class="transition-opacity duration-500 collapsed">
+  </button>
+  <div data-expandable class="transition-opacity duration-500 collapsed">
     <slot />
   </div>
 </li>

--- a/src/components/Properties.astro
+++ b/src/components/Properties.astro
@@ -10,7 +10,6 @@ const { heading = 'Attributes' } = Astro.props;
     </button>
   </div>
   <ul
-    data-attribute-list
     role="list"
     class="m-0 list-none border-y border-outline-transparent divide-y divide-outline-transparent p-0 pt-4"
   >
@@ -23,25 +22,40 @@ const { heading = 'Attributes' } = Astro.props;
 
   for (const attributesSection of document.querySelectorAll('[data-attributes]')) {
     const button = getElement('[data-expand-button]', HTMLButtonElement, attributesSection);
-    const attributeList = getElement('[data-attribute-list]', HTMLUListElement, attributesSection);
+    const expandables = Array.from(attributesSection.querySelectorAll('[data-expandable]'));
+    const carats = Array.from(attributesSection.querySelectorAll('[data-carat]'));
     button.addEventListener('click', () => {
-      button.textContent = button.innerText === 'EXPAND ALL' ? 'COLLAPSE ALL' : 'EXPAND ALL';
-      const expandables = attributeList.querySelectorAll('[data-expandable-slot]');
-      for (const expandable of expandables) {
-        if (expandable.classList.contains('collapsed')) {
-          expandable.classList.remove('collapsed');
-          expandable.classList.add('expanded');
-        } else {
-          expandable.classList.remove('expanded');
-          expandable.classList.add('collapsed');
-        }
+      if (button.innerText === 'EXPAND ALL') {
+        button.innerText = 'COLLAPSE ALL';
+        expandables.forEach(e => e.classList.replace('collapsed', 'expanded'));
+        carats.forEach(c => c.classList.add('expanded'));
+      } else {
+        button.innerText = 'EXPAND ALL';
+        expandables.forEach(e => e.classList.replace('expanded', 'collapsed'));
+        carats.forEach(c => c.classList.remove('expanded'));
       }
     });
+
+    const attributes = attributesSection.querySelectorAll('[data-attribute]');
+    for (const attribute of attributes) {
+      const carat = getElement('[data-carat]', SVGElement, attribute)
+      const expandable = getElement('[data-expandable]', HTMLDivElement, attribute);
+      attribute.addEventListener('click', () => {
+        if (expandable.classList.contains('expanded')) {
+          expandable.classList.replace('expanded', 'collapsed');
+          carat.classList.remove('expanded');
+        } else {
+          expandable.classList.replace('collapsed', 'expanded');
+          carat.classList.add('expanded');
+        }
+        button.innerText = expandables.every(e => e.classList.contains('expanded')) ? 'COLLAPSE ALL' : 'EXPAND ALL';
+      });
+    }
   }
 </script>
 
 <style is:global>
-  .expanded {
+  .expanded[data-expandable] {
     @apply
       pt-2
       opacity-100
@@ -49,11 +63,21 @@ const { heading = 'Attributes' } = Astro.props;
     ;
   }
 
-  .collapsed {
+  .collapsed[data-expandable] {
     @apply
       h-0
       opacity-0
       scale-y-0
     ;
+  }
+
+  .expanded[data-carat] {
+    @apply
+    rotate-90
+    ;
+  }
+
+  .group:hover #carat {
+    @apply visible;
   }
 </style>

--- a/src/components/Property.astro
+++ b/src/components/Property.astro
@@ -1,6 +1,6 @@
-
 ---
 import Badge from '../components/Badge.astro';
+import Carat from './icons/Carat.vue';
 
 const { name, type, required, experimental, deprecated } = Astro.props;
 const customDataTypes = ['timestamp', 'bignumber', 'monetary', 'crn', 'location', 'phonenumber'];
@@ -8,15 +8,16 @@ const formattedType = type.toLowerCase();
 const link = customDataTypes.includes(formattedType) ? '/api/data-types#' + formattedType :undefined;
 ---
 
-<li class="m-0 px-0 py-4 first:pt-0">
-  <div class="m-0 flex flex-wrap items-center gap-x-3">
+<li data-attribute class="group m-0 px-0 py-4 first:pt-0">
+  <button class="w-full relative m-0 flex flex-wrap items-center gap-x-3">
+    <Carat class="absolute -left-5 w-3 h-3 text-content-tertiary invisible" id="carat" data-carat />
     <h4 class="my-0" id={name}>{name}</h4>
     <Badge text={formattedType} link={link} />
     { required && <Badge type="required" /> }
     { experimental && <Badge type="experimental" /> }
     { deprecated && <Badge type="deprecated" /> }
-  </div>
-  <div data-expandable-slot class="w-full flex-none [&>:first-child]:mt-0 [&>:last-child]:mb-0 transition-opacity duration-500 collapsed">
+  </button>
+  <div data-expandable class="w-full flex-none [&>:first-child]:mt-0 [&>:last-child]:mb-0 transition-opacity duration-500 collapsed">
     <slot />
   </div>
 </li>


### PR DESCRIPTION
Added functionality for individual attributes to be collapsed by default and expand on click.

**Ticket:** https://www.notion.so/centrapay/Individual-attributes-expandable-6f0caabd385f47529007736ffad280bc?pvs=4

**Design:** https://www.figma.com/file/IgRlQWJTyGoZhlF4fVKD6B/Centrapay-Docs-(Tailwind)?type=design&node-id=1654-8412&mode=design&t=oTri02m3BIXILSXA-0

**Test Plan:**
- [ ] Go to docs.centrapay.com/api/accounts and use the collapsable sections. Make sure the expand/collapse functionality works as expected and the chevron is in the correct position on hover


**Screenshots:**

![image](https://github.com/centrapay/centrapay-docs/assets/70119888/b025f3f4-dd48-4908-b6c4-4b1949a0e938)

![image](https://github.com/centrapay/centrapay-docs/assets/70119888/91633dc3-2981-43ba-b49f-7f25ea15af1d)

![image](https://github.com/centrapay/centrapay-docs/assets/70119888/e54f2171-c67f-4a11-b140-552692a542da)


