### PR TITLE
WIP: Enable optional payload fields for code snippets

### DIFF
--- a/src/components/RequestCodePanel.astro
+++ b/src/components/RequestCodePanel.astro
@@ -1,11 +1,11 @@
 ---
-const { title = 'Request', filename } = Astro.props;
+const { title = 'Request', filename, optionalFields } = Astro.props;
 import { Code } from 'astro:components';
 import CodePanel from './CodePanel.astro';
 import createEndpoint from '../utils/createEndpoint.js';
 
 const file = await import(`../content/api/_endpoints/${filename}.js`);
-const endpoint = createEndpoint(file.default);
+const endpoint = createEndpoint({ endpoint: file.default, optionalFields });
 const theme = 'material-theme-darker';
 ---
 

--- a/src/content/api/_endpoints/payment-requests-create.js
+++ b/src/content/api/_endpoints/payment-requests-create.js
@@ -1,0 +1,46 @@
+export default {
+  method: 'POST',
+  path: '/api/payment-requests',
+  request: {
+    headers: {
+      'X-Api-Key': '<TOKEN>',
+      'Content-Type': 'application/json',
+    },
+    payload: {
+      required: {
+        configId: '5efbe2fb96c08357bb2b9242',
+        value: {
+          amount: '10000',
+          currency: 'NZD'
+        }
+      },
+      optional: {
+        barcode: '123456789',
+        conditionsEnabled: true,
+        patronNotPresent: true,
+        preAuth: true,
+        invoiceRef: 'sy8CRmo3sp3ArOpnfmb423',
+        purchaseOrderRef: 'oF6kj1QlH5gK0y9rjRHFh2',
+        lineItems: [
+          {
+            name: 'Hard Hat',
+            sku: 'GH1234',
+            qty: '1',
+            price: '4000',
+            tax: '15',
+            discount: '400'
+          },
+          {
+            name: 'Tool Belt',
+            sku: 'GH1234',
+            qty: '1',
+            price: '6000',
+            tax: '15',
+            discount: '600'
+          }
+        ],
+        redirectUrl: 'https://www.example.com/store/checkout',
+      }
+    },
+  },
+};

--- a/src/content/api/payment-requests.mdx
+++ b/src/content/api/payment-requests.mdx
@@ -9,6 +9,7 @@ import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';
 import Error from '../../components/Error.astro';
 import Endpoint from '../../components/Endpoint.astro';
+import RequestCodePanel from '../../components/RequestCodePanel.astro';
 import CodePanel from '../../components/CodePanel.astro';
 
 Payment Requests represent the intention for a merchant to receive payment for goods and services. Payment Requests define the amount to be paid and the Asset Types that are acceptable for payment.
@@ -503,21 +504,7 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
     </Property>
   </Properties>
 
-  <CodePanel slot="code-examples" title="Request" method="POST" path="/api/payment-requests">
-    ```bash
-    curl -X POST https://service.centrapay.com/api/payment-requests \
-      -H "X-Api-Key: $api_key" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "configId": "5efbe2fb96c08357bb2b9242",
-        "expirySeconds": "120",
-        "value": {
-          "amount": "1",
-          "currency": "NZD"
-        }
-      }'
-    ```
-  </CodePanel>
+  <RequestCodePanel slot="code-examples" filename="payment-requests-create" />
 
   <CodePanel slot="code-examples" title="Response">
     ```json

--- a/src/content/guides/ecommerce-website.mdx
+++ b/src/content/guides/ecommerce-website.mdx
@@ -5,24 +5,10 @@ nav:
   path: Reference/Merchant Integrations
   order: 12
 ---
-import CodePanel from '../../components/CodePanel.astro';
+import RequestCodePanel from '../../components/RequestCodePanel.astro';
 
 eCommerce websites accepting payments via Centrapay may want to redirect their users back to their website after they pay/cancel the payment request. In order to do this, the eCommerce website must add `allowedRedirectUrls` to it’s [Merchant Config](/api/merchant-configs).
 
 After `allowedRedirectUrls` have been added to the Merchant Config, the eCommerce website can simply pass in their `redirectUrl` when creating a [Payment Request](/api/payment-requests).
 
-<CodePanel title="Request" method="POST" path="/api/payment-requests">
-```bash
-curl -X POST https://service.centrapay.com/api/payment-requests \
-  -H "X-Api-Key: $api_key" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "configId": "5efbe2fb96c08357bb2b9242",
-    "value": {
-      "amount": "8991",
-      "currency": "NZD"
-    },
-    "redirectUrl": "https://www.example.com/store/checkout"
-  }'
-```
-</CodePanel>
+<RequestCodePanel filename="payment-requests-create" optionalFields={["redirectUrl"]} />

--- a/src/content/guides/farmlands-pos-integration.mdx
+++ b/src/content/guides/farmlands-pos-integration.mdx
@@ -8,6 +8,7 @@ nav:
   order: 2
 ---
 import CodePanel from '../../components/CodePanel.astro';
+import RequestCodePanel from '../../components/RequestCodePanel.astro';
 
 Centrapay and Farmlands have entered a partnership to enable a digital way for Farmlands Card Partners to accept Farmlands Card as payment at the point of sale. This solution will position Card Partners to be able to also accept a digital form of the Farmlands Card in the future.
 
@@ -63,42 +64,7 @@ sequenceDiagram
 
 2. The POS [creates a Payment Request](/api/payment-requests#create-a-payment-request) with the Farmlands Card barcode.
 
-  <CodePanel title="Request" method="POST" path="/api/payment-requests">
-    ```bash
-    curl -X POST https://service.centrapay.com/api/payment-requests \
-      -H "X-Api-Key: $api_key" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "barcode": "123456789",
-        "conditionsEnabled": true,
-        "configId": "5ee168e8597be5002af7b454",
-        "invoiceRef": "sy8CRmo3sp3ArOpnfmb423",
-        "lineItems": [
-          {
-            "name": "Hard Hat",
-            "sku": "GH1234",
-            "qty": "1",
-            "price": "4000",
-            "tax": "15",
-            "discount": "400"
-          },
-          {
-            "name": "Tool Belt",
-            "sku": "GH1234",
-            "qty": "1",
-            "price": "6000",
-            "tax": "15",
-            "discount": "600"
-          }
-        ],
-        "purchaseOrderRef": "oF6kj1QlH5gK0y9rjRHFh2",
-        "value": {
-          "amount": "10000",
-          "currency": "NZD"
-        }
-      }'
-    ```
-  </CodePanel>
+  <RequestCodePanel filename="payment-requests-create" optionalFields={["barcode", "conditionsEnabled", "invoiceRef", "lineItems", "purchaseOrderRef"]} />
 
   <CodePanel title="Response">
     ```json
@@ -437,41 +403,7 @@ Note over POS: ✅ Display Release confirmation
 1. The Cardholder presents their Farmlands Card for the POS to scan.
 2. The POS authorises a Pre Auth payment by [creating a Payment Request](/api/payment-requests#create-a-payment-request) with the barcode on the Farmlands Card and the `preauth` flag. Creating a Payment Request must also enable the [Payment Conditions](#payment-conditions) extension and include full details for all [Line Items](/api/payment-requests#line-item-model).
 
-  <CodePanel title="Request" method="POST" path="/api/payment-requests">
-    ```bash
-    curl -X POST https://service.centrapay.com/api/payment-requests \
-      -H "X-Api-Key: $api_key" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "barcode": "123456789",
-        "conditionsEnabled": true,
-        "configId": "5ee168e8597be5002af7b454",
-        "lineItems": [
-          {
-            "name": "Hard Hat",
-            "sku": "GH1234",
-            "qty": "1",
-            "price": "4000",
-            "tax": "15",
-            "discount": "400"
-          },
-          {
-            "name": "Tool Belt",
-            "sku": "GH1234",
-            "qty": "1",
-            "price": "6000",
-            "tax": "15",
-            "discount": "600"
-          }
-        ],
-        "preAuth": true,
-        "value": {
-          "amount": "10000",
-          "currency": "NZD"
-        }
-      }'
-    ```
-  </CodePanel>
+  <RequestCodePanel filename="payment-requests-create" optionalFields={["barcode", "conditionsEnabled", "lineItems", "preAuth"]} />
 
   <CodePanel title="Response">
     ```json
@@ -807,43 +739,7 @@ Please refer to your Farmlands Card Partner Acceptance Terms and Conditions to u
 
 Card Partners can extend the Barcode Flow to support this by [creating Payment Requests](/api/payment-requests#create-a-payment-request) with the `patronNotPresent` flag set to `true`.
 
-<CodePanel title="Request" method="POST" path="/api/payment-requests">
-```bash
-curl -X POST https://service.centrapay.com/api/payment-requests \
-  -H "X-Api-Key: $api_key" \
-  -H "Content-Type: application/json" \
-  -d '{
-    "barcode": "123456789",
-    "conditionsEnabled": true,
-    "configId": "5ee168e8597be5002af7b454",
-    "invoiceRef": "sy8CRmo3sp3ArOpnfmb423",
-    "lineItems": [
-      {
-        "name": "Hard Hat",
-        "sku": "GH1234",
-        "qty": "1",
-        "price": "4000",
-        "tax": "15",
-        "discount": "400"
-      },
-      {
-        "name": "Tool Belt",
-        "sku": "GH1234",
-        "qty": "1",
-        "price": "6000",
-        "tax": "15",
-        "discount": "600"
-      }
-    ],
-    "patronNotPresent": true,
-    "purchaseOrderRef": "oF6kj1QlH5gK0y9rjRHFh2",
-    "value": {
-      "amount": "10000",
-      "currency": "NZD"
-    }
-  }'
-```
-</CodePanel>
+<RequestCodePanel filename="payment-requests-create" optionalFields={["barcode", "conditionsEnabled", "invoiceRef", "lineItems", "patronNotPresent", "purchaseOrderRef"]} />
 
 > See also: [Patron Not Present](/guides/patron-not-present)
 

--- a/src/content/guides/merchant-integration-barcode-flow.mdx
+++ b/src/content/guides/merchant-integration-barcode-flow.mdx
@@ -7,6 +7,7 @@ nav:
   order: 4
 ---
 import CodePanel from '../../components/CodePanel.astro';
+import RequestCodePanel from '../../components/RequestCodePanel.astro';
 
 Connecting with patrons using our Barcode Flow requires the patron to present a Barcode and the merchant integration to scan it in order to [create a Payment Request](/api/payment-requests#create-a-payment-request).
 
@@ -42,21 +43,7 @@ sequenceDiagram
 1. The patron presents a Barcode for the POS to scan.
 2. The POS [creates a Centrapay Payment Request](/api/payment-requests#create-a-payment-request) with the Barcode.
 
-  <CodePanel title="Request" method="POST" path="/api/payment-requests">
-    ```bash
-    curl -X POST https://service.centrapay.com/api/payment-requests \
-      -H "X-Api-Key: $api_key" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "barcode": "123456789",
-        "configId": "5ee168e8597be5002af7b454",
-        "value": {
-          "amount": "10000",
-          "currency": "NZD"
-        }
-      }'
-    ```
-  </CodePanel>
+  <RequestCodePanel filename="payment-requests-create" optionalFields={["barcode"]} />
 
   <CodePanel title="Response">
     ```json
@@ -237,21 +224,7 @@ sequenceDiagram
 1. The patron presents a Barcode for the POS to scan.
 2. The POS [creates a Centrapay Payment Request](/api/payment-requests#create-a-payment-request) with the Barcode.
 
-  <CodePanel title="Request" method="POST" path="/api/payment-requests">
-    ```bash
-    curl -X POST https://service.centrapay.com/api/payment-requests \
-      -H "X-Api-Key: $api_key" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "barcode": "123456789",
-        "configId": "5ee168e8597be5002af7b454",
-        "value": {
-          "amount": "10000",
-          "currency": "NZD"
-        }
-      }'
-    ```
-  </CodePanel>
+  <RequestCodePanel filename="payment-requests-create" optionalFields={["barcode"]} />
 
   <CodePanel title="Response">
     ```json
@@ -413,21 +386,7 @@ sequenceDiagram
 
 3. The POS [creates a Payment Request](/api/payment-requests#create-a-payment-request) with the barcode and continues with either the [Barcode Flow](#barcode-flow) or [Quick Pay Flow](#quick-pay-flow).
 
-  <CodePanel title="Request" method="POST" path="/api/payment-requests">
-    ```bash
-    curl -X POST https://service.centrapay.com/api/payment-requests \
-      -H "X-Api-Key: $api_key" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "barcode": "123456789",
-        "configId": "5ee168e8597be5002af7b454",
-        "value": {
-          "amount": "10000",
-          "currency": "NZD"
-        }
-      }'
-    ```
-  </CodePanel>
+  <RequestCodePanel filename="payment-requests-create" optionalFields={["barcode"]} />
 
   <CodePanel title="Response">
     ```json

--- a/src/content/guides/merchant-integration-qr-code-flow.mdx
+++ b/src/content/guides/merchant-integration-qr-code-flow.mdx
@@ -7,6 +7,7 @@ nav:
   order: 3
 ---
 import CodePanel from '../../components/CodePanel.astro';
+import RequestCodePanel from '../../components/RequestCodePanel.astro';
 
 Connecting with patrons using our QR Code Flow requires the merchant integration to create a [Payment Request](/api/payment-requests) and present a QR Code for the patron to scan.
 
@@ -42,20 +43,7 @@ sequenceDiagram
 
   > The QR code decodes to a URL of the form `https://service.centrapay.com/api/payment-requests/{paymentRequestId}/pay`
 
-  <CodePanel title="Request" method="POST" path="/api/payment-requests">
-    ```bash
-    curl -X POST https://service.centrapay.com/api/payment-requests \
-      -H "X-Api-Key: $api_key" \
-      -H "Content-Type: application/json" \
-      -d '{
-        "configId": "5ee168e8597be5002af7b454",
-        "value": {
-          "amount": "10000",
-          "currency": "NZD"
-        }
-      }'
-    ```
-  </CodePanel>
+  <RequestCodePanel filename="payment-requests-create" />
 
   <CodePanel title="Response">
     ```json

--- a/src/content/guides/patron-not-present.mdx
+++ b/src/content/guides/patron-not-present.mdx
@@ -5,35 +5,10 @@ nav:
   path: Reference/Merchant Integrations
   order: 11
 ---
-import CodePanel from '../../components/CodePanel.astro';
+import RequestCodePanel from '../../components/RequestCodePanel.astro';
 
 Centrapay’s Patron Not Present extension allows a merchant to complete a payment when the patron is not physically present at the time of payment (e.g. phone-based orders).
 
 You can enable this extension by [creating a Payment Request](/api/payment-requests#create-a-payment-request) with the `patronNotPresent` flag set to true.
 
-<CodePanel title="Request" method="POST" path="/api/payment-requests">
-  ```bash
-  curl -X POST https://service.centrapay.com/api/payment-requests \
-    -H "X-Api-Key: $api_key" \
-    -H "Content-Type: application/json" \
-    -d '{
-      "barcode": "123456789",
-      "configId": "5ee168e8597be5002af7b454",
-      "lineItems": [
-        {
-          "name": "Tool Belt",
-          "sku": "GH1234",
-          "qty": "1",
-          "price": "6000",
-          "tax": "15",
-          "discount": "600"
-        }
-      ],
-      "patronNotPresent": true,
-      "value": {
-        "amount": "6000",
-        "currency": "NZD"
-      }
-    }'
-  ```
-</CodePanel>
+<RequestCodePanel filename="payment-requests-create" optionalFields={["barcode", "lineItems", "patronNotPresent"]} />

--- a/src/utils/createEndpoint.js
+++ b/src/utils/createEndpoint.js
@@ -38,8 +38,20 @@ function createSnippet(data) {
   return new HTTPSnippet(harObject);
 }
 
-function createRequests(data) {
-  const snippet = createSnippet(data);
+function createPayload({ payload, optionalFields = [] }) {
+  const { required, optional } = payload;
+  const result = { ...required };
+  optionalFields.forEach(field => {
+    if (optional[field] !== undefined) {
+      result[field] = optional[field];
+    }
+  });
+  return result;
+}
+
+function createRequests({ endpoint, optionalFields }) {
+  const payload = createPayload({ payload: endpoint.request.payload, optionalFields });
+  const snippet = createSnippet({ ...endpoint, request: { ...endpoint.request, payload }});
   const requests = {};
   Object.entries(supportedClients).forEach(([clientId, details]) => {
     requests[clientId] = {
@@ -50,11 +62,11 @@ function createRequests(data) {
   return requests;
 }
 
-export default function createEndpoint(data) {
-  validateData(data);
+export default function createEndpoint({ endpoint, optionalFields }) {
+  validateData(endpoint);
   return {
-    path: data.path,
-    method: data.method,
-    requests: createRequests(data),
+    path: endpoint.path,
+    method: endpoint.method,
+    requests: createRequests({ endpoint, optionalFields }),
   };
 }


### PR DESCRIPTION
Spike example for being able to create variations of the same API call in the guides.