### PR TITLE
🐛 Fix HTTP method for listing API keys

### DIFF
--- a/src/content/api/_endpoints/api-keys-list.js
+++ b/src/content/api/_endpoints/api-keys-list.js
@@ -1,5 +1,5 @@
 export default {
-  method: 'POST',
+  method: 'GET',
   path: '/api/accounts/Jaim1Cu1Q55uooxSens6yk/api-keys',
   request: {
     headers: {


### PR DESCRIPTION
Expect method to be GET.