### PR TITLE
🐛 Fix link for Epay website

### DIFF
--- a/src/content/api/asset-types.mdx
+++ b/src/content/api/asset-types.mdx
@@ -11,19 +11,19 @@ The following table describes the Asset Types supported for payments.
 The Category column refers to the Centrapay asset type representation if
 applicable. When blank, the Asset is not managed by a Centrapay Account.
 
-|   Asset Type    |                Description                |                Category                 |          Currencies           |  Flags   |
-| :-------------- | :---------------------------------------- | :-------------------------------------- | :---------------------------- | :------- |
-| bitcoin         | [Bitcoin](https://bitcoin.org/en/)        |                                         | `NZD` `AUD`                   | ⚡️       |
-| cca.coke        | Coke tokens                               | [Token](/api/assets#token-model)        | `NZD`                         | ⚡️ 🧪 🚫   |
-| centrapay.nzd   | Centrapay NZD wallet                      | [Money](/api/assets#money-model)        | `NZD`                         | ⚡️ 🧪     |
-| centrapay.token | Centrapay tokens                          | [Token](/api/assets#token-model)        | `NZD`                         | ⚡️ 🧪     |
-| epay.nzd        | EPay NZ giftcards                         | [Giftcard](/api/assets#gift-card-model) | `NZD`                         | ⚡️ 🧪     |
-| farmlands.nzd   | [Farmlands](https://www.farmlands.co.nz/) | [Money](/api/assets#money-model)        | `NZD`                         | ⚡️ 🧪 💸 💼 |
-| paypal          | [PayPal](https://www.paypal.com/)         |                                         | `USD`                         | ⚡️ 🧪 💸   |
-| quartz.nzd      | Quartz NZD asset                          |                                         | `NZD`                         | ⚡️ 🧪     |
-| venmo           | [Venmo](https://venmo.com/)               |                                         | `USD`                         | ⚡️ 🧪 💸   |
-| uplinkapi       | Uplink API Test asset                     |                                         | `NZD`                         | 🧪        |
-| stadius         | [Stadius](https://stadius.io)             |                                         | `NZD` `AUD` `USD` `CAD` `EUR` | ⚡️ 🧪     |
+|   Asset Type    |                   Description                   |                Category                 |          Currencies           |  Flags   |
+| :-------------- | :---------------------------------------------- | :-------------------------------------- | :---------------------------- | :------- |
+| bitcoin         | [Bitcoin](https://bitcoin.org/en/)              |                                         | `NZD` `AUD`                   | ⚡️       |
+| cca.coke        | Coke tokens                                     | [Token](/api/assets#token-model)        | `NZD`                         | ⚡️ 🧪 🚫   |
+| centrapay.nzd   | Centrapay NZD wallet                            | [Money](/api/assets#money-model)        | `NZD`                         | ⚡️ 🧪     |
+| centrapay.token | Centrapay tokens                                | [Token](/api/assets#token-model)        | `NZD`                         | ⚡️ 🧪     |
+| epay.nzd        | [EPay NZ giftcards](https://epayworldwide.com/) | [Giftcard](/api/assets#gift-card-model) | `NZD`                         | ⚡️ 🧪     |
+| farmlands.nzd   | [Farmlands](https://www.farmlands.co.nz/)       | [Money](/api/assets#money-model)        | `NZD`                         | ⚡️ 🧪 💸 💼 |
+| paypal          | [PayPal](https://www.paypal.com/)               |                                         | `USD`                         | ⚡️ 🧪 💸   |
+| quartz.nzd      | Quartz NZD asset                                |                                         | `NZD`                         | ⚡️ 🧪     |
+| venmo           | [Venmo](https://venmo.com/)                     |                                         | `USD`                         | ⚡️ 🧪 💸   |
+| uplinkapi       | Uplink API Test asset                           |                                         | `NZD`                         | 🧪        |
+| stadius         | [Stadius](https://stadius.io)                   |                                         | `NZD` `AUD` `USD` `CAD` `EUR` | ⚡️ 🧪     |
 
 
 ### Flags

--- a/src/content/api/integration-requests.mdx
+++ b/src/content/api/integration-requests.mdx
@@ -96,7 +96,7 @@ An Integration Request allows Centrapay users to request the creation of an [Int
 
 |   Name   |                        Description                         |
 | -------- | ---------------------------------------------------------- |
-| epay     | Asset provider [ePay](https://www.epay.com/)               |
+| epay     | Asset provider [ePay](https://epayworldwide.com/)          |
 | invenco  | Terminal vendor [invenco](https://www.invenco.com/)        |
 | skyzer   | Terminal vendor [skyzer](https://www.skyzer.co.nz)         |
 | smartpay | Terminal vendor [smartpay](https://www.smartpay.co.nz)     |


### PR DESCRIPTION
Related report: https://centrapay.slack.com/archives/CLBD7HMJN/p1701224823559859

Test plan: Expect redirect to https://epayworldwide.com/