### PR TITLE
Fix desktop nav scroll

### DIFF
--- a/src/components/AppShell.astro
+++ b/src/components/AppShell.astro
@@ -1,0 +1,15 @@
+---
+import Header from './Header.vue';
+import DesktopNavigation from './DesktopNavigation.astro';
+const { path, navigation } = Astro.props;
+
+const navPath = path.endsWith('/') ? path.slice(0, -1) : path;
+---
+
+<div class="flex h-screen w-screen">
+  <Header client:load path={navPath} navigation={navigation} />
+  <DesktopNavigation path={navPath} navigation={navigation} />
+  <main class="flex flex-col min-h-full w-full pt-16 md:pl-64 xl:pl-80">
+    <slot />
+  </main>
+</div>

--- a/src/components/DesktopNavigation.astro
+++ b/src/components/DesktopNavigation.astro
@@ -1,0 +1,49 @@
+---
+import PrimarySidebarDisclosure from './PrimarySidebarDisclosure.vue';
+import PageLinks from './PageLinks.vue';
+const { path, navigation } = Astro.props;
+---
+<div
+  id="sidebar"
+  class="hidden md:fixed md:h-full md:flex md:w-64 xl:w-80 md:flex-col"
+>
+  <div class="sidebar-content flex flex-grow flex-col mt-16 py-5 overflow-y-auto border-r border-gray-200 bg-white">
+    <nav
+      class="space-y-1 px-4"
+      aria-label="Sidebar"
+    >
+      <ul role="menubar">
+        {
+          navigation.items.map((section) => (
+            section.children?.length ?
+              <PrimarySidebarDisclosure
+                client:load
+                navigationItem={section}
+                path={path}
+              /> :
+              <PageLinks
+                client:load
+                navigationItem={section}
+                path={path}
+                level="1"
+              />
+          ))
+        }
+      </ul>
+    </nav>
+  </div>
+</div>
+
+<script is:inline>
+  const leftSidebar = document.querySelector('#sidebar > .sidebar-content');
+  const leftSidebarScroll = localStorage.getItem('sidebar-scroll');
+
+  if (leftSidebarScroll !== null) {
+    const scroller = leftSidebarScroll > 1000 ? 1000 : leftSidebarScroll;
+    leftSidebar.scrollTop = parseInt(scroller, 10);
+  }
+
+  window.addEventListener('beforeunload', () => {
+    localStorage.setItem('sidebar-scroll', leftSidebar.scrollTop);
+  });
+</script>

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="flex h-screen w-screen">
+  <div>
     <TransitionRoot
       as="template"
       :show="mainMenuOpen"
@@ -20,9 +20,8 @@
           >
             <DialogPanel class="relative flex w-full flex-1 flex-col bg-surface-primary">
               <div class="h-0 flex-1 overflow-y-auto pt-5 pb-4">
-                <SiteNavigation
+                <MobileNavigation
                   :path="navPath"
-                  :base-url="baseUrl"
                   :navigation="navigation"
                 />
               </div>
@@ -96,21 +95,6 @@
         </div>
       </div>
     </div>
-
-    <!-- Static sidebar for desktop -->
-    <div class="hidden md:fixed md:h-full md:flex md:w-64 xl:w-80 md:flex-col">
-      <div class="flex flex-grow flex-col mt-16 py-5 overflow-y-auto border-r border-gray-200 bg-white">
-        <SiteNavigation
-          :base-url="baseUrl"
-          :path="navPath"
-          :navigation="navigation"
-        />
-      </div>
-    </div>
-
-    <main class="flex flex-col min-h-full w-full pt-16 md:pl-64 xl:pl-80">
-      <slot />
-    </main>
   </div>
 </template>
 
@@ -120,7 +104,7 @@ import SearchLogo from '../components/icons/Search.vue';
 import CentrapayLogo from '../components/icons/CentrapayLogo.vue';
 import CloseOutline from '../components/icons/CloseOutline.vue';
 import NavigationMenu from '../components/icons/NavigationMenu.vue';
-import SiteNavigation from '../components/SiteNavigation.vue';
+import MobileNavigation from '../components/MobileNavigation.vue';
 import CommandPalette from '../components/CommandPalette.vue';
 import {
   Dialog,
@@ -131,7 +115,6 @@ import {
 
 const props = defineProps({
   path: { type: [String, undefined], required: false, default: undefined },
-  baseUrl: { type: String, required: true },
   navigation: { type: Object, required: true },
 });
 

--- a/src/components/MobileNavigation.vue
+++ b/src/components/MobileNavigation.vue
@@ -27,11 +27,9 @@
 <script setup>
 import PrimarySidebarDisclosure from './PrimarySidebarDisclosure.vue';
 import PageLinks from './PageLinks.vue';
-import Settings from './icons/Settings.vue';
 
 const props = defineProps({
   path: { type: [String, undefined], required: false, default: '' },
   navigation: { type: Object, required: true },
-  baseUrl: { type: String, required: true },
 });
 </script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,5 @@
 ---
-import AppShell from '../components/AppShell.vue';
+import AppShell from '../components/AppShell.astro';
 import MessagesBubbleDouble from '../components/icons/MessagesBubbleDouble.vue';
 import Footer from '../components/Footer.vue';
 import '../assets/css/tailwind.css';
@@ -87,7 +87,7 @@ const navigation = Navigation.create({ nav: sideNavConfig, content });
     <header>
     </header>
     <div class="flex flex-col h-screen w-screen">
-      <AppShell client:load path={Astro.url.pathname} baseUrl={Astro.url.origin} navigation={navigation}>
+      <AppShell path={Astro.url.pathname} navigation={navigation}>
         <slot />
         <button
           id="freshdesk-button"


### PR DESCRIPTION
This PR fixes the nav bar on desktop resetting whenever a page is loaded.

Testing steps:

- [ ] Navigate to a page on docs site
- [ ] Scroll the navigation on desktop
- [ ] Click a link in the navigation
- [ ] See the the scroll level isn't reset