### PR TITLE
🔧 Fix astro lint

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -23,8 +23,6 @@ parser: vue-eslint-parser
 
 parserOptions:
   parser: "@babel/eslint-parser"
-  babelOptions:
-    presets: ["@babel/preset-react"]
   ecmaVersion: 2020
   sourceType: module
   requireConfigFile: false
@@ -52,6 +50,9 @@ rules:
 overrides:
   - files: ["*.astro"]
     parser: "astro-eslint-parser"
+    parserOptions:
+      babelOptions:
+        presets: ["@babel/preset-react"]
   - files: [ "**/*.test.js" ]
     globals:
       global: readonly


### PR DESCRIPTION
On endpoint files I was getting the error: Parsing error: Cannot find module '@babel/preset-react'.
This library should just be used when linting astro files.