### PR TITLE
Attributes expanded by default

### DIFF
--- a/src/components/Properties.astro
+++ b/src/components/Properties.astro
@@ -6,7 +6,7 @@ const { heading = 'Attributes' } = Astro.props;
   <div class="flex justify-between items-center not-prose py-2">
     <h3 class="type-subtitle-1">{ heading }</h3>
     <button data-expand-button class="text-content-tertiary type-overline hover:text-content-secondary">
-      Expand all
+      Collapse all
     </button>
   </div>
   <ul

--- a/src/components/Property.astro
+++ b/src/components/Property.astro
@@ -16,7 +16,7 @@ const link = customDataTypes.includes(formattedType) ? '/api/data-types#' + form
     { experimental && <Badge type="experimental" /> }
     { deprecated && <Badge type="deprecated" /> }
   </div>
-  <div data-expandable-slot class="w-full flex-none [&>:first-child]:mt-0 [&>:last-child]:mb-0 transition-opacity duration-500 collapsed">
+  <div data-expandable-slot class="w-full flex-none [&>:first-child]:mt-0 [&>:last-child]:mb-0 transition-opacity duration-500 expanded">
     <slot />
   </div>
 </li>


### PR DESCRIPTION
We decided to expand attributes by default for now until we have an implementation for individual attributes to be expandable.

![image](https://github.com/centrapay/centrapay-docs/assets/70119888/3bab1b52-e0a3-419b-aa6d-2c8697865546)


**Test Plan:**
- [ ] docs.centrapay.com/api/accounts and assert attributes are expanded by default
- [ ] Assert the collapse/expand all button still works