### PR TITLE
add docs for new enduring consent and asset attributes

### DIFF
--- a/src/content/api/assets.mdx
+++ b/src/content/api/assets.mdx
@@ -64,6 +64,10 @@ and the model may change.
   <Property name="meta" type="object" experimental="true">
     Additional data that may only appear in the [Get Asset](#get-asset) response.
   </Property>
+
+  <Property name="name" type="string" experimental="true">
+    The name of the asset when created from an [enduring payment consent](/api/bank-account-connection-intents#bank-account-connection-intent-types). Only valid for `quartz.nzd` assets.
+  </Property>
 </Properties>
 
 ---

--- a/src/content/api/bank-account-connection-intents.mdx
+++ b/src/content/api/bank-account-connection-intents.mdx
@@ -57,6 +57,10 @@ A Bank Account Connection Intent facilitates user authorization of access to Ban
   <Property name="test" type="boolean">
     A flag which is present if the intention is to connect with a [Bank Account](/api/bank-accounts) used for testing.
   </Property>
+
+  <Property name="name" type="string">
+      The name of the consent. Only present if type is `enduring-payment-consent`.
+    </Property>
 </Properties>
 
 ### Bank Account Connection Intent Types
@@ -91,6 +95,22 @@ A Bank Account Connection Intent facilitates user authorization of access to Ban
 
     <Property name="test" type="boolean">
       A flag which is present if the intention is to connect with a [Bank Account](/api/bank-accounts/) used for testing.
+    </Property>
+
+    <Property name="name" type="string">
+      The name of the consent. Only valid if type is `enduring-payment-consent`.
+    </Property>
+
+    <Property name="expiresAt" type="timestamp">
+      The date that the consent is valid until. Only valid if type is `enduring-payment-consent`.
+    </Property>
+
+    <Property name="totalTransactions" type="number">
+      The total number of transactions the consent can be used for. Only valid if type is `enduring-payment-consent`.
+    </Property>
+
+    <Property name="totalAmount" type="monetary">
+      The total cent value of transactions the consent can be used for. Only valid if type is `enduring-payment-consent`.
     </Property>
   </Properties>
 


### PR DESCRIPTION
Updated attributes on create bank account connection intent route: 
![image](https://github.com/centrapay/centrapay-docs/assets/69737582/1eca0315-c232-42d8-a4a6-8d5c2f8cc892)
New name attribute on Asset model: 
![image](https://github.com/centrapay/centrapay-docs/assets/69737582/ffaabc95-7fa8-404f-81f8-6693d5c95bfd)
New name attribute on bank account connection intent model: 
![image](https://github.com/centrapay/centrapay-docs/assets/69737582/ac641a12-8486-439b-8aef-9b12741cb519)

