### PR TITLE
Fix spelling mistakes in our guides

### DIFF
--- a/src/content/guides/creating-test-money.mdx
+++ b/src/content/guides/creating-test-money.mdx
@@ -19,7 +19,7 @@ The test assets can be created via either the Centrapay API or the Centrapay app
 To create test dollars via the Centrapay API:
 
 1. Add email to Centrapay profile: If not already configured, set an email on your Centrapay user profile via the [update profile endpoint](/api/profiles/#update-profile).
-2. Create a test bank account: Create a bank account, using “00-“ as the bank account number prefx, via the [create bank account endpoint](/api/bank-accounts/#create-bank-account).
+2. Create a test bank account: Create a bank account, using “00-“ as the bank account number prefix, via the [create bank account endpoint](/api/bank-accounts/#create-bank-account).
 3. Create a test topup: Use the test bank account id to topup up via the [topup endpoint](/api/funds-transfers/#create-a-top-up). The topup *must* be created with a Centrapay user (ie: authenticated with JWT, not an API key) in order for the transaction email notification to be delivered.
 4. Verify the bank account: Post the 4-digit code from the test transaction confirmation email, along with the test bank account id, to the [verify bank account endpoint](/api/bank-accounts/#verify-bank-account).
 

--- a/src/content/guides/integrating-third-party-asset.mdx
+++ b/src/content/guides/integrating-third-party-asset.mdx
@@ -124,8 +124,8 @@ To verify a request start by decoding the JWT.
 
 |        Field        |                                                Description                                                |
 | ------------------- | --------------------------------------------------------------------------------------------------------- |
-| iat                 | An Unix timestap of the request's creation.                                                               |
-| exp                 | An Unix timestap that the request is vaild until. Set to 5 minutes after iat.                             |
+| iat                 | An Unix timestamp of the request's creation.                                                               |
+| exp                 | An Unix timestamp that the request is valid until. Set to 5 minutes after iat.                             |
 | aud                 | The Uplink API URL belonging to the intended recipient of the request.                                    |
 | request_body_sha256 | A hash of the request payload, created using the [SHA256 algorithm](https://en.wikipedia.org/wiki/SHA-2). |
 
@@ -184,18 +184,18 @@ An idempotency key is used for `HTTP POST` requests. Centrapay **does not** guar
 
 | Name           | Type                                                            | Necessity | Description                                                                                              |
 | -------------- | --------------------------------------------------------------- | --------- | -------------------------------------------------------------------------------------------------------- |
-| currency       | String                                                          | required  | The three letter [ISO curreny code](https://en.wikipedia.org/wiki/ISO_4217) for the payment.             |
+| currency       | String                                                          | required  | The three letter [ISO currency code](https://en.wikipedia.org/wiki/ISO_4217) for the payment.             |
 | amount         | String                                                          | required  | The value required to pay in the smallest denomination for the supported currency (e.g. cents).          |
 | authorization  | String                                                          | required  | A reference to the asset of the party paying the Payment Request.                                        |
 | merchantName   | String                                                          | required  | The name of the merchant who created the Payment Request.                                                |
 | merchantId     | String                                                          | required  | Your identifier for the merchant receiving payment.                                                      |
-| idempotencyKey | String                                                          | required  | A unique value that can be used to recognise subsequent retries of the same request.                     |
+| idempotencyKey | String                                                          | required  | A unique value that can be used to recognize subsequent retries of the same request.                     |
 | transactionId  | String                                                          | required  | An ID for the transaction in Centrapay’s system.                                                         |
 | status         | String                                                          | required  | The status of the asset transaction. See [possible status values](#statuses).                            |
 | type           | String                                                          | required  | The type of transaction. Possible values are payment or refund.                                          |
 | failureReason  | String                                                          | optional  | Required if the status is failed. See [possible failure reasons](#failure-reasons).                      |
 | refundable     | Boolean                                                         | optional  | Required if type is payment and status is successful. A flag indicating whether a payment is refundable. |
-| refundBefore   | [Timestap](/api/data-types#timestamp) | optional  | The latest time at which a refund can be initiated.                                                      |
+| refundBefore   | [Timestamp](/api/data-types#timestamp) | optional  | The latest time at which a refund can be initiated.                                                      |
 
 ### Statuses
 

--- a/src/content/guides/requesting-payment.mdx
+++ b/src/content/guides/requesting-payment.mdx
@@ -59,7 +59,7 @@ sequenceDiagram
 	note over POS: ✅ Display Confirmation
 ```
 
-| Payment Request Status |                                              Integrator Behaviour                                               |
+| Payment Request Status |                                              Integrator Behavior                                               |
 | ---------------------- | --------------------------------------------------------------------------------------------------------------- |
 | new                    | Check for [Payment Conditions](/guides/payment-conditions) then poll again for status change. |
 | paid                   | Show Confirmation. Stop polling.                                                                                |


### PR DESCRIPTION
Note, that we use U.S spelling in our guides. The exception to the rule is when guides require localised spelling.

Test plan:
- Confirm spelling fixes when site is deployed