### PR TITLE
docs: add set-preferred-bank-account-name endpoint

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -85,6 +85,7 @@ exports[`the build should not break any links 1`] = `
   "/api/bank-accounts#get-bank-authority",
   "/api/bank-accounts#list-bank-accounts",
   "/api/bank-accounts#list-bank-authorities",
+  "/api/bank-accounts#set-preferred-bank-account-name",
   "/api/bank-accounts#verify-bank-account",
   "/api/bank-accounts#verify-bank-authority",
   "/api/batch-types/farmlands",

--- a/src/content/api/_endpoints/bank-accounts-set-preferred-bank-account-name.js
+++ b/src/content/api/_endpoints/bank-accounts-set-preferred-bank-account-name.js
@@ -1,0 +1,21 @@
+export default {
+  method: 'POST',
+  path: '/api/bank-accounts/WRhAxxWpTKb5U7pXyxQjjY/set-preferred-bank-account-name',
+  request: {
+    headers: {
+      'X-Api-Key': '<TOKEN>',
+      'Content-Type': 'application/json',
+    },
+    payload: {
+      preferredBankAccountName: 'Everyday Account'
+    },
+  },
+  response: {
+    activityNumber: 1,
+    createdAt: '2020-06-12T01:17:46.499Z',
+    bankAccountId: 'WRhAxxWpTKb5U7pXyxQjjY',
+    type: 'set-preferred-bank-account-name',
+    preferredBankAccountName: 'Everyday Account',
+    createdBy: 'crn:WIj211vFs9cNACwBb04vQw:api-key:MyApiKey',
+  }
+};

--- a/src/content/api/auth.mdx
+++ b/src/content/api/auth.mdx
@@ -140,6 +140,7 @@ if there is a flag associated to it then at least one of them must be met.
 | bank-account-requests:create       | ✅             |               |                   |                         |         |
 | bank-accounts:create               | ✅             |               |                   |                         |         |
 | bank-accounts:read                 | ✅             |               |                   |                         |         |
+| bank-accounts:update               | ✅             |               |                   |                         |         |
 | business:create                    | ✅             |               |                   |                         |         |
 | business:update                    | ✅             |               |                   |                         |         |
 | business:read                      | ✅             |               |                   |                         |         |

--- a/src/content/api/bank-accounts.mdx
+++ b/src/content/api/bank-accounts.mdx
@@ -35,6 +35,10 @@ bank transaction can be used to verify a bank account.
     The name on the Bank Account provided by the user.
   </Property>
 
+  <Property name="preferredBankAccountName" type="string">
+    The preferred bank account name for the Bank Account provided by the user. This is only available on Bank Accounts of type [quartz](#bank-account-type).
+  </Property>
+
   <Property name="accountId" type="string">
     The id of the owning Centrapay [Account](/api/accounts).
   </Property>
@@ -320,6 +324,32 @@ and has authority to operate this account.
 ---
 
 <Endpoint
+  path="/api/accounts/{accountId}/bank-accounts"
+  filename="bank-accounts-list"
+>
+  ## List Bank Accounts
+
+  This endpoint allows you to list the Bank Accounts for an account.
+</Endpoint>
+
+---
+
+<Endpoint
+  path="/api/bank-accounts/{bankAccountId}/set-preferred-bank-account-name"
+  filename="bank-accounts-set-preferred-bank-account-name"
+>
+  ## Set Preferred Bank Account Name
+
+  <Properties heading="Errors">
+    <Error code="403" message="INVALID_BANK_ACCOUNT_TYPE">
+      The type of bank account is not supported for this operation. Only [quartz](#bank-account-type) bank accounts are supported.
+    </Error>
+  </Properties>
+</Endpoint>
+
+---
+
+<Endpoint
   path="/api/bank-authorities/{bankAccountId}/verify"
   filename="bank-authorities-verify"
 >
@@ -350,17 +380,6 @@ and has authority to operate this account.
       The top up / withdrawal and the bank account do not belong to the same account.
     </Error>
   </Properties>
-</Endpoint>
-
----
-
-<Endpoint
-  path="/api/accounts/{accountId}/bank-accounts"
-  filename="bank-accounts-list"
->
-  ## List Bank Accounts
-
-  This endpoint allows you to list the Bank Accounts for an account.
 </Endpoint>
 
 ---


### PR DESCRIPTION
This PR
* adds documentation for the set-preferred-bank-account-name endpoint

<img width="1167" alt="Screenshot 2024-02-09 at 4 16 44 PM" src="https://github.com/centrapay/centrapay-docs/assets/34535571/d5ab0b99-4369-48a8-8715-5d40e1baa089">
