### PR TITLE
docs: update path for the set-preferred-bank-account-name endpoint

### DIFF
--- a/src/content/api/_endpoints/bank-accounts-set-preferred-name.js
+++ b/src/content/api/_endpoints/bank-accounts-set-preferred-name.js
@@ -1,6 +1,6 @@
 export default {
   method: 'POST',
-  path: '/api/bank-accounts/WRhAxxWpTKb5U7pXyxQjjY/set-preferred-bank-account-name',
+  path: '/api/bank-accounts/WRhAxxWpTKb5U7pXyxQjjY/set-preferred-name',
   request: {
     headers: {
       'X-Api-Key': '<TOKEN>',

--- a/src/content/api/bank-accounts.mdx
+++ b/src/content/api/bank-accounts.mdx
@@ -335,8 +335,8 @@ and has authority to operate this account.
 ---
 
 <Endpoint
-  path="/api/bank-accounts/{bankAccountId}/set-preferred-bank-account-name"
-  filename="bank-accounts-set-preferred-bank-account-name"
+  path="/api/bank-accounts/{bankAccountId}/set-preferred-name"
+  filename="bank-accounts-set-preferred-name"
 >
   ## Set Preferred Bank Account Name
 


### PR DESCRIPTION
The path for this endpoint has been changed in this [PR](https://github.com/centrapay/rhea/pull/26). This PR updates the docs to reflect these changes.