### PR TITLE
feat:add archive bank account doc

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -74,6 +74,7 @@ exports[`the build should not break any links 1`] = `
   "/api/bank-account-connection-intents#create-bank-account-connection-intent",
   "/api/bank-accounts",
   "/api/bank-accounts#add-direct-debit-authority-to-a-bank-account",
+  "/api/bank-accounts#archive-bank-account",
   "/api/bank-accounts#bank-account-approval-type-summary-model",
   "/api/bank-accounts#bank-account-balance-model",
   "/api/bank-accounts#bank-account-model",

--- a/src/content/api/_endpoints/bank-accounts-archive.js
+++ b/src/content/api/_endpoints/bank-accounts-archive.js
@@ -1,0 +1,24 @@
+export default {
+  method: 'POST',
+  path: '/api/bank-accounts/b5URhAxxWpTKyxQjjY7pXW/archive',
+  request: {
+    headers: {
+      'X-Api-Key': '<TOKEN>',
+      'Content-Type': 'application/json',
+    }
+  },
+  response: {
+    id: 'b5URhAxxWpTKyxQjjY7pXW',
+    accountId: 'Jaim1Cu1Q55uooxSens6yk',
+    bankAccountNumber: '12-1234-1234567-123',
+    bankAccountName: 'Jane Doe', // sourced from account consent if one exists
+    preferredBankAccountName: 'Everyday Account', // Optional, but only available on quartz bank accounts
+    balance: '123', // interim booked fetched with account info consent
+    availableBalance: '100', // interim available fetched with account info consent
+    status: 'archived',
+    verified: true, // backwards compatible
+    directDebitAuthorized: true, // user consent for direct debit
+    createdAt: '2020-06-12T01:17:46.499Z',
+    test: true
+  }
+};

--- a/src/content/api/bank-accounts.mdx
+++ b/src/content/api/bank-accounts.mdx
@@ -341,6 +341,16 @@ and has authority to operate this account.
 ---
 
 <Endpoint
+  path="/api/bank-accounts/{bankAccountId}/archive"
+  filename="bank-accounts-archive"
+>
+  ## Archive Bank Account
+
+</Endpoint>
+
+---
+
+<Endpoint
   path="/api/bank-authorities/{bankAccountId}/verify"
   filename="bank-authorities-verify"
 >


### PR DESCRIPTION
This pr is to add a new feature: archive bank account endpoint to centrapay doc. 

Notion: https://www.notion.so/centrapay/bb4a65c348224048a07f770c40ce6c64?v=b1ac5492a81c4efeaf88a7ab7cf924c8&p=7f24559fa7dc43468fe005c69a7982c9&pm=s

Preview: 
![Screenshot 2024-02-14 at 11 15 42 AM](https://github.com/centrapay/centrapay-docs/assets/32785419/3ba12f3a-5752-4b1e-9a76-627e2275bc18)
