### PR TITLE
docs: remove assetId from merchant configs as merchants no longer have a quartz settlement asset

### DIFF
--- a/src/content/api/merchant-configs.mdx
+++ b/src/content/api/merchant-configs.mdx
@@ -54,10 +54,6 @@ A Merchant Config defines the available payment options for paying a [Payment Re
     Merchant's Centrapay Settlement Wallet to receive payments. Optional for `centrapay.nzd` types, if not supplied then a settlement wallet may be created and then assigned.
   </Property>
 
-  <Property name="assetId" type="string">
-    Merchant's Centrapay Settlement Asset to receive payments. Optional for `quartz.nzd` types, if not supplied then a settlement asset may be created and then assigned.
-  </Property>
-
   <Property name="terminalId" type="string">
     Merchant's Epay terminal id.
   </Property>


### PR DESCRIPTION
This PR
* removes the assetId field from the merchant config payload as [quartz merchants no longer have settlement assets](https://github.com/centrapay/kari/pull/13)