### PR TITLE
Update uaas documentation

### DIFF
--- a/src/content/guides/integrating-third-party-asset.mdx
+++ b/src/content/guides/integrating-third-party-asset.mdx
@@ -366,7 +366,7 @@ This endpoint is used resolve a Transaction Attempt when the transaction is pend
 
 Polling will continue until either the transaction attempt status is successful or failed, or the Centrapay Payment Request is no longer payable (e.g. it has expired).
 
-A 2XX response with an empty body should be returned if the transactionId does not exist in your system.
+You should return a 2XX response with an empty body `{}` if the transaction does not exist in your system.
 
 <CodePanel title="Request" method="GET" path="/get?transactionId=${transactionId}">
 ```bash


### PR DESCRIPTION
We want to make it clearer that we expect an empty object response {} when the transaction does not exist in the integrators system.

**Test Plan:**
- [ ] Go to docs.centrapay.com/guides/integrating-third-party-asset#get-transaction-endpoint
- [ ] Assert the documentation has updated as per the changes in this PR

![image](https://github.com/centrapay/centrapay-docs/assets/70119888/88225597-bd47-4778-a488-679b307eab21)
