### PR TITLE
Update UaaS JWT Authentication

### DIFF
--- a/src/content/guides/integrating-third-party-asset.mdx
+++ b/src/content/guides/integrating-third-party-asset.mdx
@@ -135,7 +135,7 @@ Exp is provided as a default expiry. Alternatively, use iat + your own expiry wi
 
 Assert that the audience is correct by checking that aud is equal to the base URL of your Uplink API.
 
-The request_body_sha256 property should be used to verify that the request payload has not been tampered with. This should be done by hashing the received request payload using the SHA256 algorithm and checking for equality with request_body_sha256 as shown below.
+The request_body_sha256 property should be used to verify that the request payload has not been tampered with. This should be done by hashing the received request payload using the SHA256 algorithm and checking for equality with request_body_sha256 as shown below. If the request does not have a payload then the request_body_sha256 field will not be present in the decoded JWT.
 
 <CodePanel title="Example">
   ```javascript


### PR DESCRIPTION
Make it clearer that there will be no request body hash in the decoded jwt if the request itself does not have a payload

**Test Plan:**
- [ ] Go to docs.centrapay.com/guides/integrating-third-party-asset and assert the documentation reflects the changes in this PR

![image](https://github.com/centrapay/centrapay-docs/assets/70119888/6d1ff8fc-b7e0-46ef-8ff7-a61368ce2b4e)
