### PR TITLE
Add error message for create loyalty program API

### DIFF
--- a/src/content/api/loyalty-programs.mdx
+++ b/src/content/api/loyalty-programs.mdx
@@ -7,6 +7,7 @@ nav:
 ---
 import Properties from '../../components/Properties.astro';
 import Property from '../../components/Property.astro';
+import Error from '../../components/Error.astro';
 import Endpoint from '../../components/Endpoint.astro';
 import Badge from '../../components/Badge.astro';
 
@@ -78,6 +79,12 @@ A loyalty program is a container for one or more [Promotions](/api/promotions), 
     <Property name="mediaUploadId" type="string">
       The id of the [Media Upload](/api/media-uploads/) image of the Loyalty Program.
     </Property>
+  </Properties>
+
+  <Properties heading="Errors">
+    <Error code="403" message="INVALID_ACCOUNT_TYPE">
+      The Account is of the wrong type.
+    </Error>
   </Properties>
 </Endpoint>
 


### PR DESCRIPTION
This PR adds error messages for Create Loyalty Program API
- `INVALID_ACCOUNT_TYPE`

API Design doc is [here](https://www.notion.so/centrapay/Create-Loyalty-Program-69a2848f0c664622b13d7c64f5e7fb0b#b623695e9bdf44459b36774bf0c3afde)

The Centrapay Doc can be previewed from here:
 http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/api/loyalty-programs/