### PR TITLE
Update the error message description

### DIFF
--- a/src/content/api/loyalty-programs.mdx
+++ b/src/content/api/loyalty-programs.mdx
@@ -83,7 +83,7 @@ A loyalty program is a container for one or more [Promotions](/api/promotions), 
 
   <Properties heading="Errors">
     <Error code="403" message="INVALID_ACCOUNT_TYPE">
-      The Account is of the wrong type.
+      The Account must be type `org`.
     </Error>
   </Properties>
 </Endpoint>


### PR DESCRIPTION
This is a follow-up PR from the feedback in https://github.com/centrapay/centrapay-docs/pull/974

Changes made:
- Updated the description of the error `INVALID_ACCOUNT_TYPE`

The API Design doc for the error description is also updated:
https://www.notion.so/centrapay/Create-Loyalty-Program-69a2848f0c664622b13d7c64f5e7fb0b?pvs=4