### PR TITLE
add missing img field to promotions

### DIFF
--- a/src/content/api/_endpoints/promotions-create.js
+++ b/src/content/api/_endpoints/promotions-create.js
@@ -39,6 +39,7 @@ export default {
     name: 'Spend a Buck',
     description: 'Make a payment of $1 or more',
     mediaUploadId: '26yUWG6wFgmva8UaDiCTWq',
+    img: 'https://media-upload.centrapay.com/image.png?jhbdsfau67ewejshb=487hsdjhbdgs743',
     startsAt: '2023-02-16T00:47:54.131Z',
     endsAt: '2024-02-16T00:47:54.131Z',
     rewards: [

--- a/src/content/api/_endpoints/promotions-list-by-accountId.js
+++ b/src/content/api/_endpoints/promotions-list-by-accountId.js
@@ -15,6 +15,7 @@ export default {
         name: 'Spend a Buck',
         description: 'Make a payment of $1 or more',
         mediaUploadId: '26yUWG6wFgmva8UaDiCTWq',
+        img: 'https://media-upload.centrapay.com/image.png?jhbdsfau67ewejshb=487hsdjhbdgs743',
         startsAt: '2023-02-16T00:47:54.131Z',
         endsAt: '2024-02-16T00:47:54.131Z',
         rewards: [

--- a/src/content/api/loyalty-programs.mdx
+++ b/src/content/api/loyalty-programs.mdx
@@ -32,7 +32,7 @@ A loyalty program is a container for one or more [Promotions](/api/promotions), 
     The id of the [Media Upload](/api/media-uploads/) image of the Loyalty Program.
   </Property>
 
-   <Property name="img" type="string">
+  <Property name="img" type="string">
     The img URL of the Loyalty Program.
   </Property>
 

--- a/src/content/api/promotions.mdx
+++ b/src/content/api/promotions.mdx
@@ -40,6 +40,10 @@ Promotions are a mechanism to reward accounts for completing certain actions.
     The ID of the [Media Upload](/api/media-uploads/) image of the Promotion.
   </Property>
 
+  <Property name="img" type="string">
+    The img URL of the Promotion.
+  </Property>
+
   <Property name="startsAt" type="timestamp">
     The timestamp of when the Promotion starts.
   </Property>


### PR DESCRIPTION
This change adds the missing img field in Promotion API responses. A mediaUploadId can be provided, therefore a link to the image is required.