### PR TITLE
add quotes around promotion target amount

### DIFF
--- a/src/content/api/_endpoints/promotions-create.js
+++ b/src/content/api/_endpoints/promotions-create.js
@@ -20,7 +20,7 @@ export default {
       eventType: 'payment',
       target: {
         type: 'count',
-        amount: 1
+        amount: '1'
       },
       type: 'challenge',
       conditions: [
@@ -51,7 +51,7 @@ export default {
     eventType: 'payment',
     target: {
       type: 'count',
-      amount: 1
+      amount: '1'
     },
     type: 'challenge',
     conditions: [


### PR DESCRIPTION
Added missing quotes around promotion target amount so requests can be copied from the docs.