### PR TITLE
Remove line about archived assets not being returned from listAssets API

### DIFF
--- a/src/content/api/assets.mdx
+++ b/src/content/api/assets.mdx
@@ -242,7 +242,7 @@ Tokens have the following attributes along with the base asset fields.
 >
   ## List Assets for Account
 
-  Returns a [paginated](/api/pagination) list of Assets for an account. This will not return archived assets.
+  Returns a [paginated](/api/pagination) list of Assets for an account.
 
   <Properties>
     <Property name="externalId" type="string">


### PR DESCRIPTION
The listAssets endpoint is being changed to return all assets.