### PR TITLE
rename activityType to eventType

### DIFF
--- a/src/content/api/_endpoints/promotions-create.js
+++ b/src/content/api/_endpoints/promotions-create.js
@@ -17,7 +17,7 @@ export default {
           amount: '500',
         }
       ],
-      activityType: 'payment',
+      eventType: 'payment',
       target: {
         type: 'count',
         amount: '1'
@@ -48,7 +48,7 @@ export default {
         amount: '500',
       }
     ],
-    activityType: 'payment',
+    eventType: 'payment',
     target: {
       type: 'count',
       amount: '1'

--- a/src/content/api/_endpoints/promotions-list-by-accountId.js
+++ b/src/content/api/_endpoints/promotions-list-by-accountId.js
@@ -24,7 +24,7 @@ export default {
             amount: '500',
           }
         ],
-        activityType: 'payment',
+        eventType: 'payment',
         target: {
           type: 'count',
           amount: 1

--- a/src/content/api/promotions.mdx
+++ b/src/content/api/promotions.mdx
@@ -56,8 +56,8 @@ Promotions are a mechanism to reward accounts for completing certain actions.
     A list of [Rewards](/api/promotions#promotion-reward-model) that the account will receive upon completing the Promotion.
   </Property>
 
-  <Property name="activityType" type="string">
-    The type of Activity that will trigger increments and completions of the Promotion.
+  <Property name="eventType" type="string">
+    The type of Event that will trigger increments and completions of the Promotion.
   </Property>
 
   <Property name="target" type="object">
@@ -65,7 +65,7 @@ Promotions are a mechanism to reward accounts for completing certain actions.
   </Property>
 
   <Property name="type" type="string">
-    The type of Promotion. Can be `cashback` or `challenge`. `challenge` rewards the account once, after the challenge target is met. `cashback` gives a reward based on the payment amount, which can be completed an unlimited amount of times.
+    The type of Promotion. Can be `cashback` or `challenge`. `challenge` rewards the account once, after the challenge target is met. `cashback` gives a reward based on the payment amount, which can be completed an unlimited number of times.
   </Property>
 
   <Property name="conditions" type="array">
@@ -158,8 +158,8 @@ Promotions are a mechanism to reward accounts for completing certain actions.
       A list of [Rewards](/api/promotions#promotion-reward-model) that the account will receive upon completing the Promotion.
     </Property>
 
-    <Property name="activityType" type="string" required>
-      The type of Activity that will trigger increments and completions of the Promotion.
+    <Property name="eventType" type="string" required>
+      The type of Event that will trigger increments and completions of the Promotion.
     </Property>
 
     <Property name="target" type="object">
@@ -167,7 +167,7 @@ Promotions are a mechanism to reward accounts for completing certain actions.
     </Property>
 
     <Property name="type" type="string" required>
-      The type of Promotion. Can be `cashback` or `challenge`. `challenge` rewards the account once, after the challenge target is met. `cashback` gives a reward based on the payment amount, which can be completed an unlimited amount of times.
+      The type of Promotion. Can be `cashback` or `challenge`. `challenge` rewards the account once, after the challenge target is met. `cashback` gives a reward based on the payment amount, which can be completed an unlimited number of times.
     </Property>
 
     <Property name="conditions" type="array">


### PR DESCRIPTION
After the decision was made to use the `Events` terminology here https://www.notion.so/centrapay/An-API-for-all-Event-Types-88196970a0dd42388eaa54722115eac5?pvs=4 this change updates the Promotion entity to reference `eventType` instead of `activityType`

Also an unrelated language tweak from this:
`which can be completed an unlimited amount of times`
to this:
`which can be completed an unlimited number of times`

**Test Plan**
Read the public docs after deployment and confirm the changes have taken effect