### PR TITLE
Update: Replace Activity with Event

### DIFF
--- a/src/content/api/promotions.mdx
+++ b/src/content/api/promotions.mdx
@@ -81,7 +81,7 @@ Promotions are a mechanism to reward accounts for completing certain actions.
   </Property>
 
   <Property name="field" type="string">
-    Only supplied if `type` is `sum`. This denotes which field to sum on the Activity to reach the target amount.
+    Only supplied if `type` is `sum`. This denotes which field to sum on the [Event](/api/events) to reach the target amount.
   </Property>
 
   <Property name="amount" type="number">
@@ -113,7 +113,7 @@ Promotions are a mechanism to reward accounts for completing certain actions.
 
 <Properties>
   <Property name="field" type="string">
-    The field to look at in the Activity object.
+    The field to look at in the [Event](/api/events) object.
   </Property>
 
   <Property name="value" type="string">
@@ -159,7 +159,7 @@ Promotions are a mechanism to reward accounts for completing certain actions.
     </Property>
 
     <Property name="eventType" type="string" required>
-      The [type of Event](/api/events) that will trigger increments and completions of the Promotion.
+      The type of [Event](/api/events) that will trigger increments and completions of the Promotion.
     </Property>
 
     <Property name="target" type="object">


### PR DESCRIPTION
## In this PR: ##

- The word **`Activity`** is changed to **`Event`** with links to the **`Event`** added
- A scan/check in the public doc was executed to ensure **`Event`** is mentioned instead of **`Activity`** in contexts related to Loyalty Program and Promotion

The link to preview change(s) made in the doc is [here](http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/)

****A Screenshot for the  result of the scan:****
![Screenshot 2024-03-20 at 12 18 36 PM](https://github.com/centrapay/centrapay-docs/assets/74471007/d8fe57c2-01f6-4851-8c43-d6707de6c100)
