### PR TITLE
remove test flag on events

### DIFF
--- a/src/content/api/_endpoints/events-create.js
+++ b/src/content/api/_endpoints/events-create.js
@@ -12,7 +12,6 @@ export default {
       data: {
         'userId': 'b657195e-dc2f-11ea-8566-e7710d592c99-123',
       },
-      test: true
     },
   },
   response: {
@@ -23,7 +22,6 @@ export default {
       'userId': 'b657195e-dc2f-11ea-8566-e7710d592c99-123',
     },
     idempotencyKey: 'login-de32dd90-b46c-11ea-93c3-83a333b86e7b',
-    test: true,
     createdAt: '2020-05-01T12:30:00.000Z',
     createdBy: 'crn:WIj211vFs9cNACwBb04vQw:api-key:MyApiKey',
   }

--- a/src/content/api/events.mdx
+++ b/src/content/api/events.mdx
@@ -35,10 +35,6 @@ An event is a record of a user action or outcome. Centrapay performs various tas
     <Property name="data" type="string">
      An object with one or more string fields containing any relevant metadata.
     </Property>
-
-     <Property name="test" type="boolean">
-     A flag which is present if the Event is for testing.
-    </Property>
   </Properties>
 
   <Properties heading="Errors">


### PR DESCRIPTION
This change removes the test flag from the Events API. Test events will be created by and processed for test accounts, so the flag isn't necessary.

Dev deployment: http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/api/events/