### PR TITLE
docs: update request payload for create bank account connection intent and response body for quartz asset

### DIFF
--- a/src/content/api/assets.mdx
+++ b/src/content/api/assets.mdx
@@ -97,6 +97,18 @@ Money assets have the following attributes along with the base asset fields.
   <Property name="settlement" type="boolean" experimental>
     The asset is configured for [Settlements](/api/wallets#settlement-wallets).
   </Property>
+
+  <Property name="period" type="string" experimental>
+    The period after which the `balance` will be reset. This field is only available on the [quartz](/api/asset-types) asset type. Possible values are `daily`, `weekly`, `fortnightly`, `monthly` or `yearly`.
+  </Property>
+
+  <Property name="periodStartedAt" type="timestamp" experimental>
+    Datetime when the current period was started. This field is only available on the [quartz](/api/asset-types) asset type.
+  </Property>
+
+  <Property name="periodEndingAt" type="timestamp" experimental>
+    Datetime when the current period will end. This field is only available on the [quartz](/api/asset-types) asset type.
+  </Property>
 </Properties>
 
 ---

--- a/src/content/api/bank-account-connection-intents.mdx
+++ b/src/content/api/bank-account-connection-intents.mdx
@@ -98,19 +98,15 @@ A Bank Account Connection Intent facilitates user authorization of access to Ban
     </Property>
 
     <Property name="name" type="string">
-      The name of the consent. Only valid if type is `enduring-payment-consent`.
+      The name of the consent. Only available if type is `enduring-payment-consent`.
     </Property>
 
-    <Property name="expiresAt" type="timestamp">
-      The date that the consent is valid until. Only valid if type is `enduring-payment-consent`.
+    <Property name="period" type="string">
+      The period after which the amount spent using the consent will be reset. Only available if type is `enduring-payment-consent`. Valid values are `daily`, `weekly`, `fortnightly`, `monthly` and `yearly`. Defaults to `daily`.
     </Property>
 
-    <Property name="totalTransactions" type="number">
-      The total number of transactions the consent can be used for. Only valid if type is `enduring-payment-consent`.
-    </Property>
-
-    <Property name="totalAmount" type="monetary">
-      The total cent value of transactions the consent can be used for. Only valid if type is `enduring-payment-consent`.
+    <Property name="totalAmount" type="string">
+      The total cent value of transactions the consent can be used for within the period. Only available if type is `enduring-payment-consent`.
     </Property>
   </Properties>
 


### PR DESCRIPTION
This PR
* adds the `period` field to the create bank account connection intent request payload
* adds the `period`, `periodStarted` and `periodEndingAt` fields to the quartz asset response body

Other links
* [Notion story](https://www.notion.so/centrapay/Payment-Pass-Enduring-Consents-Limits-Changes-9cef6ba011e64573aa01b5c4f35a6e3b)