### PR TITLE
feat: add request asset transfer endpoint doc

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -44,6 +44,7 @@ exports[`the build should not break any links 1`] = `
   "/api/asset-transfers#get-an-asset-transfer",
   "/api/asset-transfers#get-asset-transfer-summary",
   "/api/asset-transfers#list-asset-transfers",
+  "/api/asset-transfers#request-an-asset-transfer",
   "/api/asset-transfers#resolve-claimable-assets",
   "/api/asset-types",
   "/api/assets",

--- a/src/content/api/_endpoints/asset-transfers-request.js
+++ b/src/content/api/_endpoints/asset-transfers-request.js
@@ -19,7 +19,6 @@ export default {
     status: 'requested',
     assetType: 'quartz.nzd.main',
     description: 'request payment',
-    senderName: 'john.doe@gmail.com',
     senderAccountId: '9EDxUT91TMsUjoqoQeBuLQ',
     createdAt: '2024-03-01T23:56:21.514Z',
     createdBy: 'crn:userId:1234',

--- a/src/content/api/_endpoints/asset-transfers-request.js
+++ b/src/content/api/_endpoints/asset-transfers-request.js
@@ -1,0 +1,30 @@
+export default {
+  method: 'POST',
+  path: '/api/asset-transfer-requests',
+  request: {
+    headers: {
+      'X-Api-Key': '<TOKEN>',
+      'Content-Type': 'application/json',
+    },
+    payload: {
+      recipientAlias: '12-1234-1234567-123',
+      senderAccountId: '9EDxUT91TMsUjoqoQeBuLQ',
+      value: '1000',
+      assetType: 'quartz.nzd.test'
+    },
+  },
+  response: {
+    id: 'M7Kn2stAxNa6ri7h',
+    recipientAlias: '12-1234-1234567-123',
+    status: 'requested',
+    assetType: 'quartz.nzd.main',
+    description: 'request payment',
+    senderName: 'john.doe@gmail.com',
+    senderAccountId: '9EDxUT91TMsUjoqoQeBuLQ',
+    createdAt: '2024-03-01T23:56:21.514Z',
+    createdBy: 'crn:userId:1234',
+    suppressNotifications: false,
+    value: '1000',
+    message: 'Payment request',
+  }
+};

--- a/src/content/api/asset-transfers.mdx
+++ b/src/content/api/asset-transfers.mdx
@@ -127,11 +127,11 @@ Asset Transfer goes through different lifecycle stages.
 
   <Properties>
     <Property name="recipientAlias" type="string" required>
-      Phone number, email or handle of the person who request for asset transfer.
+      Contact information, such as phone number, email, or handle, for the individual requesting asset transfer.
     </Property>
 
     <Property name="senderAccountId" type="string" required>
-      The id of the sender who receive the request.
+      The account id of the sender who receives the request from recipientAlias.
     </Property>
 
     <Property name="assetType" type="string" required>
@@ -144,10 +144,6 @@ Asset Transfer goes through different lifecycle stages.
 
     <Property name="message" type="string">
       Shows up in transaction history against the transfer. 100 character limit.
-    </Property>
-
-    <Property name="senderName" type="string">
-      Human readable name for the sender. 30 character limit.
     </Property>
 
     <Property name="suppressNotification" type="boolean">

--- a/src/content/api/asset-transfers.mdx
+++ b/src/content/api/asset-transfers.mdx
@@ -127,7 +127,7 @@ Asset Transfer goes through different lifecycle stages.
 
   <Properties>
     <Property name="recipientAlias" type="string" required>
-      Contact information, such as phone number, email, or handle, for the individual requesting asset transfer.
+      Contact information, such as phone number, email, or handle, for the individual requesting asset transfer. Currently supports bank account number only.
     </Property>
 
     <Property name="senderAccountId" type="string" required>

--- a/src/content/api/asset-transfers.mdx
+++ b/src/content/api/asset-transfers.mdx
@@ -56,7 +56,7 @@ message fields are scrubbed to avoid storing PII.
   </Property>
 
   <Property name="senderAlias" type="string">
-    Phone number, email or handle of sender.
+    Phone number, email or handle of sender and who receives a request for asset transfer
   </Property>
 
   <Property name="senderName" type="string">
@@ -76,7 +76,7 @@ message fields are scrubbed to avoid storing PII.
   </Property>
 
   <Property name="recipientAlias" type="string">
-    Phone number, email or handle of receiver.
+    Phone number, email or handle of receiver and who make a request for asset transfer
   </Property>
 
   <Property name="createdAt" type="timestamp">
@@ -106,6 +106,7 @@ Asset Transfer goes through different lifecycle stages.
 
 |   State   |                                                    Description                                                     |
 | :-------- | :----------------------------------------------------------------------------------------------------------------- |
+| requested | Asset transfer successfully requested                                                                              |
 | created   | Asset transfer successfully created                                                                                |
 | sent      | Asset transfer notification (sms, email) was sent to a new user                                                    |
 | expired   | Asset transfer expired as new user didn't create his account and claimed the asset. This is very short lived state |
@@ -115,6 +116,62 @@ Asset Transfer goes through different lifecycle stages.
 
 ---
 
+<Endpoint
+  path="/api/asset-transfer-requests"
+  filename="asset-transfers-request"
+>
+  ## Request an Asset Transfer
+  ### Experimental API
+
+
+  Request a transfer of an asset from a sender to the recipient.
+
+  <Properties>
+    <Property name="recipientAlias" type="string" required>
+      Phone number, email or handle of the person who request for asset transfer.
+    </Property>
+
+    <Property name="senderAccountId" type="string" required>
+      The id of the sender who receive the request.
+    </Property>
+
+    <Property name="assetType" type="string" required>
+      The type of asset being transferred. Currently, supports only `quartz.nzd` assets
+    </Property>
+
+    <Property name="description" type="string">
+      Shows up in transaction history against the transfer. 200 character limit.
+    </Property>
+
+    <Property name="message" type="string">
+      Shows up in transaction history against the transfer. 100 character limit.
+    </Property>
+
+    <Property name="value" type="bignumber">
+      Amount to send. Required for money transfers. Units depend on the asset type.
+    </Property>
+
+    <Property name="senderName" type="string">
+      Human readable name for the sender. 30 character limit.
+    </Property>
+
+    <Property name="suppressNotification" type="boolean">
+      Suppress notifications from Centrapay (SMS/Email).
+    </Property>
+  </Properties>
+
+  <Properties heading="Errors">
+    <Error code="403" message="SENDER_NOT_FOUND">
+      The requests must include a valid sender alias.
+    </Error>
+
+    <Error code="403" message="INVALID_ASSET_TYPE">
+      The [asset's type](/api/asset-types/) does not support transfers.
+    </Error>
+  </Properties>
+</Endpoint>
+
+---
 
 <Endpoint
   path="/api/asset-transfers"

--- a/src/content/api/asset-transfers.mdx
+++ b/src/content/api/asset-transfers.mdx
@@ -120,8 +120,7 @@ Asset Transfer goes through different lifecycle stages.
   path="/api/asset-transfer-requests"
   filename="asset-transfers-request"
 >
-  ## Request an Asset Transfer
-  ### Experimental API
+  ## Request an Asset Transfer <Badge type="experimental"/>
 
 
   Request a transfer of an asset from a sender to the recipient.
@@ -145,10 +144,6 @@ Asset Transfer goes through different lifecycle stages.
 
     <Property name="message" type="string">
       Shows up in transaction history against the transfer. 100 character limit.
-    </Property>
-
-    <Property name="value" type="bignumber">
-      Amount to send. Required for money transfers. Units depend on the asset type.
     </Property>
 
     <Property name="senderName" type="string">


### PR DESCRIPTION
This pr adds a request asset transfer endpoint doc to centrapay doc. It is an extension of the current asset transfer. 

Notion ticket: https://www.notion.so/centrapay/bb4a65c348224048a07f770c40ce6c64?v=b1ac5492a81c4efeaf88a7ab7cf924c8&p=86ae4b2c6c614404b9546d283d029f5d&pm=s

Preview: 
![Screenshot 2024-03-28 at 12 52 35 PM](https://github.com/centrapay/centrapay-docs/assets/32785419/06ac1f39-92bf-4a2b-a335-6726fc7f15bc)

