### PR TITLE
add docs for accept asset transfer request endpoint

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -36,6 +36,7 @@ exports[`the build should not break any links 1`] = `
   "/api/asset-activities#token-refunded-activity-model",
   "/api/asset-categories",
   "/api/asset-transfers",
+  "/api/asset-transfers#accept-an-asset-transfer-request",
   "/api/asset-transfers#asset-transfer-lifecycle",
   "/api/asset-transfers#asset-transfer-model",
   "/api/asset-transfers#cancel-an-asset-transfer",

--- a/src/content/api/_endpoints/asset-transfer-requests-accept.js
+++ b/src/content/api/_endpoints/asset-transfer-requests-accept.js
@@ -1,0 +1,25 @@
+export default {
+  method: 'POST',
+  path: '/api/asset-transfers-requests/M7Kn2stAxNa6ri7h/accept',
+  request: {
+    headers: {
+      'X-Api-Key': '<TOKEN>',
+      'Content-Type': 'application/json',
+    },
+    payload: {
+      assetId: 'YGRo6TYYSxH3js7',
+      value: '1000',
+      senderName: 'Jane Doe'
+    },
+  },
+  response: {
+    assetTransferId: 'M7Kn2stAxNa6ri7h',
+    status: 'accepted',
+    type: 'asset-transfer:accepted',
+    createdAt: '2020-05-02T01:03:37.222Z',
+    createdBy: 'sdasd98199dadas',
+    assetId: 'YGRo6TYYSxH3js7',
+    senderName: 'Jane Doe',
+    value: '1000',
+  }
+};

--- a/src/content/api/asset-transfers.mdx
+++ b/src/content/api/asset-transfers.mdx
@@ -165,6 +165,63 @@ Asset Transfer goes through different lifecycle stages.
 ---
 
 <Endpoint
+  path="/api/asset-transfer-requests/{assetTransferId}/accept"
+  filename="asset-transfer-requests-accept"
+>
+  ## Accept an Asset Transfer Request <Badge type="experimental"/>
+
+  <Properties>
+    <Property name="assetId" type="string" required>
+      Id of the asset to pay the asset transfer request with. Only valid for `quartz.nzd` assets
+    </Property>
+
+    <Property name="senderName" type="string" required>
+      Human readable name for the sender. 30 character limit.
+    </Property>
+
+    <Property name="value" type="bignumber">
+      Amount to send. Required if not defined in the request; forbidden if it was.
+    </Property>
+  </Properties>
+
+  <Properties heading="Errors">
+    <Error code="403" message="ASSET_TRANSFER_REQUEST_EXPIRED">
+      The asset transfer request has already expired
+    </Error>
+
+    <Error code="403" message="ASSET_TRANSFER_REQUEST_ACCEPTED">
+      The asset transfer request has already been accepted
+    </Error>
+
+    <Error code="403" message="BANK_ACCOUNT_BALANCE_INSUFFICIENT">
+      The bank account the asset is for does not have enough balance for the transfer
+    </Error>
+
+    <Error code="403" message="QUOTA_EXCEEDED">
+      The asset transfer would exceed the provided assets quotas
+    </Error>
+
+    <Error code="403" message="ASSET_NOT_ACTIVE">
+      The asset is not active.
+    </Error>
+
+    <Error code="403" message="INVALID_ASSET_TYPE">
+      The [asset's type](/api/asset-types/) does not match the request.
+    </Error>
+
+    <Error code="403" message="VALUE_NOT_DEFINED">
+      The value of the asset transfer was not defined in either the initial request or the acceptance
+    </Error>
+
+    <Error code="403" message="VALUE_ALREADY_DEFINED">
+      The value of the asset transfer was defined in both the initial request and the acceptance
+    </Error>
+  </Properties>
+</Endpoint>
+
+---
+
+<Endpoint
   path="/api/asset-transfers"
   filename="asset-transfers-create"
 >


### PR DESCRIPTION
Adds docs for the newly created accept asset transfer request endpoint

Notion Link: https://www.notion.so/centrapay/Create-Accepted-Asset-Transfer-Request-endpoint-00fc7fb6a42443f9999922d1f89a8cd1

![image](https://github.com/centrapay/centrapay-docs/assets/69737582/1883340e-b66e-491e-9e4f-4e194418d69a)
