### PR TITLE
Add content-type for the example code

### DIFF
--- a/src/content/api/_endpoints/bank-accounts-archive.js
+++ b/src/content/api/_endpoints/bank-accounts-archive.js
@@ -4,7 +4,6 @@ export default {
   request: {
     headers: {
       'X-Api-Key': '<TOKEN>',
-      'Content-Type': 'application/json',
     }
   },
   response: {

--- a/src/content/api/_endpoints/promotions-create.js
+++ b/src/content/api/_endpoints/promotions-create.js
@@ -4,6 +4,7 @@ export default {
   request: {
     headers: {
       'X-Api-Key': '<TOKEN>',
+      'Content-Type': 'application/json',
     },
     payload: {
       name: 'Spend a Buck',


### PR DESCRIPTION
Currently, when we copy the example curl from the `Create Promotion API` from the public doc, it returns a status code **400 - Bad Request**.

To fix this,   `-H 'content-type: application/json' \` is added 

The task story is [here](https://www.notion.so/centrapay/Minor-Public-Doc-Fix-Create-Promotion-API-3a6045e5455e464d98fda1ad342e7376?pvs=4)

The public doc can be previewed from [here](http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/api/promotions/)

## Test Plan
- Directly copy the example curl of the `Create Promotion API` from the public doc.
- Call the API, it should succeed and the error response of 400 Bad Request should not return