### PR TITLE
Make promotion rewards optional

### DIFF
--- a/src/content/api/promotions.mdx
+++ b/src/content/api/promotions.mdx
@@ -162,7 +162,7 @@ Promotions are a mechanism to reward accounts for completing certain actions.
       The timestamp of when the Promotion ends.
     </Property>
 
-    <Property name="rewards" type="array" required>
+    <Property name="rewards" type="array">
       A list of [Rewards](/api/promotions#promotion-reward-model) that the account will receive upon completing the Promotion.
     </Property>
 


### PR DESCRIPTION
In preparation for the soft launch, we're making promotions without rewards possible. To achieve this, the `rewards` property in the `create promotion` API has been changed from required to optional.  The API documentation has been updated to reflect this change.

The story is [here](https://www.notion.so/centrapay/Make-Promotion-Rewards-Optional-9950a488bb374f03999a2ea7e1a1fe36?pvs=4)

The API doc can be previewed from [here](http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/api/promotions/)

<img width="1013" alt="Screenshot 2024-04-30 at 3 42 22 PM" src="https://github.com/centrapay/centrapay-docs/assets/74471007/da914e78-4bc4-45fa-b3c9-053aa5914d7a">
