### PR TITLE
Update Get Managed Integration

### DIFF
--- a/src/content/api/_endpoints/managed-integrations-get.js
+++ b/src/content/api/_endpoints/managed-integrations-get.js
@@ -1,6 +1,6 @@
 export default {
   method: 'GET',
-  path: '/api/managed-integrations/dh375hdh08f590260d9a07f',
+  path: '/api/managed-integrations/paypal-referral/DKTs3U38hdhfEqwF1JKoT2',
   request: {
     headers: {
       'X-Api-Key': '<TOKEN>',

--- a/src/content/api/managed-integrations.mdx
+++ b/src/content/api/managed-integrations.mdx
@@ -160,10 +160,10 @@ A summary of the [Invitation](/api/invitations) for a Managed Integration.
 ---
 
 <Endpoint
-  path="/api/managed-integrations/{id}"
+  path="/api/managed-integrations/{type}/{externalId}"
   filename="managed-integrations-get"
 >
   ## Get Managed Integration
 
-  This endpoint allows you to retrieve a Managed Integration by id.
+  This endpoint allows you to retrieve a Managed Integration by type and external id.
 </Endpoint>


### PR DESCRIPTION
We have reworked this endpoint to retrieve the managed integration by type and external id instead of by the integration id. This means third parties do not need to store our integration id, they only keep a record of the external id (The unique identifier they are already keeping track of).

**Ticket:** https://www.notion.so/centrapay/Create-Quartz-Managed-Integration-e1941fb52070491f8f3320f08da8b614?pvs=4

**Test Plan:**
- [ ] Go to docs.centrapay.com/api/managed-integrations and assert the endpoint has been updated as expected.

<img width="1157" alt="image" src="https://github.com/centrapay/centrapay-docs/assets/70119888/91bfd606-82f5-4ec6-8201-608f953ba584">
