### PR TITLE
Fix Integration Params Anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,6 @@ docker compose run script yarn preview
 ## Integration Tests
 
 ```
+yarn build
 yarn integration
 ```

--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -187,7 +187,7 @@ exports[`the build should not break any links 1`] = `
   "/api/managed-integrations#get-managed-integration",
   "/api/managed-integrations#invitation-summary-model",
   "/api/managed-integrations#managed-integration-model",
-  "/api/managed-integrations#params",
+  "/api/managed-integrations#params-model",
   "/api/managed-integrations#terminal-model",
   "/api/media-uploads",
   "/api/media-uploads#create-a-presigned-url-for-media-upload",

--- a/src/content/api/managed-integrations.mdx
+++ b/src/content/api/managed-integrations.mdx
@@ -37,7 +37,7 @@ A Managed Integration is an [Integration](/api/integrations)  which a third part
   </Property>
 
   <Property name="params" type="object">
-    [Params](#params) depending on the Managed Integration type.
+    [Params](#params-model) depending on the Managed Integration type.
   </Property>
 
   <Property name="createdAt" type="timestamp">
@@ -129,7 +129,7 @@ A summary of the [Invitation](/api/invitations) for a Managed Integration.
 
 ---
 
-## Params
+## Params Model
 
 ### paypal-referral
 
@@ -263,7 +263,7 @@ A summary of the [Invitation](/api/invitations) for a Managed Integration.
     </Property>
 
     <Property name="params" type="object" required>
-      [Params](#params) depending on the Managed Integration type.
+      [Params](#params-model) depending on the Managed Integration type.
     </Property>
 
     <Property name="test" type="boolean">
@@ -273,7 +273,7 @@ A summary of the [Invitation](/api/invitations) for a Managed Integration.
 
   <Properties heading="Errors">
     <Error code="400" message="INVALID_PARAMS">
-      Invalid [Params](#params) provided for Managed Integration type.
+      Invalid [Params](#params-model) provided for Managed Integration type.
     </Error>
 
     <Error code="403" message="MERCHANT_LIVENESS_MISMATCH">


### PR DESCRIPTION
Duplicate element id's meant that when attempting to snap to the params model it would instead snap to the first instance of an element with that id. Also made the integration test instructions clearer in the README

**Test Plan:**
- [ ] Go to docs.centrapay.com/api/managed-integrations
- [ ] Click on the params anchor and make sure it snaps to the correct heading (#params-model)