### PR TITLE
Remove refund config from docs

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -209,7 +209,6 @@ exports[`the build should not break any links 1`] = `
   "/api/merchants#merchant-model",
   "/api/merchants#merchant-search-result-model",
   "/api/merchants#product-model",
-  "/api/merchants#refund-config-model",
   "/api/merchants#search-merchants",
   "/api/merchants#set-merchant-onboarding-status",
   "/api/merchants#settlement-config-model",

--- a/src/content/api/merchants.mdx
+++ b/src/content/api/merchants.mdx
@@ -58,10 +58,6 @@ which define the payment methods available for a Payment Request.
     Merchant [Settlement Config](#settlement-config-model).
   </Property>
 
-  <Property name="refundConfig" type="object">
-    Merchant [Refund Config](#refund-config-model).
-  </Property>
-
   <Property name="location" type="location">
     Physical Location of Merchant. It is highly recommended that you provide this otherwise, users won't be able to find you with our [Merchant Search](#search-merchants) API if they perform a origin + distance query.
   </Property>
@@ -109,15 +105,6 @@ which define the payment methods available for a Payment Request.
 </Properties>
 
 ---
-
-## Refund Config Model
-
-
-<Properties>
-  <Property name="bankAccountId" type="string">
-    The id of the bank account that will be used when processing refunds. The bank account must belong to the same account as the merchant.
-  </Property>
-</Properties>
 
 ## Merchant Search Result Model
 
@@ -196,10 +183,6 @@ which define the payment methods available for a Payment Request.
       Merchant [Settlement Config](#settlement-config-model).
     </Property>
 
-    <Property name="refundConfig" type="object">
-      Merchant [Refund Config](#refund-config-model).
-    </Property>
-
     <Property name="location" type="location">
       Physical Location of Merchant. It is highly recommended that you provide this otherwise, users won't be able to find you with our [Merchant Search](#search-merchants) API if they perform a origin + distance query.
     </Property>
@@ -256,11 +239,6 @@ which define the payment methods available for a Payment Request.
     <Property name="settlementConfig" type="object">
       Merchant [Settlement Config](#settlement-config-model).
     </Property>
-
-    <Property name="refundConfig" type="object">
-      Merchant [Refund Config](#refund-config-model).
-    </Property>
-
 
     <Property name="location" type="location">
       Physical Location of Merchant. It is highly recommended that you provide this otherwise, users won't be able to find you with our [Merchant Search](#search-merchants) API if they perform a origin + distance query.


### PR DESCRIPTION
Story: https://www.notion.so/centrapay/BE-Remove-refundConfig-f80a5329c0f5406bac9b141fdb9939ac?pvs=4

We are no longer going to be using the merchant refund config and will be removing it from the front and backend. 