### PR TITLE
Add parent account id to the account API docs

### DIFF
--- a/src/content/api/accounts.mdx
+++ b/src/content/api/accounts.mdx
@@ -59,6 +59,11 @@ individual account.
   <Property name="subscriptions" type="array">
     A list of [Subscriptions](#subscription-model) on the Account.
   </Property>
+
+  <Property name="parentAccountId" type="string">
+    The unique identifier of the parent account to which the current account is linked.
+    This field establishes a hierarchical relationship between accounts, indicating that the current account was created by the specified parent account.
+  </Property>
 </Properties>
 
 ---


### PR DESCRIPTION
Story: https://www.notion.so/centrapay/Update-Account-Docs-to-include-parentAccountId-2226691d256d433b972d83e8a1e8b459?pvs=4

parentAccountId was added to the API response due to requirements around events and notifications. There is currently no documentation around the account hierarchy within Centrapay so additional documentation will probably be needed in the future. This will be a larger task requiring the addition of a guide. This change is mainly just to keep our docs and APIs consistent. 