### PR TITLE
✨ Add 'Display Error Reasons' to error handling guide

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -372,6 +372,7 @@ exports[`the build should not break any links 1`] = `
   "/guides/merchant-integration-barcode-flow#quick-pay-flow",
   "/guides/merchant-integration-error-handling",
   "/guides/merchant-integration-error-handling#configure-pos-timeout",
+  "/guides/merchant-integration-error-handling#display-error-reasons",
   "/guides/merchant-integration-error-handling#on-this-page-title",
   "/guides/merchant-integration-error-handling#resolving-persistent-errors",
   "/guides/merchant-integration-error-handling#respect-payment-status",

--- a/src/content/guides/merchant-integration-error-handling.mdx
+++ b/src/content/guides/merchant-integration-error-handling.mdx
@@ -1,13 +1,14 @@
 ---
-title: Merchant Integration Error Handling
+title: Error Handling
 description: How to deal with inconsistencies in Payment Request statuses due to network issues or race conditions.
 nav:
   path: Reference/Merchant Integrations
   title: Error Handling
   order: 5
 ---
+import CodePanel from '../../components/CodePanel.astro';
 
-Below are our guidelines for dealing with inconsistencies in [Payment Request](/api/payment-requests) statuses due to network issues or race conditions.
+Below are our guidelines for dealing with inconsistencies in [Payment Request](/api/payment-requests) statuses due to network issues, race conditions, or [asset](/api/asset-types/) specific behaviours.
 
 ## Respect Payment Status
 
@@ -16,6 +17,25 @@ Use the Payment Request status as the source of truth when determining if a Paym
 ### Void Unknown Status
 
 If the status of a transaction cannot be determined to be successful after retrying, then the Payment Request should be voided. [Voiding a Payment Request](/api/payment-requests#void-a-payment-request) will cancel the request and trigger any refunds if necessary.
+
+## Display Error Reasons
+
+Centrapay has a limited set of error messages to simplify integration for our third-party partners.
+Due to this, the same error message can be returned for different reasons.
+Centrapay provides additional details in the `reason` field to enhance error messages and assist with debugging.
+Integrators may choose to display the `reason` to provide more information to the user, however, it is recommended that`reason` is not used to drive application logic.
+
+<CodePanel title="Error Response">
+``` json
+{
+  "statusCode": 403,
+  "message": "ERROR_MESSAGE",
+  "error": "Forbidden",
+  "reason": "A more detailed description of the reason for the error"
+}
+```
+</CodePanel>
+
 
 ## Configure POS Timeout
 


### PR DESCRIPTION
Recommend displaying error `reason` to enhance merchant errors.

Test plan: Expect to see section 'Display Error Reasons' on page https://docs.centrapay.com/guides/merchant-integration-error-handling/

Preview: http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/guides/merchant-integration-error-handling/#display-error-reasons

![Uploading Screenshot 2024-05-31 at 9.27.44 AM.png…]()
