### PR TITLE
✨ Add REFUND_DECLINED error

### DIFF
--- a/src/content/api/legacy-payment-requests.mdx
+++ b/src/content/api/legacy-payment-requests.mdx
@@ -409,6 +409,9 @@ is returned with the payment request info as `payments[].ledger`.
     <Error code="403" message="REFUND_WINDOW_EXCEEDED">
       The time since the payment exceeds the window of time a transaction can be refunded in.
     </Error>
+    <Error code="403" message="REFUND_DECLINED">
+      The refund parameters were valid but refund was declined because additional business rules were violated.
+    </Error>
   </Properties>
 
 </Endpoint>

--- a/src/content/api/payment-requests.mdx
+++ b/src/content/api/payment-requests.mdx
@@ -721,6 +721,9 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
     <Error code="403" message="CONFIRMATION_NOT_FOUND">
       The confirmationIdempotencyKey does not match a Confirmation on the Payment Request.
     </Error>
+    <Error code="403" message="REFUND_DECLINED">
+      The refund parameters were valid but refund was declined because additional business rules were violated.
+    </Error>
   </Properties>
 
 </Endpoint>


### PR DESCRIPTION
Add error for the following endpoints:
1. [Refund a Payment Request](https://docs.centrapay.com/api/payment-requests/#refund-a-payment-request)
2. [Legacy - Refund a Transaction](https://docs.centrapay.com/api/legacy-payment-requests/#refund-a-transaction)

<img width="553" alt="image" src="https://github.com/centrapay/centrapay-docs/assets/64108933/0b28f3c1-9ebe-449d-b6c1-797c73dce6c1">


Test plan: Expect to see `REFUND_DECLINED` error on pages listed above.