### PR TITLE
📝 Document that quartz.nzd payment option requires externalId

### DIFF
--- a/src/content/api/_endpoints/merchant-configs-create.js
+++ b/src/content/api/_endpoints/merchant-configs-create.js
@@ -19,6 +19,10 @@ export default {
         {
           type: 'farmlands.nzd.main',
           farmlandsMerchantNumber: 'DbgY2SyD5M85zkePJjsQEf'
+        },
+        {
+          type: 'quartz.nzd.main',
+          externalMerchantId: '0012399012'
         }
       ]
     },
@@ -42,6 +46,10 @@ export default {
       {
         type: 'farmlands.nzd.main',
         farmlandsMerchantNumber: 'DbgY2SyD5M85zkePJjsQEf'
+      },
+      {
+        type: 'quartz.nzd.main',
+        externalMerchantId: '0012399012'
       }
     ]
   }

--- a/src/content/api/merchant-configs.mdx
+++ b/src/content/api/merchant-configs.mdx
@@ -67,7 +67,7 @@ A Merchant Config defines the available payment options for paying a [Payment Re
   </Property>
 
   <Property name="externalMerchantId" type="string">
-    Id of the external merchant. Required for `epay`, `stadius` and `uplinkapi.test` types.
+    Id of the external merchant. Required for `epay`, `stadius`, `quartz`, and `uplinkapi.test` types.
   </Property>
 </Properties>
 


### PR DESCRIPTION
- Document that externalId is required for quartz payment option.
- Update create merchant config route with example.

Test plan:
- Expect [Payment Option Config Model](https://docs.centrapay.com/api/merchant-configs/#payment-option-config-model) to say that quartz requires externalId.
- Expect [Create Merchant Config Route](https://docs.centrapay.com/api/merchant-configs/#create-merchant-config) to have quartz example.


<img width="1728" alt="Screenshot 2024-06-28 at 7 59 40 AM" src="https://github.com/centrapay/centrapay-docs/assets/64108933/35ca4aaf-269a-4e04-a840-32bc3fce6e99">

<img width="1728" alt="Screenshot 2024-06-28 at 7 59 34 AM" src="https://github.com/centrapay/centrapay-docs/assets/64108933/725471d7-f856-4585-8cb0-c8433cff46fc">

