### PR TITLE
add display fields to promotion rewards

### DIFF
--- a/src/content/api/promotions.mdx
+++ b/src/content/api/promotions.mdx
@@ -112,6 +112,14 @@ Promotions are a mechanism to reward accounts for completing certain actions.
     The ID of the [Token Collection](/api/tokens#token-collection-model) that should be rewarded. Only supplied if `assetType` is `centrapay.token.test` or `centrapay.token.main`.
   </Property>
 
+  <Property name="name" type="string">
+    The name of the [Token Collection](/api/tokens#token-collection-model) that is being rewarded.
+  </Property>
+
+  <Property name="img" type="string">
+    The image of the [Token Collection](/api/tokens#token-collection-model) that is being rewarded.
+  </Property>
+
   <Property name="amount" type="number">
     The amount of the chosen asset to reward. Only supplied if Promotion is type `challenge`.
   </Property>


### PR DESCRIPTION
This change adds `name` and `img` to Promotion Rewards when they are created with a reward `collectionId`.
The field values are taken off the collection.
Story here: https://www.notion.so/centrapay/Points-Earned-when-Promotions-Completed-217c9f34b86c457abe83698e601e1183?pvs=4

Deployed here: http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/