### PR TITLE
Fix typo in auth table

### DIFF
--- a/src/content/api/auth.mdx
+++ b/src/content/api/auth.mdx
@@ -126,7 +126,7 @@ if there is a flag associated to it then at least one of them must be met.
 | ---------------------------------- | ------------- | ------------- | ----------------- | ----------------------- | ------- |
 | accounts:create                    | ✅             |               |                   |                         |         |
 | accounts:read                      | ✅             |               |                   | ✅                       | ✅       |
-| accounts:updat                     | ✅             |               |                   |                         |         |
+| accounts:update                    | ✅             |               |                   |                         |         |
 | api-keys:create                    | ✅             |               |                   |                         |         |
 | api-keys:list                      | ✅             |               |                   |                         |         |
 | api-keys:update                    | ✅             |               |                   |                         |         |


### PR DESCRIPTION
A tiny typo 🤏 in our Auth table
![Screenshot 2024-07-11 at 1 14 48 PM](https://github.com/centrapay/centrapay-docs/assets/74471007/d15d8b4e-62a8-4d3a-988a-c3662988030c)

### Fix ###
updat  ->  update

![Screenshot 2024-07-11 at 1 15 18 PM](https://github.com/centrapay/centrapay-docs/assets/74471007/738ccc16-e2c8-4b23-a1c0-a8e3d124c6fe)

### The public doc can be previewed from [here](http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/api/auth/) ###