### PR TITLE
fix: typo in accept asset transfer url

### DIFF
--- a/src/content/api/_endpoints/asset-transfer-requests-accept.js
+++ b/src/content/api/_endpoints/asset-transfer-requests-accept.js
@@ -1,6 +1,6 @@
 export default {
   method: 'POST',
-  path: '/api/asset-transfers-requests/M7Kn2stAxNa6ri7h/accept',
+  path: '/api/asset-transfer-requests/M7Kn2stAxNa6ri7h/accept',
   request: {
     headers: {
       'X-Api-Key': '<TOKEN>',


### PR DESCRIPTION
## Description
* Fixes typo in the accept asset transfer request example (i.e. the word transfer was plural)

| Before | After |
|--------|--------|
| <img width="532" alt="image" src="https://github.com/user-attachments/assets/1df9093a-d8fd-472e-88ae-0fd1f531d541"> | <img width="548" alt="image" src="https://github.com/user-attachments/assets/e07dc756-2335-48a9-baf1-a69592db665f"> | 