### PR TITLE
Add required tags to the Redemption Condition payload

### DIFF
--- a/src/content/api/tokens.mdx
+++ b/src/content/api/tokens.mdx
@@ -253,11 +253,11 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
   This endpoint allows you to create a [Redemption Condition](#redemption-condition-model).
 
   <Properties>
-    <Property name="merchantId" type="string">
+    <Property name="merchantId" type="string" required>
       The identifier of the [Merchant](/api/merchants) that is accepting the collection.
     </Property>
 
-    <Property name="allowedProducts" type="object">
+    <Property name="allowedProducts" type="object" required>
       List of [Allowed Products](#allowed-products-model). Required for collections of type `product`.
     </Property>
   </Properties>


### PR DESCRIPTION
Add `requried` tags to the fields - `merchantId` and  `allowedProducts` , to match with the code in Kari.

The public doc can be previewed from [here](http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/api/tokens/#create-redemption-condition)

### Code ###
![Screenshot 2024-07-15 at 4 47 17 PM](https://github.com/user-attachments/assets/44ad44f3-8195-4012-9394-eca225418005)

### Before this PR ###
<img width="991" alt="Screenshot 2024-07-15 at 4 48 58 PM" src="https://github.com/user-attachments/assets/4edb674f-e593-4b38-963b-7194016dde4f">

### After this PR ###
<img width="856" alt="Screenshot 2024-07-16 at 9 38 47 PM" src="https://github.com/user-attachments/assets/ebdfaa2b-7d09-467d-80dd-95a350333c73">
