### PR TITLE
Add Set Allowed Products for Redemption Conditions API

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -280,6 +280,7 @@ exports[`the build should not break any links 1`] = `
   "/api/tokens#create-token-collection",
   "/api/tokens#list-token-collections",
   "/api/tokens#redemption-condition-model",
+  "/api/tokens#set-allowed-products-for-redemption-condition",
   "/api/tokens#token-collection-model",
   "/api/tokens#token-expires-after-model",
   "/api/tokens#token-model",

--- a/src/content/api/_endpoints/collections-redemption-conditions-allowed-products-set.js
+++ b/src/content/api/_endpoints/collections-redemption-conditions-allowed-products-set.js
@@ -1,0 +1,57 @@
+export default {
+  method: 'POST',
+  path: '/api/collections/c_NFhUgPQEYbk2EbTXAYArTX/redemption-conditions/DKTs3U38hdhfEqwF1JKoT2/set-allowed-products',
+  request: {
+    headers: {
+      'X-Api-Key': '<TOKEN>',
+      'Content-Type': 'application/json',
+    },
+    payload: {
+      allowedProducts: [
+        {
+          sku: '100001',
+          name: 'White Bread',
+          maxValue: {
+            currency: 'NZD',
+            amount: '400'
+          }
+        },
+        {
+          sku: '100002',
+          name: 'Sourdough Bread',
+          maxValue: {
+            currency: 'NZD',
+            amount: '800'
+          }
+        }
+      ]
+    },
+  },
+  response: {
+    id: 'DKTs3U38hdhfEqwF1JKoT2',
+    merchantId: '36EALpZ89XpShxM2Ee9sXT',
+    collectionId: 'c_NFhUgPQEYbk2EbTXAYArTX',
+    allowedProducts: [
+      {
+        sku: '100001',
+        name: 'White Bread',
+        maxValue: {
+          currency: 'NZD',
+          amount: '400'
+        }
+      },
+      {
+        sku: '100002',
+        name: 'Sourdough Bread',
+        maxValue: {
+          currency: 'NZD',
+          amount: '800'
+        }
+      }
+    ],
+    createdAt: '2022-05-12T04:30:11.001Z',
+    createdBy: 'crn::user:b657195e-dc2f-11ea-8566-e7710d592c99',
+    updatedAt: '2022-11-12T04:30:11.001Z',
+    updatedBy: 'crn::user:b657195e-dc2f-11ea-8566-e7710g542c49',
+  }
+};

--- a/src/content/api/auth.mdx
+++ b/src/content/api/auth.mdx
@@ -178,6 +178,7 @@ if there is a flag associated to it then at least one of them must be met.
 | payment-requests:confirm 🗄         | ✅             |               | ✅                 |                         | ✅       |
 | quotas:read                        | ✅             |               |                   |                         |         |
 | redemption-conditions:create 🪙     | ✅             |               |                   |                         |         |
+| redemption-conditions:update 🪙     | ✅             |               |                   |                         |         |
 | scanned-code:decode                | ✅             |               | ✅                 |                         | ✅       |
 | tokens:create 🪙                    | ✅             |               |                   |                         |         |
 | topups:read                        | ✅             |               |                   |                         |         |

--- a/src/content/api/tokens.mdx
+++ b/src/content/api/tokens.mdx
@@ -277,6 +277,30 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
 ---
 
 <Endpoint
+  path="/api/collections/{collectionId}/redemption-conditions/{redemptionConditionId}/set-allowed-products"
+  filename="collections-redemption-conditions-allowed-products-set"
+>
+  ## Set Allowed Products for Redemption Condition <Badge type="experimental" />
+
+  This endpoint allows you to set [Allowed Products](#allowed-products-model) for a [Redemption Condition](#redemption-condition-model).
+
+  <Properties>
+    <Property name="allowedProducts" type="object" required>
+      List of [Allowed Products](#allowed-products-model). Required for collections of type `product`.
+    </Property>
+  </Properties>
+
+  <Properties heading="Errors">
+    <Error code="403" message="INVALID_AMOUNT">
+      One or more of the maxValue amount in the products has exceeded the maxValue amount defined on the collection.
+    </Error>
+
+  </Properties>
+</Endpoint>
+
+--
+
+<Endpoint
   path="/api/tokens"
   filename="tokens-create"
 >


### PR DESCRIPTION
The permission `redemption-conditions:update` is included in the auth table
The API design is [here](https://www.notion.so/centrapay/Set-AllowedProducts-for-Redemption-Condition-6ff9c5b7d49c47d894ae22007c41ef8a?pvs=4)

The doc can be previewed from [here](http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/api/tokens/#set-allowed-products-for-redemption-condition)
Related PR: https://github.com/centrapay/kari/pull/319

<img width="938" alt="Screenshot 2024-07-16 at 10 30 54 PM" src="https://github.com/user-attachments/assets/e2f11aeb-eed5-4eff-8f73-fa70becdfd9f">

<img width="1306" alt="Screenshot 2024-07-16 at 11 18 36 PM" src="https://github.com/user-attachments/assets/04cbc131-324d-4261-aa3d-a4a7d19685dc">

