### PR TITLE
Document type field for create merchant API

### DIFF
--- a/src/content/api/merchants.mdx
+++ b/src/content/api/merchants.mdx
@@ -186,6 +186,10 @@ which define the payment methods available for a Payment Request.
     <Property name="location" type="location">
       Physical Location of Merchant. It is highly recommended that you provide this otherwise, users won't be able to find you with our [Merchant Search](#search-merchants) API if they perform a origin + distance query.
     </Property>
+
+    <Property name="type" type="string">
+      Valid values: `physical` or `e-commerce`.
+    </Property>
   </Properties>
 
   <Properties heading="Errors">

--- a/src/content/api/merchants.mdx
+++ b/src/content/api/merchants.mdx
@@ -62,6 +62,10 @@ which define the payment methods available for a Payment Request.
     Physical Location of Merchant. It is highly recommended that you provide this otherwise, users won't be able to find you with our [Merchant Search](#search-merchants) API if they perform a origin + distance query.
   </Property>
 
+  <Property name="type" type="string">
+    Valid values: `physical` or `e-commerce`. Used for reporting purposes.
+  </Property>
+
   <Property name="onboardingStatus" type="string">
     The onboarding status of the Merchant. See [Onboarding Statuses](#onboarding-statuses) for possible values.
   </Property>

--- a/src/content/api/merchants.mdx
+++ b/src/content/api/merchants.mdx
@@ -58,12 +58,12 @@ which define the payment methods available for a Payment Request.
     Merchant [Settlement Config](#settlement-config-model).
   </Property>
 
-  <Property name="location" type="location">
-    Physical Location of Merchant. It is highly recommended that you provide this otherwise, users won't be able to find you with our [Merchant Search](#search-merchants) API if they perform a origin + distance query.
+  <Property name="type" type="string">
+    Valid values: `physical` or `e-commerce`. E-commerce merchants will not be displayed in the store finder.
   </Property>
 
-  <Property name="type" type="string">
-    Valid values: `physical` or `e-commerce`. Used for reporting purposes.
+  <Property name="location" type="location">
+    Physical Location of Merchant. It is highly recommended that you provide this otherwise, users won't be able to find you with our [Merchant Search](#search-merchants) API if they perform a origin + distance query. This field is forbidden when the provided type is `e-commerce`.
   </Property>
 
   <Property name="onboardingStatus" type="string">
@@ -187,12 +187,12 @@ which define the payment methods available for a Payment Request.
       Merchant [Settlement Config](#settlement-config-model).
     </Property>
 
-    <Property name="location" type="location">
-      Physical Location of Merchant. It is highly recommended that you provide this otherwise, users won't be able to find you with our [Merchant Search](#search-merchants) API if they perform a origin + distance query.
-    </Property>
-
     <Property name="type" type="string">
       Valid values: `physical` or `e-commerce`.
+    </Property>
+
+    <Property name="location" type="location">
+      Physical Location of Merchant. It is highly recommended that you provide this otherwise, users won't be able to find you with our [Merchant Search](#search-merchants) API if they perform a origin + distance query.
     </Property>
   </Properties>
 

--- a/src/content/api/merchants.mdx
+++ b/src/content/api/merchants.mdx
@@ -59,7 +59,7 @@ which define the payment methods available for a Payment Request.
   </Property>
 
   <Property name="type" type="string">
-    Valid values: `physical` or `e-commerce`. E-commerce merchants will not be displayed in the store finder.
+    Valid values: `physical` or `e-commerce`. Merchants with a physical store should provide type `physical`. Online only merchants should provide type `e-commerce`. E-commerce merchants will not be displayed in the store finder.
   </Property>
 
   <Property name="location" type="location">


### PR DESCRIPTION
We have added a `type` field to the create merchant API. This allows users to specify whether the merchant is a physical store or an online ecommerce merchant. The change documents the new field.