### PR TITLE
document collection types supported by Create Token API

### DIFF
--- a/src/content/api/tokens.mdx
+++ b/src/content/api/tokens.mdx
@@ -311,6 +311,7 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
   <Properties>
     <Property name="collectionId" type="string" required>
       The [Token Collection](#token-collection-model) that will govern the branding and redemption rules for the token.
+      Currently only Collections of type `product` are supported.
     </Property>
 
     <Property name="idempotencyKey" type="string" required>


### PR DESCRIPTION
Document the Collection types (`product`) supported by Create Token API

http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/api/tokens/#create-token

**To test**
Confirm updated copy displayed in public docs
