### PR TITLE
fix: compatible terminals description

### DIFF
--- a/src/content/guides/compatible-terminals.mdx
+++ b/src/content/guides/compatible-terminals.mdx
@@ -8,7 +8,7 @@ nav:
 import Disclosure from '../../components/Disclosure.vue';
 import AccordionListWrapper from '../../components/AccordionListWrapper.astro';
 
-The Centrapay service is supported on a range payment and point of sale devices listed below. If the device model is not in this list, it may not be supported. If you would like to discuss a new integration or support of Centrapay on a new device, please contact Centrapay at support@centrapay.com
+The Centrapay service is supported on a range payment terminals and point of sale devices listed below. If the device model is not in this list, it may not be supported. If you would like to discuss a new integration or support of Centrapay on a new device, please contact Centrapay at support@centrapay.com
 
 ## Terminal Providers
 

--- a/src/content/guides/compatible-terminals.mdx
+++ b/src/content/guides/compatible-terminals.mdx
@@ -8,7 +8,7 @@ nav:
 import Disclosure from '../../components/Disclosure.vue';
 import AccordionListWrapper from '../../components/AccordionListWrapper.astro';
 
-The Centrapay service is supported on a range payment terminals and point of sale devices listed below. If the device model is not in this list, it may not be supported. If you would like to discuss a new integration or support of Centrapay on a new device, please contact Centrapay at support@centrapay.com
+The Centrapay service is supported on a range of payment terminals and point of sale devices listed below. If the device model is not in this list, it may not be supported. If you would like to discuss a new integration or support of Centrapay on a new device, please contact Centrapay at support@centrapay.com
 
 ## Terminal Providers
 


### PR DESCRIPTION
This pr is a fix for compatible terminal description. 

Test plan:

- [ ] The compatible terminal page should load
- [ ]  The dropdown should load the content once it is click
- [ ]  The navigation path is /guides/compatible-terminals#terminal-providers

