### PR TITLE
♻️ Update ecommerce guide to return full Payment Request from onClick handler

### DIFF
--- a/src/content/guides/ecommerce-website.mdx
+++ b/src/content/guides/ecommerce-website.mdx
@@ -58,7 +58,7 @@ autonumber
   MS->>CP: Create Payment Request
   CP-->>MS: Payment Request created
   MS-->>MP: Payment Request created
-  MP-->>-CP: Return Payment Request ID
+  MP-->>-CP: Return Payment Request
   Note over CP: Show Payment Request details
   Consumer->>CP: Complete payment
   Note over CP: Close Centrapay Checkout popup
@@ -87,7 +87,7 @@ autonumber
       window.centrapay({
         async onClick() {
           // Create Payment Request
-          // Return Payment Request ID
+          // Return Payment Request
         },
         async onComplete(data) {
           if (data.paymentRequest.status === 'new') {
@@ -109,7 +109,7 @@ autonumber
 
         This callback is triggered when the customer clicks the ‘Pay with Centrapay’ button.
 
-        The callback is expected to [Create a Payment Request](/api/payment-requests/#create-a-payment-request) and return the Payment Request ID.
+        The callback is expected to [Create a Payment Request](/api/payment-requests/#create-a-payment-request) and return the Payment Request.
         Our payment protocol supports several optional extensions. Please review the extensions below and determine which ones you need for your integration.
         - [Line Items](https://docs.centrapay.com/guides/line-items)
         - [Requesting Pre Auth](https://docs.centrapay.com/guides/requesting-pre-auth)


### PR DESCRIPTION
Update the e-commerce guide to instruct integrators to return the full Payment Request as we want `paymentRequest.url` for popup redirection. 

Docs preview: http://centrapay-docs.dev.s3-website-ap-southeast-1.amazonaws.com/guides/ecommerce-website/

Test plan: Expect instructions to be updated as per preview site.