### PR TITLE
remove redundant errors from update business

### DIFF
--- a/src/content/api/businesses.mdx
+++ b/src/content/api/businesses.mdx
@@ -176,16 +176,6 @@ A Business represents a company registered with the New Zealand Companies Office
       The number associated with your Farmlands business.
     </Property>
   </Properties>
-
-  <Properties heading="Errors">
-    <Error code="403" message="INVALID_ACCOUNT">
-      Account does not exist, is not authorized, is of the wrong type, or is not in the NZ region.
-    </Error>
-
-    <Error code="403" message="INVALID_NZBN">
-      The NZBN provided does not match any NZ business.
-    </Error>
-  </Properties>
 </Endpoint>
 
 ---


### PR DESCRIPTION
noticed that these errors were documented on the update business endpoint but are not valid responses.

**Test Plan:**
- [ ] Go to docs.centrapay.com/api/businesses#update-business and assert the errors are no longer documented