### PR TITLE
♻️ Update ecommerce SDK subdomain

### DIFF
--- a/src/content/guides/ecommerce-website.mdx
+++ b/src/content/guides/ecommerce-website.mdx
@@ -29,7 +29,7 @@ It handles displaying the Centrapay button and launching the Centrapay checkout.
 
 > This link is under development and not yet active.
 
-Production: `https://service.centrapay.com/ecommerce/centrapay.js?merchantId={merchantId}`
+Production: `https://sdk.centrapay.com/ecommerce/centrapay.js?merchantId={merchantId}`
 
 ## Popup Method
 
@@ -80,7 +80,7 @@ autonumber
 ```html
   <html>
 	<head>
-		<script src="https://service.centrapay.com/ecommerce/centrapay.js?merchantId={merchantId}"></script>
+		<script src="https://sdk.centrapay.com/ecommerce/centrapay.js?merchantId={merchantId}"></script>
 	</head>
 	<body>
 		<div id="centrapay-button-container"></div>


### PR DESCRIPTION
Update SDK subdomain from `service.centrapay.com` to `sdk.centrapay.com`.
See related Decision Record to create a sdk.centrapay.com subdomain.

Test plan: Expect ecommerce guide to show sdk.centrapay.com subdomain.