### PR TITLE
Update pay to include external payment ref

### DIFF
--- a/src/content/api/_endpoints/payment-requests-pay.js
+++ b/src/content/api/_endpoints/payment-requests-pay.js
@@ -10,7 +10,8 @@ export default {
       assetType: 'centrapay.nzd.main',
       assetId: 'WRhAxxWpTKb5U7pXyxQjjY',
       amount: '200',
-      mode: 'partial-payment'
+      mode: 'partial-payment',
+      externalPaymentRef: '62e4b0d7-551b-4b93-8b62-28265b4457d1'
     },
   },
   response: {
@@ -30,6 +31,8 @@ export default {
     createdBy: 'crn::user:0af834c8-1110-11ec-9072-3e22fb52e878',
     paymentRequestCreatedBy: 'crn::user:0af834c8-1110-11ec-9072-3e22fb52e878',
     activityNumber: '2',
-    mode: 'partial-payment'
+    mode: 'partial-payment',
+    id: '94a564c9a66d4893b7edf8ccafe3c5fb',
+    externalPaymentRef: '62e4b0d7-551b-4b93-8b62-28265b4457d1'
   }
 };

--- a/src/content/api/payment-requests.mdx
+++ b/src/content/api/payment-requests.mdx
@@ -616,6 +616,9 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
     <Property name="amount" type="string">
       The value required to pay using the canonical units for the Asset Type.
     </Property>
+    <Property name="externalPaymentRef" type="string">
+      An external reference to the payment. Required when `assetType` is `farmlands.nzd.*`.
+    </Property>
   </Properties>
 
   <Properties heading="Errors">


### PR DESCRIPTION
This PR updates the pay endpoint to show the new property for `externalPaymentRef` this also updates to show that we return the `id` for the activity as well.

Testing Steps:
* Assert that `externalPaymentRef` is shown in the properties
* Asset that `externalPaymentRef` is shown in the example request payload
* Assert that `externalPaymentRef` and `id` are shown in the example response