### PR TITLE
❌ Remove warning that SDK URL is not yet active

### DIFF
--- a/src/content/guides/ecommerce-website.mdx
+++ b/src/content/guides/ecommerce-website.mdx
@@ -27,8 +27,6 @@ Centrapay will provide you with the following resources to allow you to start cr
 The Centrapay SDK enables acceptance of Centrapay payments on your website.
 It handles displaying the Centrapay button and launching the Centrapay checkout.
 
-> This link is under development and not yet active.
-
 Production: `https://sdk.centrapay.com/ecommerce/centrapay.js?merchantId={merchantId}`
 
 ## Popup Method


### PR DESCRIPTION
We have a disclaimer at the top that the availability and functionality can change. This URL is now live so warning saying it is not yet active can be removed.

Test plan: Expect warning not to be visible.