### PR TITLE
♻️ Add URL to payment request summary example

### DIFF
--- a/src/content/api/_endpoints/payment-requests-get-summary.js
+++ b/src/content/api/_endpoints/payment-requests-get-summary.js
@@ -3,6 +3,7 @@ export default {
   path: '/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw/summary',
   response: {
     id: 'MhocUmpxxmgdHjr7DgKoKw',
+    url: 'https://app.centrapay.com/pay/MhocUmpxxmgdHjr7DgKoKw',
     merchantName: 'Centrapay Café',
     value: {
       currency: 'NZD',


### PR DESCRIPTION
Add url field as this is now provided to display a QR code on the public payment page.

Test plan: Expect URL to be displayed in example.