### PR TITLE
add ceil option to token expires after model

### DIFF
--- a/src/content/api/tokens.mdx
+++ b/src/content/api/tokens.mdx
@@ -91,12 +91,17 @@ A [Redemption Condition](#redemption-condition-model) is created for each [Merch
 
 
 <Properties>
-  <Property name="period" type="string">
+  <Property name="period" type="string" required>
     Supported values are `hour`, `day`, `week`, `month` and `year`.
   </Property>
 
-  <Property name="duration" type="string">
+  <Property name="duration" type="string" required>
     Number of `period` until token expiration.
+  </Property>
+
+  <Property name="ceil" type="string">
+    Interval to round token expiry up to.
+    Supported values are `hour`, `day`, `week`, `month` and `year`.
   </Property>
 </Properties>
 


### PR DESCRIPTION
This change was recently made as a part of https://www.notion.so/centrapay/Payap-points-expiry-10ea9ab17e80809697addec8e78fa080

test plan: 
- go to https://docs.centrapay.com/api/tokens/#token-expires-after-model and expect the new ceil field to be visible

![image](https://github.com/user-attachments/assets/3a1667ec-3fcf-4b36-971c-b7f72e600327)
