### PR TITLE
✨ Add UX700 to list of supported Verifone devices

### DIFF
--- a/src/content/guides/compatible-devices.mdx
+++ b/src/content/guides/compatible-devices.mdx
@@ -114,6 +114,8 @@ The Centrapay service is supported on a range of payment and point of sale devic
       VX820
 
       VX820 Duet
+
+      UX700 (Unattended Android)
     </Disclosure>
   </div>
 


### PR DESCRIPTION
Test plan: Expect to see "UX700 (Unattended Android)" in Verifone list of supported devices.