### PR TITLE
🔗 Add link to e-commerce checkout sample

### DIFF
--- a/src/content/guides/ecommerce-website.mdx
+++ b/src/content/guides/ecommerce-website.mdx
@@ -9,8 +9,6 @@ import CodePanel from '../../components/CodePanel.astro';
 
 Centrapay enables businesses to process payments with connected Centrapay assets online. To process online payments, businesses need to integrate with one of our eCommerce payment flows.
 
-> The Centrapay Checkout is under active development and its behavior, functionality, and availability may change without notice.
-
 ## Know before you code
 
 Please get in touch with Centrapay to configure your business for eCommerce.
@@ -28,6 +26,12 @@ The Centrapay SDK enables acceptance of Centrapay payments on your website.
 It handles displaying the Centrapay button and launching the Centrapay checkout.
 
 Production: `https://sdk.centrapay.com/ecommerce/centrapay.js?merchantId={merchantId}`
+
+### Centrapay Checkout Sample
+
+A [sample Centrapay e-commerce application](https://github.com/centrapay/centrapay-checkout-sample) is available.
+It uses the Centrapay SDK on the frontend and Node.js on the backend.
+Please refer to the README.md file for configuration instructions.
 
 ## Popup Method
 


### PR DESCRIPTION
Change: Add link for checkout sample.

Test plan: On https://docs.centrapay.com/guides/ecommerce-website, expect to see a Centrapay Checkout Sample header. This should contain a valid link to the GitHub checkout sample.