### PR TITLE
Upgrade to Node 22

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
       - run: yarn install --immutable
       - run: ./build.sh --mode development
       - name: Configure AWS Credentials

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
       - run: yarn install --immutable
       - run: yarn lint
       - run: yarn test

--- a/.github/workflows/pull-request-notification.yml
+++ b/.github/workflows/pull-request-notification.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
       - run: |
           curl -X POST "${{ secrets.NEW_PR_SLACK_HOOK_URL }}" \
           --data "$(

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 22
       - run: yarn install --immutable
       - run: yarn lint
       - run: yarn test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: "3"
-
 services:
   app:
-    image: node:18-alpine
+    image: node:22-alpine
     init: true
     working_dir: /work
     volumes: [ ".:/work" ]
@@ -14,7 +12,7 @@ services:
     environment:
       - "ENV=development"
   script:
-    image: node:18-alpine
+    image: node:22-alpine
     init: true
     working_dir: /work
     stop_signal: SIGKILL


### PR DESCRIPTION
Node 18 is in maintenance mode. Node 22 is the currently active LTS version.

https://nodejs.org/en/about/previous-releases

Test plan:
- Confirm site runs successfully locally. Both with and without docker compose
- Confirm CI pipelines pass