### PR TITLE
Add markdoc

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -12,6 +12,8 @@ import rehypeSectionize from '@hbsnow/rehype-sectionize';
 import vue from '@astrojs/vue';
 import mdx from '@astrojs/mdx';
 
+import markdoc from '@astrojs/markdoc';
+
 // https://astro.build/config
 export default defineConfig({
   site: 'https://docs.centrapay.com',
@@ -19,6 +21,7 @@ export default defineConfig({
     vue(),
     tailwind({ applyBaseStyles: false }),
     mdx(),
+    markdoc(),
   ],
   markdown: {
     remarkPlugins: [ mermaid ],

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "integration": "vitest --watch=false --config vitest.integration.config.js"
   },
   "devDependencies": {
+    "@astrojs/markdoc": "^0.11.5",
     "@astrojs/mdx": "^3.1.7",
     "@astrojs/tailwind": "^5.1.1",
     "@astrojs/vue": "^4.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,6 +53,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@astrojs/markdoc@npm:^0.11.5":
+  version: 0.11.5
+  resolution: "@astrojs/markdoc@npm:0.11.5"
+  dependencies:
+    "@astrojs/internal-helpers": "npm:0.4.1"
+    "@astrojs/markdown-remark": "npm:5.3.0"
+    "@astrojs/prism": "npm:3.1.0"
+    "@markdoc/markdoc": "npm:^0.4.0"
+    esbuild: "npm:^0.21.5"
+    github-slugger: "npm:^2.0.0"
+    gray-matter: "npm:^4.0.3"
+    htmlparser2: "npm:^9.1.0"
+  peerDependencies:
+    astro: ^3.0.0 || ^4.0.0
+  checksum: 10c0/ae70edb9f60a2ce5cfcdd2ea905e31b5b687692ef0fd97c7704560c4e8765c861d60b8a1023632e7b4a8219c071b0e261e29a38c885626a63dcd56513599fd0d
+  languageName: node
+  linkType: hard
+
 "@astrojs/markdown-remark@npm:5.3.0":
   version: 5.3.0
   resolution: "@astrojs/markdown-remark@npm:5.3.0"
@@ -1119,6 +1137,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@markdoc/markdoc@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "@markdoc/markdoc@npm:0.4.0"
+  dependencies:
+    "@types/markdown-it": "npm:12.2.3"
+  peerDependencies:
+    "@types/react": "*"
+    react: "*"
+  dependenciesMeta:
+    "@types/markdown-it":
+      optional: true
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    react:
+      optional: true
+  checksum: 10c0/32619bfa682681ad5feb337997050bf1c65e732787ac7a63aa7e25e4224a73d9a07cf9c2c18660342d3f4b1d0fa4c15194761fd72657be2e5d20f9a7a8e81988
+  languageName: node
+  linkType: hard
+
 "@mdx-js/mdx@npm:^3.0.1":
   version: 3.1.0
   resolution: "@mdx-js/mdx@npm:3.1.0"
@@ -1600,6 +1638,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/linkify-it@npm:*":
+  version: 5.0.0
+  resolution: "@types/linkify-it@npm:5.0.0"
+  checksum: 10c0/7bbbf45b9dde17bf3f184fee585aef0e7342f6954f0377a24e4ff42ab5a85d5b806aaa5c8d16e2faf2a6b87b2d94467a196b7d2b85c9c7de2f0eaac5487aaab8
+  languageName: node
+  linkType: hard
+
+"@types/markdown-it@npm:12.2.3":
+  version: 12.2.3
+  resolution: "@types/markdown-it@npm:12.2.3"
+  dependencies:
+    "@types/linkify-it": "npm:*"
+    "@types/mdurl": "npm:*"
+  checksum: 10c0/f72e08f69d76be2e30cd367fd6e5302c6878aa44e5b1a952fe7e41280044502bcb9bac8459ad94f6bb5e4f9c4cb52803950609ad66786f0fddc3a8bd533f777d
+  languageName: node
+  linkType: hard
+
 "@types/mdast@npm:^3.0.0":
   version: 3.0.15
   resolution: "@types/mdast@npm:3.0.15"
@@ -1615,6 +1670,13 @@ __metadata:
   dependencies:
     "@types/unist": "npm:*"
   checksum: 10c0/84f403dbe582ee508fd9c7643ac781ad8597fcbfc9ccb8d4715a2c92e4545e5772cbd0dbdf18eda65789386d81b009967fdef01b24faf6640f817287f54d9c82
+  languageName: node
+  linkType: hard
+
+"@types/mdurl@npm:*":
+  version: 2.0.0
+  resolution: "@types/mdurl@npm:2.0.0"
+  checksum: 10c0/cde7bb571630ed1ceb3b92a28f7b59890bb38b8f34cd35326e2df43eebfc74985e6aa6fd4184e307393bad8a9e0783a519a3f9d13c8e03788c0f98e5ec869c5e
   languageName: node
   linkType: hard
 
@@ -5397,7 +5459,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"htmlparser2@npm:^9.0.0":
+"htmlparser2@npm:^9.0.0, htmlparser2@npm:^9.1.0":
   version: 9.1.0
   resolution: "htmlparser2@npm:9.1.0"
   dependencies:
@@ -8932,6 +8994,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "root-workspace-0b6124@workspace:."
   dependencies:
+    "@astrojs/markdoc": "npm:^0.11.5"
     "@astrojs/mdx": "npm:^3.1.7"
     "@astrojs/tailwind": "npm:^5.1.1"
     "@astrojs/vue": "npm:^4.5.2"


### PR DESCRIPTION
Markdoc enables us to enforce a cleaner separation between content and components. See the [decision record here](https://www.notion.so/centrapay/Use-Markdoc-to-author-Centrapay-Docs-content-1a9be0b4f3a641068e9b4a97db7ccf50)

Test plan:
- Existing MDX pages continue to build and render correctly for development and static builds