### PR TITLE
♻️ Make Astro prose

### DIFF
--- a/src/components/Prose.astro
+++ b/src/components/Prose.astro
@@ -1,0 +1,14 @@
+<div
+  class="
+    prose prose-slate max-w-none
+    prose-headings:font-display prose-headings:font-normal
+    prose-h2:scroll-mt-16 prose-h2:mt-8 prose-h2:pt-8 prose-h2:border-t
+    prose-h3:scroll-mt-20
+    prose-h4:scroll-mt-20
+    prose-lead:text-slate-500
+    prose-a:no-underline prose-a:text-content-primary hover:prose-a:no-underline
+    prose-img:mb-8 prose-img:mx-auto prose-img:object-contain
+  "
+>
+  <slot />
+</div>

--- a/src/pages/api/[...slug].astro
+++ b/src/pages/api/[...slug].astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from '../../utils/getCollection';
-import Prose from '../../components/Prose.vue';
+import Prose from '../../components/Prose.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import customComponents from '../../utils/customComponents';
 import ApiH2 from '../../components/ApiH2.astro';
@@ -30,7 +30,7 @@ const { title, description } = entry.data;
             { title }
           </h1>
         </header>
-        <Prose client:load>
+        <Prose>
           <Content components={{ ...customComponents, h2: ApiH2, h3: H3 }}/>
         </Prose>
       </article>

--- a/src/pages/guides/[...slug].astro
+++ b/src/pages/guides/[...slug].astro
@@ -1,6 +1,6 @@
 ---
 import { getCollection } from '../../utils/getCollection';
-import Prose from '../../components/Prose.vue';
+import Prose from '../../components/Prose.astro';
 import TocNav from '../../components/TocNav.vue';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import customComponents from '../../utils/customComponents';
@@ -41,7 +41,7 @@ const { title, description } = entry.data;
             { title }
           </h1>
         </header>
-        <Prose client:load>
+        <Prose>
           <Content components={{ ...customComponents, h2: H2 }}/>
         </Prose>
       </article>


### PR DESCRIPTION
Change prose around guides and API documents to have an astro prose. This removes client load directive and means we can use markdoc 🔥🔥🔥

Test plan: Expect visual appearance of APIs and guides to be unchanged.