### PR TITLE
♻️ Add liveness to Payment Request summary

### DIFF
--- a/src/content/api/_endpoints/payment-requests-get-summary.js
+++ b/src/content/api/_endpoints/payment-requests-get-summary.js
@@ -56,5 +56,6 @@ export default {
         discount: '199'
       }
     ],
+    liveness: 'test'
   }
 };


### PR DESCRIPTION
Add liveness to Payment Request summary to make it easy to know which deeplinks to use on public Payment Request page.

Test plan: Expect to see liveness on example https://docs.centrapay.com/api/payment-requests/#get-payment-request-summary