### PR TITLE
Override block quote node

### DIFF
--- a/markdoc.config.mjs
+++ b/markdoc.config.mjs
@@ -2,6 +2,10 @@ import { defineMarkdocConfig, component, nodes } from '@astrojs/markdoc/config';
 
 export default defineMarkdocConfig({
   nodes: {
+    blockquote: {
+      ...nodes.blockquote,
+      render: component('./src/components/Note.astro'),
+    },
     fence: {
       attributes: {
         ...nodes.fence.attributes,
@@ -13,11 +17,6 @@ export default defineMarkdocConfig({
     link: {
       ...nodes.link,
       render: component('./src/components/Link.astro'),
-    },
-  },
-  tags: {
-    note: {
-      render: component('./src/components/Note.astro'),
     },
   },
 });

--- a/src/content/guides/creating-test-money.mdoc
+++ b/src/content/guides/creating-test-money.mdoc
@@ -12,9 +12,7 @@ The test bank account can be used to create a topup request. The 4-digit bank ac
 
 The test assets can be created via either the Centrapay API or the Centrapay app.
 
-{% note %}
-Test bank accounts count toward resource quotas.
-{% /note %}
+> Test bank accounts count toward resource quotas.
 
 ## Via API
 

--- a/src/content/guides/transaction-reporting.mdoc
+++ b/src/content/guides/transaction-reporting.mdoc
@@ -12,6 +12,4 @@ The settlement process to the merchant will differ depending on which [Asset Typ
 
 The Asset Types used for payment should be communicated to the user in any transaction reporting function on the merchant side.
 
-{% note %}
-Transaction reporting capabilities offered to the merchant that indicate Centrapay was used for payment MUST qualify the asset type used.
-{% /note %}
+> Transaction reporting capabilities offered to the merchant that indicate Centrapay was used for payment MUST qualify the asset type used.


### PR DESCRIPTION
Override blockquote node instead of using a custom note tag to simplify content authoring.

Test plan:
- Confirm no visual changes for the creating test money and transaction reporting guides