### PR TITLE
🐛 [10% time]: Fix mobile menu

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -26,7 +26,7 @@ const { path, navigation } = Astro.props;
           </a>
         </div>
       </div>
-      <div class="flex items-center gap-x-4 pr-6">
+      <div class="flex items-center">
         <SiteSearch client:load />
         <MobileMenu client:load data-mobile-menu path={path} navigation={navigation} />
       </div>

--- a/src/components/MobileMenu.vue
+++ b/src/components/MobileMenu.vue
@@ -1,69 +1,64 @@
 <template>
-  <button
-    class="flex items-center ring-focus-ring focus:outline-none focus:ring-2 focus:ring-inset md:hidden"
-    @click="mainMenuOpen = !mainMenuOpen"
+  <Popover
+    v-slot="{ open }"
+    class="static isolate z-50 md:hidden"
   >
-    <span class="sr-only">Open Main Menu</span>
-    <NavigationMenu
-      v-if="!mainMenuOpen"
-      class="block size-6 text-content-tertiary"
-      aria-hidden="true"
-    />
-    <CloseOutline
-      v-else
-      class="block size-6 text-content-tertiary"
-      aria-hidden="true"
-    />
-  </button>
-  <TransitionRoot
-    as="template"
-    :show="mainMenuOpen"
-  >
-    <Dialog
-      as="div"
-      class="relative"
-    >
-      <div class="fixed inset-x-0 inset-y-16 flex min-h-full">
-        <TransitionChild
-          as="template"
-          enter="transition ease-in-out duration-150 transform"
-          enter-from="-translate-y-full"
-          enter-to="translate-y-0"
-          leave="transition ease-in-out duration-150 transform"
-          leave-from="translate-y-0"
-          leave-to="-translate-y-full"
-        >
-          <DialogPanel class="relative flex w-full flex-1 flex-col bg-surface-primary">
-            <div class="h-0 flex-1 overflow-y-auto pb-4 pt-5">
-              <nav
-                class="space-y-1 px-4"
-                aria-label="Sidebar"
-              >
-                <ul role="menubar">
-                  <div
-                    v-for="item in navigation.items"
-                    :key="item.title"
-                  >
-                    <PrimarySidebarDisclosure
-                      v-if="item.children?.length"
-                      :navigation-item="item"
-                      :path="path"
-                    />
-                    <PageLinks
-                      v-else
-                      :navigation-item="item"
-                      :path="path"
-                      :level="1"
-                    />
-                  </div>
-                </ul>
-              </nav>
-            </div>
-          </DialogPanel>
-        </TransitionChild>
+    <div class="py-5">
+      <div class="mx-auto max-w-7xl px-6 lg:px-8">
+        <PopoverButton class="flex items-center ring-focus-ring focus:outline-none focus:ring-2 focus:ring-inset">
+          <NavigationMenu
+            v-if="!open"
+            class="block size-6 text-content-tertiary"
+            aria-hidden="true"
+          />
+          <CloseOutline
+            v-else
+            class="block size-6 text-content-tertiary"
+            aria-hidden="true"
+          />
+        </PopoverButton>
       </div>
-    </Dialog>
-  </TransitionRoot>
+    </div>
+
+    <transition
+      enter-active-class="transition ease-out duration-200"
+      enter-from-class="opacity-0 -translate-y-1"
+      enter-to-class="opacity-100 translate-y-0"
+      leave-active-class="transition ease-in duration-150"
+      leave-from-class="opacity-100 translate-y-0"
+      leave-to-class="opacity-0 -translate-y-1"
+    >
+      <PopoverPanel class="absolute inset-x-0 inset-y-16 -z-10">
+        <div class="relative size-auto bg-surface-primary">
+          <div class="flex min-h-full w-full flex-1 overflow-y-scroll py-2">
+            <nav
+              class="w-full space-y-1 px-4"
+              aria-label="Sidebar"
+            >
+              <ul role="menubar">
+                <div
+                  v-for="item in navigation.items"
+                  :key="item.title"
+                >
+                  <PrimarySidebarDisclosure
+                    v-if="item.children?.length"
+                    :navigation-item="item"
+                    :path="path"
+                  />
+                  <PageLinks
+                    v-else
+                    :navigation-item="item"
+                    :path="path"
+                    :level="1"
+                  />
+                </div>
+              </ul>
+            </nav>
+          </div>
+        </div>
+      </PopoverPanel>
+    </transition>
+  </Popover>
 </template>
 
 <script setup>
@@ -71,12 +66,7 @@ import CloseOutline from './icons/CloseOutline.vue';
 import NavigationMenu from './icons/NavigationMenu.vue';
 import PageLinks from './PageLinks.vue';
 import PrimarySidebarDisclosure from './PrimarySidebarDisclosure.vue';
-import {
-  Dialog,
-  DialogPanel,
-  TransitionChild,
-  TransitionRoot,
-} from '@headlessui/vue';
+import { Popover, PopoverButton, PopoverPanel } from '@headlessui/vue'
 import { ref } from 'vue';
 
 const props = defineProps({


### PR DESCRIPTION
Current behaviour: Mobile menu can be opened but then 'X' button cannot be clicked to close it.
Change: Make it so that mobile menu can be opened and closed.

Test plan: Expect that mobile menu can be closed. Expect desktop menu to be unchanged.