### PR TITLE
Use datadog for monitoring

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,4 @@
 COMPOSE_FILE=docker-compose.yml:docker-compose-dev.yml
+DATADOG_ENABLED=false
+ENV=local
+GITHUB_RUN_ID=0

--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,2 @@
+ENV=dev
+DATADOG_ENABLED=true

--- a/.env.prod
+++ b/.env.prod
@@ -1,0 +1,2 @@
+ENV=prod
+DATADOG_ENABLED=true

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           node-version: 22
       - run: yarn install --immutable
-      - run: yarn build --mode development
+      - run: yarn build --mode dev
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       - run: yarn install --immutable
       - run: yarn lint
       - run: yarn test
-      - run: yarn build
+      - run: yarn build --mode prod
       - uses: JamesIves/github-pages-deploy-action@3.7.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,6 +17,6 @@ jobs:
       - run: yarn install --immutable
       - run: yarn lint
       - run: yarn test
-      - run: yarn build
+      - run: yarn build --mode prod
       - run: yarn linkinator
       - run: yarn integration

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -40,6 +40,10 @@ const content = await Promise.all(collections.map(async page => {
 }));
 
 const navigation = Navigation.create({ nav: sideNavConfig, content });
+
+const datadogEnabled = import.meta.env.DATADOG_ENABLED;
+const env = import.meta.env.ENV;
+const version = import.meta.env.GITHUB_RUN_ID;
 ---
 <!DOCTYPE html>
 <html lang="en">
@@ -49,12 +53,12 @@ const navigation = Navigation.create({ nav: sideNavConfig, content });
     <meta name="viewport" content="width=device-width">
     <title>{metaTitle}</title>
     <meta name="description" content={description}>
-    <meta property="img" content={`${Astro.url.origin}${img}`}>
+    <meta property="img" content={img}>
 
     <!-- OpenGraph Tags -->
     <meta name="og:title" content={metaTitle}>
     <meta name="og:description" content={description}>
-    <meta property="og:image" content={`${Astro.url.origin}${img}`}>
+    <meta property="og:image" content={img}>
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
@@ -71,16 +75,32 @@ const navigation = Navigation.create({ nav: sideNavConfig, content });
     </script>
     <script src="https://aus-widget.freshworks.com/widgets/51000002960.js" defer async type="text/javascript"></script>
 
-    <!-- Hotjar Tracking Code for Centrapay Docs -->
-    <script type="text/javascript" charset="utf-8">
-      (function(h,o,t,j,a,r){
-        h.hj = h.hj || function(){(h.hj.q = h.hj.q || []).push(arguments);};
-        h._hjSettings = {hjid: 3333046,hjsv: 6};
-        a = o.getElementsByTagName('head')[0];
-        r = o.createElement('script');r.async = 1;
-        r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
-        a.appendChild(r);
-      })(window,document,'https://static.hotjar.com/c/hotjar-','.js?sv=');
+    <!-- Datadog -->
+    <script is:inline define:vars={{env, version, datadogEnabled}}>
+      /* eslint-disable no-undef */
+      if (datadogEnabled === 'true') {
+        (function(h,o,u,n,d) {
+          h = h[d] = h[d] || {q: [],onReady: function(c){h.q.push(c);}};
+          d = o.createElement(u);d.async = 1;d.src = n;
+          n = o.getElementsByTagName(u)[0];n.parentNode.insertBefore(d,n);
+        })(window,document,'script','https://www.datadoghq-browser-agent.com/us1/v5/datadog-rum.js','DD_RUM');
+        window.DD_RUM.onReady(function() {
+          window.DD_RUM.init({
+            clientToken: 'pub57276ecbb44c72e44eddae1f327e7109',
+            applicationId: '31d8b456-9734-45e2-8fd3-5cf23ceb5c87',
+            site: 'datadoghq.com',
+            service: 'centrapay-docs',
+            env,
+            version,
+            sessionSampleRate: 100,
+            sessionReplaySampleRate: 20,
+            trackUserInteractions: true,
+            trackResources: true,
+            trackLongTasks: true,
+            defaultPrivacyLevel: 'mask-user-input',
+          });
+        });
+      }
     </script>
   </head>
   <body>


### PR DESCRIPTION
Use Datadog for monitoring to replace Hotjar. Use Vite's mode to switch environment configuration. Add environment variable to toggle Datadog integration for developers.

Test plan:
- Confirm local logs are not shown in datadog by default.
- Confirm dev and prod logs are sent to datadog
- Confirm env and version tags on logs are correctly set.