### PR TITLE
Ignore custom mermaid class

### DIFF
--- a/src/components/Mermaid.astro
+++ b/src/components/Mermaid.astro
@@ -1,4 +1,5 @@
 ---
+/* eslint-disable tailwindcss/no-custom-classname */
 const {code} = Astro.props;
 ---
 <center>


### PR DESCRIPTION
Ignore custom mermaid class to prevent linter warnings in PRs and workflows.

Test plan:
- Confirm linter warning is no longer present locally and in Github workflows