### PR TITLE
Update environment name of deploy-prod step

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -140,7 +140,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-22.04
     environment:
-      name: github-pages
+      name: prod
       url: ${{steps.deployment.outputs.page_url}}
     steps:
       - id: deployment


### PR DESCRIPTION
Now that we're no longer deploying our site from a branch, we can standardise the name of the production environment being referenced to receive deployment notifications from internal tooling.

Test plan:
- Confirm deployment notifications are received when a production environment is waiting for approval.