### PR TITLE
🥩 Split guides and API Reference navigation

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -8,7 +8,7 @@ const { path, navigation } = Astro.props;
 <centrapay-header>
   <header class="fixed inset-x-0 z-10 flex h-16 shrink-0 bg-white shadow">
     <div class="flex w-full items-center justify-between">
-      <div class="flex items-center">
+      <div class="flex w-full items-center justify-between pr-2 md:pr-4">
         <a
           href="/"
           class="flex size-16 items-center justify-center bg-content-primary ring-focus-ring focus:outline-none focus:ring-2 focus:ring-inset"
@@ -16,13 +16,20 @@ const { path, navigation } = Astro.props;
           <span class="sr-only">Go to home page</span>
           <CentrapayLogo class="inline-block size-8 text-content-on-color" />
         </a>
-        <div class="ml-7 flex flex-row space-x-1">
+        <div class="ml-7 flex flex-row space-x-2">
           <a
             href="/"
             target="_self"
             class="rounded-lg bg-gray-100 px-3 py-2 text-sm font-medium leading-5 text-gray-600 ring-focus-ring hover:bg-gray-200 hover:text-content-primary focus:outline-none focus:ring-2 focus:ring-inset"
           >
             Docs
+          </a>
+          <a
+            href="/api/introduction"
+            target="_self"
+            class="rounded-lg bg-gray-100 px-3 py-2 text-sm font-medium leading-5 text-gray-600 ring-focus-ring hover:bg-gray-200 hover:text-content-primary focus:outline-none focus:ring-2 focus:ring-inset"
+          >
+            API Reference
           </a>
         </div>
       </div>

--- a/src/components/SecondarySidebarDisclosure.vue
+++ b/src/components/SecondarySidebarDisclosure.vue
@@ -55,5 +55,5 @@ const disclosureSelected = computed(() => {
     path: props.path
   });
 });
-const defaultOpen = ref(disclosureSelected.value);
+const defaultOpen = ref(true);
 </script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,8 +4,6 @@ import MessagesBubbleDouble from '../components/icons/MessagesBubbleDouble.vue';
 import Footer from '../components/Footer.astro';
 import '../assets/css/tailwind.css';
 import { getCollection } from '../utils/getCollection';
-import Navigation from '../navigation/Navigation';
-import sideNavConfig from '../navigation/sideNavConfig';
 
 export function getStaticPaths() {
   return [
@@ -19,22 +17,9 @@ const {
   title,
   description,
   img,
+  navigation
 } = Astro.props;
 const metaTitle = title ? title + ' - Centrapay Docs' : 'Centrapay Docs';
-
-const collections = await Promise.all([
-  ...await getCollection('guides'),
-  ...await getCollection('connections'),
-  ...await getCollection('api')
-]);
-
-const content = await Promise.all(collections.map(async page => {
-  const { headings } = await page.render();
-  page.headings = headings.filter(heading => heading.depth === 2);
-  return page;
-}));
-
-const navigation = Navigation.create({ nav: sideNavConfig, content });
 
 const datadogEnabled = import.meta.env.DATADOG_ENABLED;
 const env = import.meta.env.ENV;

--- a/src/layouts/ConnectionLayout.astro
+++ b/src/layouts/ConnectionLayout.astro
@@ -2,9 +2,9 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Prose from '../components/Prose.astro';
 
-const { title, description, img } = Astro.props;
+const { title, description, img, navigation } = Astro.props;
 ---
-<BaseLayout title={title} description={description} img={img}>
+<BaseLayout title={title} description={description} img={img} navigation={navigation}>
   <div>
     <slot name="header" />
     <div>

--- a/src/layouts/FarmlandsLayout.astro
+++ b/src/layouts/FarmlandsLayout.astro
@@ -1,9 +1,9 @@
 ---
 import ConnectionLayout from '../layouts/ConnectionLayout.astro';
 import Farmlands from '../components/Farmlands.astro';
-const { title, description, img } = Astro.props;
+const { title, description, img, navigation } = Astro.props;
 ---
-<ConnectionLayout title={title} description={description} img={img}>
+<ConnectionLayout title={title} description={description} img={img} navigation={navigation}>
   <div slot="header">
     <Farmlands />
   </div>

--- a/src/navigation/apiNavigation.js
+++ b/src/navigation/apiNavigation.js
@@ -1,23 +1,7 @@
-const navigationItems = [
-  {
-    title: 'Reference',
-    subTitle: 'Learn about core features',
-    icon: 'Receipt',
-    children: [
-      { title: 'Centrapay Experiences' },
-      { title: 'Digital Assets' },
-      { title: 'Merchant Integrations' },
-      { title: 'App Integrations' },
-    ]
-  },
-  {
-    title: 'Connections',
-    subTitle: 'For our partners',
-    icon: 'Connections',
-    children: [
-      { title: 'Farmlands' },
-    ]
-  },
+import { getCollection } from '../utils/getCollection';
+import Navigation from '../navigation/Navigation';
+
+const nav = [
   {
     title: 'API',
     subTitle: 'For developers',
@@ -36,4 +20,13 @@ const navigationItems = [
   },
 ];
 
-export default navigationItems;
+const collections = await getCollection('api');
+const content = await Promise.all(collections.map(async page => {
+  const { headings } = await page.render();
+  page.headings = headings.filter(heading => heading.depth === 2);
+  return page;
+}));
+
+const navigation = Navigation.create({ nav, content });
+
+export default navigation;

--- a/src/navigation/guideNavigation.js
+++ b/src/navigation/guideNavigation.js
@@ -1,0 +1,39 @@
+import { getCollection } from '../utils/getCollection';
+import Navigation from '../navigation/Navigation';
+
+const nav = [
+  {
+    title: 'Reference',
+    subTitle: 'Learn about core features',
+    icon: 'Receipt',
+    children: [
+      { title: 'Centrapay Experiences' },
+      { title: 'Digital Assets' },
+      { title: 'Merchant Integrations' },
+      { title: 'App Integrations' },
+    ]
+  },
+  {
+    title: 'Connections',
+    subTitle: 'For our partners',
+    icon: 'Connections',
+    children: [
+      { title: 'Farmlands' },
+    ]
+  },
+];
+
+const collections = await Promise.all([
+  ...await getCollection('guides'),
+  ...await getCollection('connections'),
+]);
+
+const content = await Promise.all(collections.map(async page => {
+  const { headings } = await page.render();
+  page.headings = headings.filter(heading => heading.depth === 2);
+  return page;
+}));
+
+const navigation = Navigation.create({ nav, content });
+
+export default navigation;

--- a/src/pages/api/[...slug].astro
+++ b/src/pages/api/[...slug].astro
@@ -4,6 +4,7 @@ import Prose from '../../components/Prose.astro';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import customComponents from '../../utils/customComponents';
 import ApiH2 from '../../components/ApiH2.astro';
+import navigation from '../../navigation/apiNavigation';
 
 export async function getStaticPaths() {
   const api = await getCollection('api');
@@ -18,7 +19,7 @@ const { Content } = await entry.render();
 const previewImg = entry.data.img || '/default-cover.jpg';
 const { title, description } = entry.data;
 ---
-<BaseLayout title={title} description={description} img={previewImg}>
+<BaseLayout title={title} description={description} img={previewImg} navigation={navigation}>
   <div class="desktop-gutters relative mx-auto flex justify-center">
     <div class="min-w-0 flex-auto p-8">
       <article>

--- a/src/pages/connections/[...slug].astro
+++ b/src/pages/connections/[...slug].astro
@@ -3,6 +3,7 @@ import { getCollection } from '../../utils/getCollection';
 import customComponents from '../../utils/customComponents';
 import H2 from '../../components/H2.astro';
 import FarmlandsLayout from '../../layouts/FarmlandsLayout.astro';
+import navigation from '../../navigation/guideNavigation';
 
 export async function getStaticPaths() {
   const connections = await getCollection('connections');
@@ -16,7 +17,7 @@ const { entry } = Astro.props;
 const { Content } = await entry.render();
 const { title, description, img } = entry.data;
 ---
-<FarmlandsLayout title={title} description={description} img={img}>
+<FarmlandsLayout title={title} description={description} img={img} navigation={navigation}>
   <Content />
 </FarmlandsLayout>
 

--- a/src/pages/guides/[...slug].astro
+++ b/src/pages/guides/[...slug].astro
@@ -5,6 +5,7 @@ import TocNav from '../../components/TocNav.vue';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import customComponents from '../../utils/customComponents';
 import H2 from '../../components/H2.astro';
+import navigation from '../../navigation/guideNavigation';
 
 export async function getStaticPaths() {
   const guides = await getCollection('guides');
@@ -19,7 +20,7 @@ const { Content, headings } = await entry.render();
 const previewImg = entry.data.img || '/default-cover.jpg';
 const { title, description } = entry.data;
 ---
-<BaseLayout title={title} description={description} img={previewImg}>
+<BaseLayout title={title} description={description} img={previewImg} navigation={navigation}>
   <div class="relative mx-auto xl:mx-0">
     <div class="flex w-full justify-center">
       <div class="flex grow justify-center">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,6 +2,8 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import FeaturedContentCard from '../components/FeaturedContentCard.astro';
 import { getEntry } from 'astro:content';
+import { getCollection } from '../utils/getCollection';
+import navigation from '../navigation/guideNavigation';
 
 const paymentFlowsGuide = await getEntry('guides', 'payment-flows');
 const farmlandsPortal = await getEntry('guides', 'farmlands-portal');
@@ -11,7 +13,7 @@ const description = 'Learn to connect with Centrapay experiences.';
 const img = '/homepage-preview.png';
 ---
 
-<BaseLayout description={description} img={img}>
+<BaseLayout description={description} img={img} navigation={navigation}>
   <div class="mx-auto my-8 w-full max-w-5xl px-4 sm:px-8">
     <div class="mb-16 flex flex-col space-y-6">
       <h1 class="type-display mb-4">


### PR DESCRIPTION
Changes:
- Separate navigation for guides and API reference
- Add buttons on header bar to go between guides and API reference

Test plan: Expect to see buttons on header bar in desktop and mobile. Expect navigation to only contain relevant guide OR API content on desktop and mobile.