### PR TITLE
Add missing API docs

### DIFF
--- a/src/content/api/api-keys.mdoc
+++ b/src/content/api/api-keys.mdoc
@@ -2,7 +2,7 @@
 title: API Keys
 description: Introduction to API Keys
 nav:
-  path: API
+  path: API Reference
   order: 6
 ---
 API keys provide enduring access to a single Centrapay [Account](/api/accounts).

--- a/src/content/api/auth.mdoc
+++ b/src/content/api/auth.mdoc
@@ -2,7 +2,7 @@
 title: Auth
 description: Introduction to Authentication
 nav:
-  path: API
+  path: API Reference
   order: 2
 ---
 ## Authenticating API Calls

--- a/src/content/api/batches.mdoc
+++ b/src/content/api/batches.mdoc
@@ -2,7 +2,7 @@
 title: Batches
 description: Batch model and related endpoints
 nav:
-  path: API
+  path: Batches
   order: 10
 ---
 Batches enable bulk loading of resource onto the Centrapay platform.

--- a/src/content/api/data-types.mdoc
+++ b/src/content/api/data-types.mdoc
@@ -2,7 +2,7 @@
 title: Data Types
 description: Introduction to Data Types
 nav:
-  path: API
+  path: API Reference
   order: 4
 ---
 

--- a/src/content/api/http-status-codes.mdoc
+++ b/src/content/api/http-status-codes.mdoc
@@ -2,7 +2,7 @@
 title: HTTP Status Codes
 description: Introduction to HTTP Status Codes
 nav:
-  path: API
+  path: API Reference
   order: 3
 ---
 Centrapay APIs respond with 200, 400, 401, 403, 404, or 429 HTTP status codes.

--- a/src/content/api/introduction.mdoc
+++ b/src/content/api/introduction.mdoc
@@ -2,7 +2,7 @@
 title: Introduction
 description: Introduction to the API Reference
 nav:
-  path: API
+  path: API Reference
   order: 1
 ---
 The Centrapay API is an [RMM](https://en.wikipedia.org/wiki/Richardson_Maturity_Model)

--- a/src/content/api/invitations.mdoc
+++ b/src/content/api/invitations.mdoc
@@ -2,7 +2,7 @@
 title: Invitations
 description: Invitation model and related endpoints
 nav:
-  path: API
+  path: Invitations
   order: 13
 ---
 An Invitation can be used to allow users to claim ownership of a resource on the Centrapay platform.

--- a/src/content/api/media-uploads.mdoc
+++ b/src/content/api/media-uploads.mdoc
@@ -2,7 +2,7 @@
 title: Media Uploads
 description: Media Uploads API Reference
 nav:
-  path: API
+  path: Media Uploads
   order: 15
 ---
 ## Media Upload Model

--- a/src/content/api/object-ids.mdoc
+++ b/src/content/api/object-ids.mdoc
@@ -2,7 +2,7 @@
 title: Object IDs
 description: Object Identifiers (IDs)
 nav:
-  path: API
+  path: API Reference
   order: 7
 ---
 

--- a/src/content/api/pagination.mdoc
+++ b/src/content/api/pagination.mdoc
@@ -2,7 +2,7 @@
 title: Pagination
 description: Introduction to Pagination
 nav:
-  path: API
+  path: API Reference
   order: 5
 ---
 Pagination allows a listing endpoint to return a subset of results. The goal is to reduce memory

--- a/src/content/api/profiles.mdoc
+++ b/src/content/api/profiles.mdoc
@@ -2,7 +2,7 @@
 title: Profiles
 description: Profile model and related endpoints
 nav:
-  path: API
+  path: Profiles
   order: 18
 ---
 A profile represents a Centrapay user's attributes.

--- a/src/content/api/quotas.mdoc
+++ b/src/content/api/quotas.mdoc
@@ -2,7 +2,7 @@
 title: Quotas
 description: Quota model and related endpoints
 nav:
-  path: API
+  path: Quotas
   order: 19
 ---
 Centrapay account quotas are enforced on usage types such as spending or topping up, and may apply to a time period (daily, monthly, yearly). Account quotas may be affected by the verification status of the Centrapay account.

--- a/src/content/api/settlements.mdoc
+++ b/src/content/api/settlements.mdoc
@@ -2,7 +2,7 @@
 title: Settlements
 description: Settlement models and related endpoints
 nav:
-  path: API
+  path: Settlements
   order: 21
 ---
 A Settlement is created from completed [Payment Requests](/api/payment-requests/) over a specified period for each supported [Asset Type](/api/asset-types/) for each [Merchant](/api/merchants/).

--- a/src/navigation/apiNavigation.js
+++ b/src/navigation/apiNavigation.js
@@ -2,15 +2,22 @@ import { getCollection } from '../utils/getCollection';
 import Navigation from '../navigation/Navigation';
 
 const nav = [
+  { title: 'API Reference', order: 6 },
   { title: 'Accounts', order: 7 },
   { title: 'Assets', order: 8 },
   { title: 'Bank Accounts', order: 9 },
+  { title: 'Batches', order: 10 },
   { title: 'Events', order: 11 },
   { title: 'Integrations', order: 12 },
+  { title: 'Invitations', order: 13 },
   { title: 'Loyalty Programs', order: 14 },
+  { title: 'Media Uploads', order: 15 },
   { title: 'Merchants', order: 16 },
   { title: 'Payment Requests', order: 17 },
+  { title: 'Profiles', order: 18 },
+  { title: 'Quotas', order: 19 },
   { title: 'Scanned Codes', order: 20 },
+  { title: 'Settlements', order: 21 },
 ];
 
 const collections = await getCollection('api');


### PR DESCRIPTION
Add API docs that were accidentally removed from the sidebar in https://github.com/centrapay/centrapay-docs/pull/1132/files#diff-4460da6ebd489d74cd52390cd1fa1d5f28708b14f0c15ca687bde6092f3c9e9e

Test plan:
- Confirm missing docs are present in the API reference sidebar