### PR TITLE
Render declared sidebar order

### DIFF
--- a/src/navigation/Navigation.js
+++ b/src/navigation/Navigation.js
@@ -18,8 +18,8 @@ class NavGroup {
       parentPath: path
     })) || [];
     const childPages = content.filter(c => c.data.nav.path === path.join('/'))
-      .map(Page.fromContent)
-      .sort((a, b) => a.nav.order - b.nav.order);
+      .map(Page.fromContent);
+
 
     return new NavGroup({
       title: nav.title,

--- a/src/navigation/apiNavigation.js
+++ b/src/navigation/apiNavigation.js
@@ -2,22 +2,22 @@ import { getCollection } from '../utils/getCollection';
 import Navigation from '../navigation/Navigation';
 
 const nav = [
-  { title: 'API Reference', order: 6 },
-  { title: 'Accounts', order: 7 },
-  { title: 'Assets', order: 8 },
-  { title: 'Bank Accounts', order: 9 },
-  { title: 'Batches', order: 10 },
-  { title: 'Events', order: 11 },
-  { title: 'Integrations', order: 12 },
-  { title: 'Invitations', order: 13 },
-  { title: 'Loyalty Programs', order: 14 },
-  { title: 'Media Uploads', order: 15 },
-  { title: 'Merchants', order: 16 },
-  { title: 'Payment Requests', order: 17 },
-  { title: 'Profiles', order: 18 },
-  { title: 'Quotas', order: 19 },
-  { title: 'Scanned Codes', order: 20 },
-  { title: 'Settlements', order: 21 },
+  { title: 'API Reference' },
+  { title: 'Accounts' },
+  { title: 'Assets' },
+  { title: 'Bank Accounts' },
+  { title: 'Batches' },
+  { title: 'Events' },
+  { title: 'Integrations' },
+  { title: 'Invitations' },
+  { title: 'Loyalty Programs' },
+  { title: 'Media Uploads' },
+  { title: 'Merchants' },
+  { title: 'Payment Requests' },
+  { title: 'Profiles' },
+  { title: 'Quotas' },
+  { title: 'Scanned Codes' },
+  { title: 'Settlements' },
 ];
 
 const collections = await getCollection('api');


### PR DESCRIPTION
Rendering the sidebar sections in the order that they're declared prevents any unnecessary churn tweaking order numbers whenever the sidebar is added to or restructured.

Test plan:
- Confirm sidebar order remains the same