### PR TITLE
Allow concurrent workflows

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -13,10 +13,6 @@ permissions:
   pages: write
   id-token: write
 
-concurrency:
-  group: "pages"
-  cancel-in-progress: false
-
 jobs:
   setup:
     continue-on-error: true


### PR DESCRIPTION
Currently we can't have more than 1 CI/CD workflow run in progress. This slows down our deployments. We have existing internal controls to guard against older deployments overwriting newer ones.

Test plan:
- Confirm workflows are allowed to run concurrently