### PR TITLE
Fix sidebar links

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -43,7 +43,7 @@
                 <a
                   role="menuitem"
                   class="block py-2 pl-6 text-xs text-gray-600"
-                  :href="`${navigationChild.path}#${navigationGrandchild.id}`"
+                  :href="`${navigationChild.path}#${navigationGrandchild.slug}`"
                 >
                   {{ navigationGrandchild.text }}
                 </a>


### PR DESCRIPTION
Sidebar links to anchor headings are currently broken due to the Astro v5 upgrade renaming all instances of 'slug' to 'id'.

Test plan:
- Confirm links to anchor headings in the the sidebar are being set to expected values for api, guides and connection collections