### PR TITLE
add support email links to rate limit docs

### DIFF
--- a/src/content/api/http-status-codes.mdoc
+++ b/src/content/api/http-status-codes.mdoc
@@ -108,11 +108,6 @@ Centrapay API rate limits have been exceeded. See [Rate Limits](/api/rate-limits
 }
 ```
 
-### Debugging
-* Check the `Retry-After` HTTP response header for the number of seconds
-  before the next request will be accepted.
-* Contact integrations@centrapay.com to increase your limits.
-
 ## 5xx Server Error
 
 If you get a 500 level error, something has gone wrong on our end. Retrying

--- a/src/content/api/rate-limits.mdoc
+++ b/src/content/api/rate-limits.mdoc
@@ -13,7 +13,7 @@ The general rate limit is 200rpm, however for certain APIs we may apply a specif
 
 Rate limits for authenticated endpoints are applied to the account making the call. This means if you are using a `X-Centrapay-Account` header, the rate limits will still be consumed for the account that the jwt or api key belongs to, not the targeted account.
 
-If you require higher rate limits for your use case, please contact support to request an increase.
+If you require higher rate limits for your use case, please contact support at [integrations@centrapay.com](mailto:integrations@centrapay.com) to request an increase.
 
 ## Preventing Rate Limiting
 
@@ -26,7 +26,7 @@ There are a few main situations that can lead to getting rate limited. Being awa
   Making requests concurrently can quickly reach the rate limits, causing many requests to fail. Consider instead having sequential calls.
     
 - **Influx of usage:**
-  Events such as sales can lead to many users interacting with your system. If you are anticipating an increase in usage, consider contacting support for an increase in your rate limits beforehand.
+  Events such as sales can lead to many users interacting with your system. If you are anticipating an increase in usage, consider contacting support at [integrations@centrapay.com](mailto:integrations@centrapay.com) for an increase in your rate limits beforehand.
     
 
 ## Handling Rate Limits


### PR DESCRIPTION
This Pr is adding changes that were accidentally left out of when merging https://github.com/centrapay/centrapay-docs/pull/1148

Test Plan:
- Ensure that the correct links to the support email are showing in the rate limit docs