### PR TITLE
add promotionId to promotion membership model

### DIFF
--- a/src/content/api/_endpoints/promotion-memberships-list.js
+++ b/src/content/api/_endpoints/promotion-memberships-list.js
@@ -12,6 +12,7 @@ export default {
         id: '8aoMfscvtuewsuJzmzBzAs',
         accountId: '57SyRRgZ1U8Kq2wKpCnSR5',
         programId: 'WRhAxxWpTKb5U7pXyxQjjY',
+        promotionId: '8aoMfscvtuewsuJzmzBzAs',
         name: 'Spend a Buck',
         summary: 'Make a payment',
         mediaUploadId: '26yUWG6wFgmva8UaDiCTWq',

--- a/src/content/api/promotion-memberships.mdoc
+++ b/src/content/api/promotion-memberships.mdoc
@@ -11,11 +11,11 @@ Promotion Memberships represents an [Account's](/api/accounts) membership to a [
 
 {% properties %}
   {% property name="id" type="string" %}
-    The unique identifier for the Promotion.
+    The unique identifier for the Promotion Membership.
   {% /property %}
 
   {% property name="accountId" type="string" %}
-    The ID of the [Account](/api/accounts) that owns the Promotion.
+    The ID of the [Account](/api/accounts) that has the membership to the Promotion.
   {% /property %}
 
   {% property name="name" type="string" %}
@@ -24,6 +24,10 @@ Promotion Memberships represents an [Account's](/api/accounts) membership to a [
 
   {% property name="programId" type="string" %}
     The ID of the [Loyalty Program](/api/loyalty-programs) that the Promotion belongs to.
+  {% /property %}
+
+  {% property name="promotionId" type="string" %}
+    The ID of the Promotion.
   {% /property %}
 
   {% property name="summary" type="string" %}


### PR DESCRIPTION
promotionId has been added to API response here https://github.com/centrapay/rhea/pull/445

**To test**
Confirm changes appear in prod docs