### PR TITLE
Add idempotencyKey field to pay a payment request API

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -147,6 +147,7 @@ exports[`the build should not break any links 1`] = `
   "/api/http-status-codes#404-route-not-found",
   "/api/http-status-codes#429-too-many-requests",
   "/api/http-status-codes#5xx-server-error",
+  "/api/idempotency",
   "/api/integration-requests",
   "/api/integration-requests#activate-integration-request",
   "/api/integration-requests#configure-integration-request",

--- a/src/content/api/_endpoints/payment-requests-pay.js
+++ b/src/content/api/_endpoints/payment-requests-pay.js
@@ -7,6 +7,7 @@ export default {
       'Content-Type': 'application/json',
     },
     payload: {
+      idempotencyKey: 'b62-11ec-9072-3e22fb52e878',
       assetType: 'centrapay.nzd.main',
       assetId: 'WRhAxxWpTKb5U7pXyxQjjY',
       amount: '200',
@@ -20,6 +21,7 @@ export default {
       currency: 'NZD',
       amount: '1000'
     },
+    idempotencyKey: '8b62-11ec-9072-3e22fb52e878',
     assetType: 'centrapay.nzd.main',
     paymentRequestId: 'MhocUmpxxmgdHjr7DgKoKw',
     shortCode: 'CP-C7F-ZS5-015',

--- a/src/content/api/idempotency.mdoc
+++ b/src/content/api/idempotency.mdoc
@@ -1,0 +1,9 @@
+---
+title: Idempotency
+description: Introduction to Idempotency
+nav:
+  path: API Reference
+  order: 9
+---
+Several key APIs support Idempotency. Idempotency allows requests to be safely retried without risk of performing the operation twice. When calling an API, provide an idempotency key. Then, if a connection error occurs, you can safely repeat the request using the same key without risk of the operation being performed twice.
+

--- a/src/content/api/idempotency.mdoc
+++ b/src/content/api/idempotency.mdoc
@@ -5,6 +5,8 @@ nav:
   path: API Reference
   order: 9
 ---
-Several key APIs support Idempotency. Idempotency allows requests to be safely retried without risk of performing the operation twice. When calling an API, provide an idempotency key. Then, if a connection error occurs, you can safely repeat the request using the same key without risk of the operation being performed twice.
+Several Centrapay APIs support Idempotency. Those that do, accept an idempotencyKey property in the request payload.
+
+Idempotency allows requests to be safely retried without risk of performing the operation twice. When calling an API, provide an idempotency key. Then, if a connection or 500 error occurs, you can safely repeat the request using the same key.
 
 The result of successful requests to our APIs will be saved alongside their idempotency key. Subsequent requests with the same key return the same result.

--- a/src/content/api/idempotency.mdoc
+++ b/src/content/api/idempotency.mdoc
@@ -7,3 +7,4 @@ nav:
 ---
 Several key APIs support Idempotency. Idempotency allows requests to be safely retried without risk of performing the operation twice. When calling an API, provide an idempotency key. Then, if a connection error occurs, you can safely repeat the request using the same key without risk of the operation being performed twice.
 
+The result of successful requests to our APIs will be saved alongside their idempotency key. Subsequent requests with the same key return the same result.

--- a/src/content/api/payment-requests.mdoc
+++ b/src/content/api/payment-requests.mdoc
@@ -621,11 +621,11 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
   - Use `authorization` to authorize an external transaction.
 
   {% properties %}
-    {% property name="idempotencyKey" type="string" required=true %}
-      A unique identifier that prevents duplicate processing of the same request.
-    {% /property %}
     {% property name="assetType" type="string" required=true %}
       An [Asset Type](/api/asset-types) reference.
+    {% /property %}
+    {% property name="idempotencyKey" type="string" required=true %}
+      A unique identifier that prevents duplicate processing of the same request. See [idempotency](/api/idempotency).
     {% /property %}
     {% property name="assetId" type="string" %}
       The id of the Asset being used to make payment.

--- a/src/content/api/payment-requests.mdoc
+++ b/src/content/api/payment-requests.mdoc
@@ -615,7 +615,7 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
 %}
   ## Pay a Payment Request
 
-  To pay a Payment Request you must supply the name of the [Asset Type](/api/asset-types) , `idempotencyKey` and one of `assetId`, `transactionId` or `authorization`.
+  To pay a Payment Request you must supply the name of the [Asset Type](/api/asset-types), `idempotencyKey` and one of `assetId`, `transactionId` or `authorization`.
   - Use `assetId` if the [Asset Type](/api/asset-types) is managed by Centrapay.
   - Use `transactionId` to verify an external transaction such as a Bitcoin payment.
   - Use `authorization` to authorize an external transaction.

--- a/src/content/api/payment-requests.mdoc
+++ b/src/content/api/payment-requests.mdoc
@@ -615,12 +615,15 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
 %}
   ## Pay a Payment Request
 
-  To pay a Payment Request you must supply the name of the [Asset Type](/api/asset-types) and one of `assetId`, `transactionId` or `authorization`.
+  To pay a Payment Request you must supply the name of the [Asset Type](/api/asset-types) , `idempotencyKey` and one of `assetId`, `transactionId` or `authorization`.
   - Use `assetId` if the [Asset Type](/api/asset-types) is managed by Centrapay.
   - Use `transactionId` to verify an external transaction such as a Bitcoin payment.
   - Use `authorization` to authorize an external transaction.
 
   {% properties %}
+    {% property name="idempotencyKey" type="string" required=true %}
+      A unique identifier that prevents duplicate processing of the same request.
+    {% /property %}
     {% property name="assetType" type="string" required=true %}
       An [Asset Type](/api/asset-types) reference.
     {% /property %}


### PR DESCRIPTION
`idempotencyKey` is a new field that is required for the pay payment request API. This will allow integrators to safely retry failed requests without incurring duplicate charges.


## Changes made ##
![Screenshot 2024-12-23 at 12 33 20 PM](https://github.com/user-attachments/assets/f858bd55-bdf7-492a-b703-5bbaba02c80b)
