### PR TITLE
Update POS to POS server for requests to centrapay

### DIFF
--- a/src/content/guides/farmlands-pos-integration.mdoc
+++ b/src/content/guides/farmlands-pos-integration.mdoc
@@ -34,23 +34,27 @@ sequenceDiagram
 
 	participant Cardholder
 	participant POS
+	participant POS Server
 	participant Centrapay
 
 	Note over Cardholder: Present Barcode
 	Cardholder->>POS: Scan Barcode
 
-	POS->>Centrapay: Create Payment Request with Barcode
+  POS->>POS Server: Request Payment
 
-	loop Poll for Payment Confirmation
-		POS->>Centrapay: Get Payment Request
+	POS Server->>Centrapay: Create Payment Request with Barcode
 
-		alt Payment Condition Pending
+	loop Poll until final state
+		POS Server->>Centrapay: Get Payment Request
+
+		opt Payment Condition Pending
 			note over POS: ❓ Prompt Cashier to Accept or Decline Condition
-			POS->>Centrapay: POS Accepts Condition
-		else Payment Request Status is paid
-			Note over POS: Stop Polling for Confirmation
+      POS->>POS Server: Accept Condition
+			POS Server->>Centrapay: Accept Condition
 		end
 	end
+
+  POS Server->>POS: Send Payment Status
 
 	Note over POS: ✅ Display Successful Payment
 ```
@@ -61,7 +65,7 @@ sequenceDiagram
 
     ![The back of an example Farmlands card, displaying a barcode and a 9-digit card number](/farmlands-card.png)
 
-2. The POS [creates a Payment Request](/api/payment-requests#create-a-payment-request) with the Farmlands Card barcode.
+2. The POS server [creates a Payment Request](/api/payment-requests#create-a-payment-request) with the Farmlands Card barcode.
 
     ```bash {% title="Request" %}
     curl -X POST https://service.centrapay.com/api/payment-requests \
@@ -155,7 +159,7 @@ sequenceDiagram
     }
     ```
 
-3. The POS [polls the Payment Request](/api/payment-requests#get-a-payment-request) every second for status changes.
+3. The POS server [polls the Payment Request](/api/payment-requests#get-a-payment-request) every second for status changes.
 
     ```bash {% title="Request" %}
     curl https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw \
@@ -219,7 +223,8 @@ sequenceDiagram
     }
     ```
 
-4. [Polling the Payment Request](/api/payment-requests#get-a-payment-request) returns a list of pending `merchantConditions` in the response. The POS must prompt the cashier to [accept](/api/payment-requests#accept-a-payment-condition) or [decline](/api/payment-requests#decline-a-payment-condition) each [Payment Condition](#payment-conditions) in order to successfully complete a payment.
+4. [Polling the Payment Request](/api/payment-requests#get-a-payment-request) may return a list of pending `merchantConditions` in the response.
+   The POS must prompt the cashier to [accept](/api/payment-requests#accept-a-payment-condition) or [decline](/api/payment-requests#decline-a-payment-condition) each [Payment Condition](#payment-conditions) in order to successfully complete a payment.
 
     ```bash {% title="Request" %}
     curl -X POST https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw/conditions/1/accept \
@@ -246,7 +251,7 @@ sequenceDiagram
     }
     ```
 
-    A successful payment is identified when all Payment Conditions have an `accepted` status and the [Payment Request](/api/payment-requests/) status is `paid`. Here, the POS must stop polling and display confirmation of the successful payment.
+    A successful payment is identified when all Payment Conditions have an `accepted` status and the [Payment Request](/api/payment-requests/) status is `paid`. Here, the POS server should stop polling and display confirmation of the successful payment.
 
     ```bash {% title="Request" %}
     curl https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw \
@@ -382,41 +387,51 @@ autonumber
 
 participant Cardholder
 participant POS
+participant POS Server
 participant Centrapay
 
 Note over Cardholder: Present Barcode
 Cardholder->>POS: Scan Barcode
 
-POS->>Centrapay: Create Payment Request with Barcode and the preAuth flag
+POS->>POS Server: Request Payment
+
+POS Server->>Centrapay: Create Payment Request with Barcode and the preAuth flag
 
 loop Poll for Payment Confirmation
-	POS->>Centrapay: Get Payment Request
+	POS Server->>Centrapay: Get Payment Request
 
-	alt Payment Condition Pending
-			note over POS: ❓ Prompt Cashier to Accept or Decline Condition
-			POS->>Centrapay: POS Accepts Condition
-		else Payment Request Status is paid
-			Note over POS: Stop Polling for Confirmation
-		end
+  opt Payment Condition Pending
+    note over POS: ❓ Prompt Cashier to Accept or Decline Condition
+    POS->>POS Server: Accept Condition
+    POS Server->>Centrapay: Accepts Condition
+  end
 end
+
+POS Server->>POS: Send Payment Status
 
 Note over POS: ✅ Display Authorization Confirmation
 
-Note over POS, Centrapay: ⏱ Some time later..
+Note over Cardholder, Centrapay: ⏱ Some time later..
 
 loop 0..Many (Up to Authorised Amount)
-	POS->>Centrapay: Make Confirmations Against Authorised Funds
-
+  POS->>POS Server: Request Confirmation
+	POS Server->>Centrapay: Make Confirmations Against Authorised Funds
+	Centrapay->>POS Server: Response
+  POS Server->>POS: Send Confirmation Status
 	Note over POS: ✅ Display Confirmation
 end
 
-POS->>Centrapay: Release Remaining Authorised Funds
-Note over POS: ✅ Display Release confirmation
-
+opt Order completed without using all Authorised funds
+  POS->>POS Server: Request Release of Authorised Funds
+  POS Server->>Centrapay: Release Remaining Authorised Funds
+  Centrapay->>POS Server: Response
+  POS Server->>POS: Send Release Status
+  Note over POS: ✅ Display Release confirmation
+end
 ```
 
 1. The Cardholder presents their Farmlands Card for the POS to scan.
-2. The POS authorises a Pre Auth payment by [creating a Payment Request](/api/payment-requests#create-a-payment-request) with the barcode on the Farmlands Card and the `preauth` flag. Creating a Payment Request must also enable the [Payment Conditions](#payment-conditions) extension and include full details for all [Line Items](/api/payment-requests#line-item-model).
+2. The POS server authorises a Pre Auth payment by [creating a Payment Request](/api/payment-requests#create-a-payment-request) with the barcode on the Farmlands Card and the `preauth` flag. Creating a Payment Request must also enable the [Payment Conditions](#payment-conditions) extension and include full details for all [Line Items](/api/payment-requests#line-item-model).
 
     ```bash {% title="Request" %}
     curl -X POST https://service.centrapay.com/api/payment-requests \
@@ -509,7 +524,7 @@ Note over POS: ✅ Display Release confirmation
     }
     ```
 
-3. The POS [polls the Payment Request](/api/payment-requests#get-a-payment-request) every second for status changes.
+3. The POS server [polls the Payment Request](/api/payment-requests#get-a-payment-request) every second for status changes.
 
     ```bash {% title="Request" %}
     curl https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw \
@@ -573,7 +588,8 @@ Note over POS: ✅ Display Release confirmation
     }
     ```
 
-4. [Polling the Payment Request](/api/payment-requests#get-a-payment-request) returns a list of pending `merchantConditions` in the response. The POS must prompt the cashier to [accept](/api/payment-requests#accept-a-payment-condition) or [decline](/api/payment-requests#decline-a-payment-condition) each [Payment Condition](#payment-conditions) in order to successfully authorise a Pre Auth payment.
+4. [Polling the Payment Request](/api/payment-requests#get-a-payment-request) returns a list of pending `merchantConditions` in the response.
+   The POS must prompt the cashier to [accept](/api/payment-requests#accept-a-payment-condition) or [decline](/api/payment-requests#decline-a-payment-condition) each [Payment Condition](#payment-conditions) in order to successfully authorise a Pre Auth payment.
 
     ```bash {% title="Request" %}
     curl -X POST https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw/conditions/1/accept \
@@ -600,7 +616,8 @@ Note over POS: ✅ Display Release confirmation
     }
     ```
 
-    A successful authorisation is identified when all Payment Conditions have an `accepted` status, the [Payment Request](/api/payment-requests/) status is `paid` and the `preAuthStatus` is `authorized`. Here, the POS must stop polling and display confirmation of the successful authorisation.
+    A successful authorisation is identified when all Payment Conditions have an `accepted` status, the [Payment Request](/api/payment-requests/) status is `paid` and the `preAuthStatus` is `authorized`.
+    Here, the POS server must stop polling and display confirmation of the successful authorisation.
 
     ```bash {% title="Request" %}
     curl https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw \
@@ -665,7 +682,8 @@ Note over POS: ✅ Display Release confirmation
     }
     ```
 
-5. When the purchase is ready to be fulfilled, the POS [makes a Pre Auth confirmation](/api/payment-requests#confirm-pre-auth-payment-request) against the [Payment Request](/api/payment-requests/). Multiple confirmations can be performed against an authorisation but the total value cannot exceed the original authorised value.
+5. When the purchase is ready to be fulfilled, the POS server [makes a Pre Auth confirmation](/api/payment-requests#confirm-pre-auth-payment-request) against the [Payment Request](/api/payment-requests/).
+   Multiple confirmations can be performed against an authorisation but the total value cannot exceed the original authorised value.
 
     ```bash {% title="Request" %}
     curl -X POST https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw/confirm \
@@ -721,8 +739,8 @@ Note over POS: ✅ Display Release confirmation
     }
     ```
 
-6. The POS [releases any remaining authorised funds](/api/payment-requests#release-pre-auth-funds) against the [Payment Request](/api/payment-requests/) back to the Cardholder.
-To confirm if there are funds requiring release you can [list payment activities](/api/payment-requests#list-payment-activities-for-a-payment-request) and sum the confirmation [payment activities](/api/payment-requests#payment-activity-model).
+6. The POS server [releases any remaining authorised funds](/api/payment-requests#release-pre-auth-funds) against the [Payment Request](/api/payment-requests/) back to the Cardholder.
+   To confirm if there are funds requiring release you can [list payment activities](/api/payment-requests#list-payment-activities-for-a-payment-request) and sum the confirmation [payment activities](/api/payment-requests#payment-activity-model).
 
     > Only call release if there are funds requiring release.
 
@@ -846,19 +864,26 @@ sequenceDiagram
 
 	participant Cardholder
 	participant POS
+	participant POS Server
 	participant Centrapay
 
 	Cardholder->>POS: Present Transaction Reference
 
-	Note over POS: Look up Payment Request ID
+  POS->>POS Server: Send Payment Reference
 
-	POS->>Centrapay: Refund Payment Request
+	Note over POS Server: Look up Payment Request ID
+
+	POS Server->>Centrapay: Refund Payment Request
+
+  Centrapay->>POS Server: Refund Status
+
+  POS Server->>POS: Send Refund Status
 
 	Note over POS: ✅ Display Refund Confirmation
 ```
 
 1. The Cardholder presents a transaction reference on their paper receipt. The POS looks up the [Payment Request](/api/payment-requests/) ID using the transaction reference.
-2. The POS [refunds the Payment Request](/api/payment-requests#refund-a-payment-request) using its ID.
+2. The POS server[refunds the Payment Request](/api/payment-requests#refund-a-payment-request) using its ID.
 
     ```bash {% title="Request" %}
     curl -X POST https://service.centrapay.com/api/payment-requests/{paymentRequestId}/refund \

--- a/src/content/guides/merchant-integration-barcode-flow.mdoc
+++ b/src/content/guides/merchant-integration-barcode-flow.mdoc
@@ -18,27 +18,31 @@ sequenceDiagram
 
 	participant Patron
 	participant POS
+  participant POS Server
 	participant Centrapay
 
 	Note over Patron: Present Barcode
 	Patron->>POS: Scan Barcode
 
-	POS->>Centrapay: Create Payment Request with Barcode
+  POS->>POS Server: Request Payment
+
+	POS Server->>Centrapay: Create Payment Request with Barcode
 
 	par
-		loop
-			POS->>Centrapay: Poll for Payment Confirmation
+		loop Poll until final state
+			POS Server->>Centrapay: Get Payment Request
 		end
 
 		Patron->>Centrapay: Pay Payment Request
 	end
 
+  POS Server->>POS: Send Payment Status
+
 	Note over POS: ✅ Display Successful Payment
-	Note over Patron: ✅ Display Successful Payment
 ```
 
 1. The patron presents a Barcode for the POS to scan.
-2. The POS [creates a Centrapay Payment Request](/api/payment-requests#create-a-payment-request) with the Barcode.
+2. The POS server [creates a Centrapay Payment Request](/api/payment-requests#create-a-payment-request) with the Barcode.
 
     ```bash {% title="Request" %}
     curl -X POST https://service.centrapay.com/api/payment-requests \
@@ -83,7 +87,7 @@ sequenceDiagram
     }
     ```
 
-3. The POS [polls the Payment Request for](/api/payment-requests#get-a-payment-request) Payment Confirmation.
+3. The POS server [polls the Payment Request for](/api/payment-requests#get-a-payment-request) Payment Confirmation.
 
     ```bash {% title="Request" %}
     curl https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw \
@@ -118,7 +122,7 @@ sequenceDiagram
     }
     ```
 
-4. While the POS continues to poll, the patron [pays the Payment Request](/api/payment-requests#pay-a-payment-request) via their Centrapay integrated app.
+4. While the POS server continues to poll, the patron [pays the Payment Request](/api/payment-requests#pay-a-payment-request) via their Centrapay integrated app.
 
     ```bash {% title="Request" %}
     curl -X POST https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw/pay \
@@ -152,7 +156,8 @@ sequenceDiagram
     ```
 
 
-    When the Payment Request status is `paid`, the POS stops polling and displays confirmation of the successful payment.
+   When the Payment Request status is in a final state (`paid`, `cancelled` or `expired`).
+   The POS server stops polling and the POS displays the result.
 
     ```bash {% title="Request" %}
     curl https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw \
@@ -190,7 +195,7 @@ sequenceDiagram
 
 ## Quick Pay Flow
 
-Quick Pay is used to immediately confirm the payment without requiring patron approval.
+Quick Pay is used to immediately complete the payment without requiring patron approval.
 
 The patron’s barcode must be linked to an asset type that allows Quick Pay in order to use this flow. See [Asset Types](/api/asset-types) for the list of asset types that support Quick Pay.
 
@@ -200,24 +205,28 @@ sequenceDiagram
 
 	participant Patron
 	participant POS
+	participant POS Server
 	participant Centrapay
 
 	Note over Patron: Present Barcode
 	Patron->>POS: Scan Barcode
 
-	POS->>Centrapay: Create Payment Request with Barcode
+  POS->>POS Server: Request Payment
 
-	loop
-		POS->>Centrapay: Poll for Payment Confirmation
-		note over Centrapay: Automatically Confirm the Payment
+	POS Server->>Centrapay: Create Payment Request with Barcode
+
+  loop Poll until final state
+    POS Server->>Centrapay: Get Payment Request
+		note over Centrapay: Confirm Details and Complete Payment
 	end
 
+  POS Server->>POS: Send Payment Status
+
 	Note over POS: ✅ Display Successful Payment
-	Note over Patron: ✅ Display Successful Payment
 ```
 
 1. The patron presents a Barcode for the POS to scan.
-2. The POS [creates a Centrapay Payment Request](/api/payment-requests#create-a-payment-request) with the Barcode.
+2. The POS server [creates a Centrapay Payment Request](/api/payment-requests#create-a-payment-request) with the Barcode.
 
     ```bash {% title="Request" %}
     curl -X POST https://service.centrapay.com/api/payment-requests \
@@ -262,7 +271,7 @@ sequenceDiagram
     }
     ```
 
-3. The POS [polls the Payment Request for](/api/payment-requests#get-a-payment-request) payment confirmation.
+3. The POS server [polls the Payment Request for](/api/payment-requests#get-a-payment-request) payment completion.
 
     ```bash {% title="Request" %}
     curl https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw \
@@ -296,8 +305,9 @@ sequenceDiagram
       }
     }
     ```
-
-4. When Centrapay receives the first attempt to poll the Payment Request, it will automatically trigger payment. After payment is successful and the Payment Request status is `paid`; the POS stops polling and displays confirmation of the successful payment.
+4. When Centrapay receives the first attempt to poll the Payment Request, it will trigger a payment.
+   When the Payment Request status is in a final state (`paid`, `cancelled` or `expired`).
+   The POS server stops polling and the POS displays the result.
 
     ```bash {% title="Request" %}
     curl https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw \
@@ -335,7 +345,8 @@ sequenceDiagram
 
 ## Checking Barcode Details
 
-The POS can optionally [decode a scanned barcode](/api/scanned-codes#decode-scanned-code) in order to get further details about a barcode before it creates a Payment Request. For example, the POS can use the barcode `provider` to apply any provider-specific discounts before creating the Payment Request.
+The POS server can optionally [decode a scanned barcode](/api/scanned-codes#decode-scanned-code) in order to get further details about a barcode before it creates a Payment Request.
+For example, the POS server can use the barcode `provider` to apply any provider-specific discounts before creating the Payment Request.
 
 ```mermaid
 sequenceDiagram
@@ -343,19 +354,27 @@ sequenceDiagram
 
 	participant Patron
 	participant POS
+	participant POS Server
 	participant Centrapay
 
 	Note over Patron: Present Barcode
 	Patron->>POS: Scan Barcode
 
-	POS->>Centrapay: Decode Barcode
+  POS->>POS Server: Request Barcode Details
+
+	POS Server->>Centrapay: Decode Barcode
+
+  POS Server->>POS: Send Barcode Validity
+
 	Note over POS: Apply Provider Discounts
 
-	POS->>Centrapay: Create Payment Request with Barcode
+  POS->>POS Server: Request Payment
+
+	POS Server->>Centrapay: Create Payment Request with Barcode
 ```
 
 1. The patron presents a barcode for the POS to scan.
-2. The POS [decodes the scanned barcode](/api/scanned-codes#decode-scanned-code) and applies any provider-related discounts.
+2. The POS server [decodes the scanned barcode](/api/scanned-codes#decode-scanned-code) and applies any provider-related discounts.
     ```bash {% title="Request" %}
     curl -X POST https://service.centrapay.com/api/decode \
       -H "Authorization: $jwt" \
@@ -378,7 +397,7 @@ sequenceDiagram
     ```
 
 
-3. The POS [creates a Payment Request](/api/payment-requests#create-a-payment-request) with the barcode and continues with either the [Barcode Flow](#barcode-flow) or [Quick Pay Flow](#quick-pay-flow).
+3. The POS server [creates a Payment Request](/api/payment-requests#create-a-payment-request) with the barcode and continues with either the [Barcode Flow](#barcode-flow) or [Quick Pay Flow](#quick-pay-flow).
 
     ```bash {% title="Request" %}
     curl -X POST https://service.centrapay.com/api/payment-requests \

--- a/src/content/guides/merchant-integration-qr-code-flow.mdoc
+++ b/src/content/guides/merchant-integration-qr-code-flow.mdoc
@@ -16,27 +16,35 @@ sequenceDiagram
 
 	participant Patron
 	participant POS
+  participant POS Server
 	participant Centrapay
 
-	POS->>Centrapay: Create Payment Request
+  POS->>POS Server: Request Payment
+
+	POS Server->>Centrapay: Create Payment Request
+
+  POS Server->>POS: Send Payment Request Details
 
 	note over POS: Present QR Code
 
 	Patron->>POS: Scan QR Code
 
 	par
-		loop
-			POS->>Centrapay: Poll for Payment Confirmation
+		loop Poll until final state
+			POS Server->>Centrapay: Get Payment Request
 		end
 
 		Patron->>Centrapay: Pay Payment Request
 	end
 
+  POS Server->>POS: Send Payment Status
+
 	Note over POS: ✅ Display Successful Payment
 	Note over Patron: ✅ Display Successful Payment
 ```
 
-1. The POS [creates a Payment Request](/api/payment-requests#create-a-payment-request) and presents a QR code to the Patron on a customer-facing display.
+1. The POS server [creates a Payment Request](/api/payment-requests#create-a-payment-request).
+   The POS then presents a QR code to the Patron on a customer-facing display.
 
     > The QR code decodes to a URL of the form `https://app.centrapay.com/pay/{paymentRequestId}`
 
@@ -80,7 +88,7 @@ sequenceDiagram
     ```
 
 2. The patron scans the QR code using a Centrapay-enabled app.
-3. The POS [polls the Payment Request for](/api/payment-requests#get-a-payment-request) Payment Confirmation.
+3. The POS server [polls the Payment Request for](/api/payment-requests#get-a-payment-request) Payment Confirmation.
 
     ```bash {% title="Request" %}
     curl https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw \
@@ -113,7 +121,9 @@ sequenceDiagram
     }
     ```
 
-4. While the POS continues to poll, the patron [pays the Payment Request](/api/payment-requests#pay-a-payment-request) via their Centrapay integrated app. When the Payment Request status is `paid`, the POS stops polling and displays confirmation of the successful payment.
+4. While the POS server continues to poll, the patron [pays the Payment Request](/api/payment-requests#pay-a-payment-request)
+   via their Centrapay integrated app. When the Payment Request status is in a final state (`paid`, `cancelled` or `expired`).
+   The POS server stops polling and the POS displays the result.
 
     ```bash {% title="Request" %}
     curl -X POST https://service.centrapay.com/api/payment-requests/MhocUmpxxmgdHjr7DgKoKw/pay \

--- a/src/content/guides/requesting-payment.mdoc
+++ b/src/content/guides/requesting-payment.mdoc
@@ -41,14 +41,14 @@ Short codes can be used for [Initiating Refunds](/guides/initiating-refunds).
 
 ## Polling for Payment Confirmation
 
-After connecting with the patron, the POS must [poll the Payment Request status](/api/payment-requests#get-a-payment-request) every second until the status has changed.
+After connecting with the patron, the POS server must [poll the Payment Request status](/api/payment-requests#get-a-payment-request) every second until the status has changed.
 
 ```mermaid
 sequenceDiagram
 	autonumber
 
 	participant Patron
-	participant POS
+	participant POS as POS Server
 	participant Centrapay
 
 	Patron->>POS: Connect with Patron


### PR DESCRIPTION
There was some feedback from an integrator that they were confused with the naming and thought that their POS should be making the API calls to Centrapay. 
This PR updates the references from POS to POS server where the entity is making API calls to Centrapay.

![image](https://github.com/user-attachments/assets/c1832b12-b1e7-4ea4-b857-954adec188df)
![image](https://github.com/user-attachments/assets/3b139c56-1c55-4f8b-87ce-468312497aa8)
![image](https://github.com/user-attachments/assets/45b3c573-ef0d-4856-a735-95c2ecf3547b)
![image](https://github.com/user-attachments/assets/312b8ae7-bb22-45b7-a1da-64d22acfdf5f)
![image](https://github.com/user-attachments/assets/58633c85-6d13-457a-a45d-c269876b1357)
![image](https://github.com/user-attachments/assets/1c872f20-8c25-4719-bc87-0be05c533c4c)
![image](https://github.com/user-attachments/assets/81b50079-eefc-4ba5-a497-2ffa800fb73d)


Testing Steps:
* Check updated pages have been updated.