### PR TITLE
Update the list payment requests by external reference API to match the route

### DIFF
--- a/src/content/api/_endpoints/payment-requests-list-by-external-ref.js
+++ b/src/content/api/_endpoints/payment-requests-list-by-external-ref.js
@@ -6,7 +6,7 @@ export default {
       'X-Api-Key': '<TOKEN>',
     },
     queryString: {
-      accountId: '1mdj7bj95gjo92r0ux6wfy69gj3h77',
+      merchantAccountId: '1mdj7bj95gjo92r0ux6wfy69gj3h77',
     },
   },
   response: {

--- a/src/content/api/payment-requests.mdoc
+++ b/src/content/api/payment-requests.mdoc
@@ -586,12 +586,15 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
   Results are [paginated](/api/pagination/).
 
   {% properties %}
-    {% property name="accountId" type="string" required=true %}
-      The id of the [Account](/api/accounts/) used to create the Payment Request.
+    {% property name="merchantAccountId" type="string" required=true %}
+      The [Account](/api/accounts/) of the merchant that the Payment Request was created for.
     {% /property %}
     {% property name="pageKey" type="string" %}
       Used to retrieve the next page of items.
       Note: The `pageKey` value, if provided, needs to be URL-encoded.
+    {% /property %}
+    {% property name="paginationLimit" type="string" %}
+      Maximum number of Payment Requests to return.
     {% /property %}
   {% /properties %}
 {% /endpoint %}


### PR DESCRIPTION
Story: https://www.notion.so/centrapay/Support-Search-Not-Working-Cleanup-183a9ab17e808056840ffc97340fbd68?pvs=4

The API had some changes recently, this updates the docs to match the current API spec.