### PR TITLE
feat: add ciba support doc on authorize bank connection intent

### DIFF
--- a/src/content/api/bank-account-connection-intents.mdoc
+++ b/src/content/api/bank-account-connection-intents.mdoc
@@ -48,10 +48,6 @@ A Bank Account Connection Intent facilitates user authorization of access to Ban
     A URL to the third-party beginning the authorization flow.
   {% /property %}
 
-  {% property name="authRequestId" type="string" %}
-    A unique identifier to be used to poll for the authorization status.
-  {% /property %}
-
   {% property name="test" type="boolean" %}
     A flag which is present if the intention is to connect with a [Bank Account](/api/bank-accounts) used for testing.
   {% /property %}

--- a/src/content/api/bank-account-connection-intents.mdoc
+++ b/src/content/api/bank-account-connection-intents.mdoc
@@ -122,8 +122,13 @@ A Bank Account Connection Intent facilitates user authorization of access to Ban
   This endpoint allows you to authorize a Bank Account Connection Intent.
 
   {% properties %}
-    {% property name="code" type="string" required=true %}
+    {% property name="code" type="string" %}
       Authorization code returned from third-party.
     {% /property %}
+  {% /properties %}
+  {% properties heading="Errors" %}
+    {% error code="403" message="AUTHORIZATION_PENDING" %}
+      User has not completed steps to authorize the consent
+    {% /error %}
   {% /properties %}
 {% /endpoint %}

--- a/src/content/api/bank-account-connection-intents.mdoc
+++ b/src/content/api/bank-account-connection-intents.mdoc
@@ -48,6 +48,10 @@ A Bank Account Connection Intent facilitates user authorization of access to Ban
     A URL to the third-party beginning the authorization flow.
   {% /property %}
 
+  {% property name="authRequestId" type="string" %}
+    A unique identifier to be used to poll for the authorization status.
+  {% /property %}
+
   {% property name="test" type="boolean" %}
     A flag which is present if the intention is to connect with a [Bank Account](/api/bank-accounts) used for testing.
   {% /property %}


### PR DESCRIPTION
This pr updates the bank connection intent doc with ciba support documentation.  

Notion ticket: https://www.notion.so/centrapay/142a9ab17e80815a81dac890d397fde5?v=142a9ab17e8081ad8fc7000c66a4de11&p=196a9ab17e80808c9deecb8b6d6100b1&pm=s

Before 
![Screenshot 2025-02-11 at 3 20 37 PM](https://github.com/user-attachments/assets/83012787-e1a4-40fa-8624-621177db10d3)

After 
![Screenshot 2025-02-11 at 3 20 52 PM](https://github.com/user-attachments/assets/34a6e72c-8359-42d1-b9a1-2eb63592191b)

Test plans:
- [ ] Bank Connection Intent doc should load 
- [ ] Expect the CIBA docs to display under Bank Connection Intent doc
