### PR TITLE
update list promotion memberships docs to include loyaltyProgramId param

### DIFF
--- a/src/content/api/_endpoints/promotion-memberships-list.js
+++ b/src/content/api/_endpoints/promotion-memberships-list.js
@@ -5,6 +5,9 @@ export default {
     headers: {
       'X-Api-Key': '<TOKEN>',
     },
+    queryString: {
+      loyaltyProgramIU: 'WRhAxxWpTKb5U7pXyxQjjY',
+    }
   },
   response: {
     items: [

--- a/src/content/api/promotion-memberships.mdoc
+++ b/src/content/api/promotion-memberships.mdoc
@@ -70,7 +70,7 @@ Promotion Memberships represents an [Account's](/api/accounts) membership to a [
     The list of [Conditions](/api/promotions#promotion-condition-model) that need to be met when incrementing/completing the Promotion.
   {% /property %}
 
-   {% property name="description" type="string" %}
+  {% property name="description" type="string" %}
     Displayable description for the Promotion.
   {% /property %}
 
@@ -112,4 +112,11 @@ Promotion Memberships represents an [Account's](/api/accounts) membership to a [
   ## List Promotion Memberships by Account {% badge type="experimental" /%}
 
   Returns a [paginated](/api/pagination/) list of Promotion Memberships for an [Account](/api/accounts)
+
+  ### Query Parameters
+  {% properties %}
+    {% property name="loyaltyProgramId" type="string" %}
+      The Loyalty Program to fetch promotion memberships for
+    {% /property %}
+  {% /properties %}
 {% /endpoint %}

--- a/src/content/api/promotion-memberships.mdoc
+++ b/src/content/api/promotion-memberships.mdoc
@@ -116,7 +116,7 @@ Promotion Memberships represents an [Account's](/api/accounts) membership to a [
   ### Query Parameters
   {% properties %}
     {% property name="loyaltyProgramId" type="string" %}
-      The Loyalty Program to fetch promotion memberships for
+      The [Loyalty Program](/api/loyalty-programs) to fetch promotion memberships for
     {% /property %}
   {% /properties %}
 {% /endpoint %}


### PR DESCRIPTION
This updates the docs for list promotion memberships api to include the new loyaltyProgramId param

Test Plan:
- Ensure the page displays correctly

![image](https://github.com/user-attachments/assets/280833c7-d1be-4b9d-91ce-7eec40c8d817)
