### PR TITLE
fix typo in list promotion memberships example

### DIFF
--- a/src/content/api/_endpoints/promotion-memberships-list.js
+++ b/src/content/api/_endpoints/promotion-memberships-list.js
@@ -6,7 +6,7 @@ export default {
       'X-Api-Key': '<TOKEN>',
     },
     queryString: {
-      loyaltyProgramIU: 'WRhAxxWpTKb5U7pXyxQjjY',
+      loyaltyProgramId: 'WRhAxxWpTKb5U7pXyxQjjY',
     }
   },
   response: {


### PR DESCRIPTION
There was a typo in the previous change: https://github.com/centrapay/centrapay-docs/pull/1166

Test Plan:
- expect typo to be fixed