### PR TITLE
Add API to Get Merchant Config by Id

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -213,7 +213,7 @@ exports[`the build should not break any links 1`] = `
   "/api/merchant-configs",
   "/api/merchant-configs#create-merchant-config",
   "/api/merchant-configs#get-merchant-config",
-  "/api/merchant-configs#get-merchant-config-by-config-id",
+  "/api/merchant-configs#get-merchant-config-by-id",
   "/api/merchant-configs#list-merchant-configs",
   "/api/merchant-configs#merchant-config-model",
   "/api/merchant-configs#payment-option-config-model",

--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -213,6 +213,7 @@ exports[`the build should not break any links 1`] = `
   "/api/merchant-configs",
   "/api/merchant-configs#create-merchant-config",
   "/api/merchant-configs#get-merchant-config",
+  "/api/merchant-configs#get-merchant-config-by-config-id",
   "/api/merchant-configs#list-merchant-configs",
   "/api/merchant-configs#merchant-config-model",
   "/api/merchant-configs#payment-option-config-model",

--- a/src/content/api/_endpoints/legacy-merchant-configs-get.js
+++ b/src/content/api/_endpoints/legacy-merchant-configs-get.js
@@ -1,6 +1,6 @@
 export default {
   method: 'GET',
-  path: '/api/merchant-configs/mc_5ee168e8597be5002af7b454',
+  path: '/api/merchants/5ee0c486308f590260d9a07f/configs/5ee168e8597be5002af7b454',
   request: {
     headers: {
       'X-Api-Key': '<TOKEN>',

--- a/src/content/api/legacy-payment-requests.mdoc
+++ b/src/content/api/legacy-payment-requests.mdoc
@@ -224,7 +224,7 @@ is returned with the payment request info as `payments[].ledger`.
   path="/payments/api/requests.pay"
   filename="legacy-payment-requests-pay"
 %}
-  ## Pay a Payment Request <{% badge type="deprecated" /%}
+  ## Pay a Payment Request {% badge type="deprecated" /%}
 
   This endpoint allows you to pay a Payment Request.
 

--- a/src/content/api/merchant-configs.mdoc
+++ b/src/content/api/merchant-configs.mdoc
@@ -110,9 +110,20 @@ See [Asset Types](/api/asset-types) for values that may be present in the `type`
 
 {% endpoint
   path="/api/merchants/{merchantId}/configs/{configId}"
+  filename="legacy-merchant-configs-get"
+%}
+  ## Get Merchant Config {% badge type="deprecated" /%}
+
+  This endpoint allows you to retrieve a Merchant Config by Merchant id and Merchant Config id.
+{% /endpoint %}
+
+---
+
+{% endpoint
+  path="/api/merchant-configs/{configId}"
   filename="merchant-configs-get"
 %}
-  ## Get Merchant Config
+  ## Get Merchant Config by Config Id
 
   This endpoint allows you to retrieve a Merchant Config by id.
 {% /endpoint %}

--- a/src/content/api/merchant-configs.mdoc
+++ b/src/content/api/merchant-configs.mdoc
@@ -109,21 +109,10 @@ See [Asset Types](/api/asset-types) for values that may be present in the `type`
 ---
 
 {% endpoint
-  path="/api/merchants/{merchantId}/configs/{configId}"
-  filename="legacy-merchant-configs-get"
-%}
-  ## Get Merchant Config {% badge type="deprecated" /%}
-
-  This endpoint allows you to retrieve a Merchant Config by Merchant id and Merchant Config id.
-{% /endpoint %}
-
----
-
-{% endpoint
   path="/api/merchant-configs/{configId}"
   filename="merchant-configs-get"
 %}
-  ## Get Merchant Config by Config Id
+  ## Get Merchant Config by Id
 
   This endpoint allows you to retrieve a Merchant Config by id.
 {% /endpoint %}
@@ -169,4 +158,15 @@ See [Asset Types](/api/asset-types) for values that may be present in the `type`
       An item in the `collectionIds` array does not exist or does not belong to a supported collection type.
     {% /error %}
   {% /properties %}
+{% /endpoint %}
+
+---
+
+{% endpoint
+  path="/api/merchants/{merchantId}/configs/{configId}"
+  filename="legacy-merchant-configs-get"
+%}
+  ## Get Merchant Config {% badge type="deprecated" /%}
+
+  This endpoint allows you to retrieve a Merchant Config by Merchant id and Merchant Config id.
 {% /endpoint %}


### PR DESCRIPTION
Changes made in this PR:

- Updated the docs to include the new API for GET merchant config by config id.
- The existing GET merchant config API is being deprecated, so related files have been renamed with "legacy" for clarity and a deprecated badge is added

**API Design** is [here](https://www.notion.so/centrapay/Get-MerchantConfig-By-Config-ID-1a8a9ab17e8080ae93d6fa94c2080946?pvs=4)

**Story** is [here](https://www.notion.so/centrapay/Create-Endpoint-to-validate-merchantConfig-1a7a9ab17e8080f6a8dcd972c103e565?pvs=4)

**Related PRs:**
- Permission https://github.com/centrapay/styx/pull/250
- API: https://github.com/centrapay/kari/pull/679

### Test Plan ###
Ensure the page display correctly
<img width="256" alt="Screenshot 2025-03-06 at 12 16 44 PM" src="https://github.com/user-attachments/assets/d334eed0-3b91-40aa-a6b4-520176d20f73" />

#### New API ####
<img width="1199" alt="Screenshot 2025-03-06 at 12 14 12 PM" src="https://github.com/user-attachments/assets/f8a90c8d-08c8-4443-9f49-902bf2ca777b" />

#### Deprecated API is located at the bottom of the page ####
<img width="1490" alt="Screenshot 2025-03-06 at 12 14 06 PM" src="https://github.com/user-attachments/assets/726a3a91-00fb-491f-849a-c212b5befbb2" />

