### PR TITLE
♻️ Create Media Uploads Endpoint

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -208,7 +208,7 @@ exports[`the build should not break any links 1`] = `
   "/api/managed-integrations#params-model",
   "/api/managed-integrations#terminal-model",
   "/api/media-uploads",
-  "/api/media-uploads#create-a-presigned-url-for-media-upload",
+  "/api/media-uploads#create-a-media-upload",
   "/api/media-uploads#get-media-upload-location",
   "/api/media-uploads#media-upload-model",
   "/api/merchant-configs",

--- a/src/content/api/_endpoints/media-uploads-create.js
+++ b/src/content/api/_endpoints/media-uploads-create.js
@@ -4,16 +4,24 @@ export default {
   request: {
     headers: {
       'X-Api-Key': '<TOKEN>',
-      'Content-Type': 'application/json',
+      'Content-Type': 'multipart/form-data',
     },
-    payload: {
-      accountId: 'Jaim1Cu1Q55uooxSens6yk',
-      mimeType: 'image/png',
-      fileName: 'image.png'
-    },
+    postData: {
+      mimeType: 'multipart/form-data',
+      params: [
+        {
+          name: 'purpose',
+          value: 'branding-logo'
+        },
+        {
+          name: 'file',
+          fileName: '/path/to/a/file.png',
+          contentType: 'image/png'
+        }
+      ]
+    }
   },
   response: {
     id: 'DKTs3U38hdhfEqwF1JKoT2',
-    uploadUrl: 'https://media-upload.centrapay.com/image.png?jhbdsfau67ewejshb=487hsdjhbdgs743'
   }
 };

--- a/src/content/api/media-uploads.mdoc
+++ b/src/content/api/media-uploads.mdoc
@@ -13,16 +13,12 @@ nav:
     The Media Upload's unique identifier.
   {% /property %}
 
-  {% property name="accountId" type="string" %}
-    The Media Upload's owning Centrapay Account id.
+  {% property name="file" type="object" %}
+    A file to upload. Make sure that the specifications follow [RFC 2388](https://datatracker.ietf.org/doc/html/rfc2388), which defines file transfers for the multipart/form-data protocol.
   {% /property %}
 
-  {% property name="mimeType" type="string" %}
-    The media (MIME) type of the upload.
-  {% /property %}
-
-  {% property name="fileName" type="string" %}
-    The file name of the upload.
+  {% property name="purpose" type="string" %}
+    The [purpose](#purpose) of the Media Upload.
   {% /property %}
 
   {% property name="createdAt" type="timestamp" %}
@@ -40,11 +36,17 @@ nav:
   {% property name="updatedBy" type="crn" %}
     The User or API Key that updated the Media Upload.
   {% /property %}
-
-  {% property name="uploadUrl" type="string" %}
-    A presigned URL that gives users time-limited permission to upload media.
-  {% /property %}
 {% /properties %}
+
+
+### Purpose
+
+Each valid purpose has specific file format and size requirements.
+
+|          Purpose           |                          Description                          | Supported MIME Types | Max Size |
+| -------------------------- | ------------------------------------------------------------- | -------------------- | -------- |
+| `asset-program-onboarding` | A file used to onboard Asset Programs.                        | CSV                  | 50KB     |
+| `branding-logo`            | A logo used for any branding including [Tokens](http://localhost:4321/api/tokens) and [Businesses](http://localhost:4321/api/businesses). | JPEG, PNG            | 512KB    |
 
 ---
 
@@ -52,22 +54,25 @@ nav:
   path="/api/media-uploads"
   filename="media-uploads-create"
 %}
-  ## Create a presigned URL for Media Upload {% badge type="experimental" /%}
+  ## Create a Media Upload {% badge type="experimental" /%}
 
-  This endpoint allows you to upload a media file to Centrapay. It returns a presigned URL that can be used to download the media file.
+  This endpoint allows you to upload a file to Centrapay.
 
   {% properties %}
-    {% property name="accountId" type="string" required=true %}
-      The Media Upload's owning Centrapay Account id.
-    {% /property %}
+      {% property name="file" type="object" required=true %}
+        A file to upload. Make sure that the specifications follow [RFC 2388](https://datatracker.ietf.org/doc/html/rfc2388), which defines file transfers for the multipart/form-data protocol.
+      {% /property %}
 
-    {% property name="mimeType" type="string" required=true %}
-      The media (MIME) type of the upload.
-    {% /property %}
+      {% property name="purpose" type="string" required=true %}
+        The [purpose](#purpose) of the Media Upload.
+      {% /property %}
+  {% /properties %}
 
-    {% property name="fileName" type="string" required=true %}
-      The file name of the upload.
-    {% /property %}
+
+  {% properties heading="Errors" %}
+    {% error code="403" message="FILE_TYPE_INVALID" %}
+      Invalid file extension or mime type provided for the purpose.
+    {% /error %}
   {% /properties %}
 {% /endpoint %}
 

--- a/src/utils/__tests__/__snapshots__/createEndpoint.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/createEndpoint.test.js.snap
@@ -1,5 +1,14 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`createEndpoint > creates a snippet for a multipart/form-data request 1`] = `
+"curl -X POST \\
+ https://service.centrapay.com/api/test \\
+ -H 'content-type: multipart/form-data' \\
+ -H 'x-api-key: <TOKEN>' \\
+ -F foo=bar \\
+ -F file=@file.png"
+`;
+
 exports[`createEndpoint > creates a valid JSON response 1`] = `
 "{
   "foo": "bar",

--- a/src/utils/__tests__/createEndpoint.test.js
+++ b/src/utils/__tests__/createEndpoint.test.js
@@ -72,6 +72,34 @@ describe('createEndpoint', () => {
     expect(endpoint.response).toMatchSnapshot();
   });
 
+  it('creates a snippet for a multipart/form-data request', () => {
+    const endpoint = createEndpoint({
+      method: 'POST',
+      path: '/api/test',
+      request: {
+        headers: {
+          'X-Api-Key': '<TOKEN>',
+          'Content-Type': 'multipart/form-data',
+        },
+        postData: {
+          mimeType: 'multipart/form-data',
+          params: [
+            {
+              name: 'foo',
+              value: 'bar'
+            },
+            {
+              name: 'file',
+              fileName: 'file.png',
+              contentType: 'image/png'
+            }
+          ]
+        }
+      },
+    });
+    expect(endpoint.requests.curl.code).toMatchSnapshot();
+  });
+
   describe('invalid scenarios', () => {
     const invalidScenarios = [
       {

--- a/src/utils/createEndpoint.js
+++ b/src/utils/createEndpoint.js
@@ -43,6 +43,9 @@ function createSnippet(data) {
       text: JSON.stringify(data.request.payload)
     };
   }
+  if (data.request?.postData) {
+    harObject.postData = data.request?.postData;
+  }
   return new HTTPSnippet(harObject);
 }
 


### PR DESCRIPTION
Change experimental Media Uploads endpoint.

Changes:
- Allow creating multipart/form-data endpoints.
- Update Media Uploads model, and create a list of purposes.
- Update Create Media Uploads endpoint.

Test plan: Expect to see docs updated per screenshots.

<img width="1198" alt="image" src="https://github.com/user-attachments/assets/a7ab2aa7-b3d9-48e7-86ed-10f4ec87e09c" />

<img width="860" alt="Screenshot 2025-03-11 at 10 21 59 am" src="https://github.com/user-attachments/assets/09c30489-77f7-41a1-bab0-3b372cec5e69" />