### PR TITLE
📝 Add media upload file size error

### DIFF
--- a/src/content/api/media-uploads.mdoc
+++ b/src/content/api/media-uploads.mdoc
@@ -73,6 +73,9 @@ Each valid purpose has specific file format and size requirements.
     {% error code="403" message="FILE_TYPE_INVALID" %}
       Invalid file extension or mime type provided for the purpose.
     {% /error %}
+    {% error code="403" message="FILE_TOO_LARGE" %}
+      File size exceeds the allowed threshold.
+    {% /error %}
   {% /properties %}
 {% /endpoint %}
 


### PR DESCRIPTION
Add error when file is too large.

API Design: https://www.notion.so/centrapay/Create-Media-Upload-1aba9ab17e8080eeba3bf9b7da5b3b34

Test plan: Expect to see per screenshot.