### PR TITLE
Update compatible terminals

### DIFF
--- a/src/content/guides/compatible-devices.mdoc
+++ b/src/content/guides/compatible-devices.mdoc
@@ -45,7 +45,7 @@ The Centrapay service is supported on a range of payment and point of sale devic
 - M400
 - M424
 - M440
-- P400
+- P400 (P400 PLUS)
 - P630
 - V200T
 - V205C
@@ -53,11 +53,7 @@ The Centrapay service is supported on a range of payment and point of sale devic
 - V240M
 - V400
 - V400C
-- VX675
-- VX680
 - VX690
-- VX820
-- VX820 Duet
 - UX700 (Unattended Android)
 
 ## Windcave


### PR DESCRIPTION
As per sales and cs request update to terminal information page

Testing Steps
* See that P400 is changed to P400 (P400 PLUS)
* See that the following terminals are removed
- Verifone VX675
- Verifone VX680
- Verifone VX820
- Verifone VX820 Duet