### PR TITLE
Update promotion model to include supply limit and remaining supply fields

### DIFF
--- a/src/content/api/_endpoints/promotions-create.js
+++ b/src/content/api/_endpoints/promotions-create.js
@@ -31,7 +31,8 @@ export default {
           operator: 'greater-than'
         }
       ],
-      description: 'The amount of the payment must be greater than $1.'
+      description: 'The amount of the payment must be greater than $1.',
+      supplyLimit: '10'
     },
   },
   response: {
@@ -64,6 +65,8 @@ export default {
       }
     ],
     description: 'The amount of the payment must be greater than $1.',
+    supplyLimit: '10',
+    remainingSupply: '10',
     createdAt: '2023-02-08T04:04:27.426Z',
     createdBy: 'crn::user:1234',
     updatedAt: '2023-02-08T04:04:27.426Z',

--- a/src/content/api/_endpoints/promotions-list-by-accountId.js
+++ b/src/content/api/_endpoints/promotions-list-by-accountId.js
@@ -38,6 +38,8 @@ export default {
             operator: 'greater-than'
           }
         ],
+        supplyLimit: '10',
+        remainingSupply: '3',
         createdAt: '2023-02-08T04:04:27.426Z',
         createdBy: 'crn::user:1234',
         updatedAt: '2023-02-08T04:04:27.426Z',

--- a/src/content/api/_endpoints/promotions-list-by-loyaltyProgramId.js
+++ b/src/content/api/_endpoints/promotions-list-by-loyaltyProgramId.js
@@ -38,6 +38,8 @@ export default {
             operator: 'greater-than'
           }
         ],
+        supplyLimit: '10',
+        remainingSupply: '7',
         createdAt: '2023-02-08T04:04:27.426Z',
         createdBy: 'crn::user:1234',
         updatedAt: '2023-02-08T04:04:27.426Z',

--- a/src/content/api/promotions.mdoc
+++ b/src/content/api/promotions.mdoc
@@ -77,6 +77,14 @@ Promotions are a mechanism to reward accounts for completing certain actions.
   {% property name="createdBy" type="crn" %}
     The User or API Key that created the Promotion.
   {% /property %}
+
+  {% property name="supplyLimit" type="string" %}
+    The maximum number of [Promotion Memberships](/api/promotion-memberships) that can be created.
+  {% /property %}
+
+  {% property name="remainingSupply" type="string" %}
+    The number of [Promotion Memberships](/api/promotion-memberships) still available to be created.
+  {% /property %}
 {% /properties %}
 
 ## Promotion Target Model
@@ -190,6 +198,10 @@ Promotions are a mechanism to reward accounts for completing certain actions.
 
     {% property name="description" type="string" %}
       Displayable description for the Promotion.
+    {% /property %}
+
+    {% property name="supplyLimit" type="string" %}
+    The maximum number of [Promotion Memberships](/api/promotion-memberships) that can be created.
     {% /property %}
   {% /properties %}
 


### PR DESCRIPTION
This PR is related to https://github.com/centrapay/kari/pull/694  - Setting supply limit on promotions

- `supplyLimit` is an optional payload.
- `supplyLimit` and `remainingSupply` are returned in the API responses

### Test Plan ### 
Ensure the pages display correctly
- In the **Promotion model** section:
    - [ ] `supplyLimit` and `remainingSupply` fields are added
- In **Create Promotion** section:
    - [ ] `supplyLimit` is included in the attributes and request payload
   -  [ ]  `supplyLimit` and `remainingSupply` fields are returned in the response
- In **List Promotions by Account** section: 
   -  [ ]  `supplyLimit` and `remainingSupply` fields are returned in the response
- In **List Promotions by Loyalty Program** section: 
   -  [ ]  `supplyLimit` and `remainingSupply` fields are returned in the response 