### PR TITLE
♻️ Fix business-onboarding purpose

### DIFF
--- a/src/content/api/media-uploads.mdoc
+++ b/src/content/api/media-uploads.mdoc
@@ -43,9 +43,9 @@ nav:
 
 Each valid purpose has specific file format and size requirements.
 
-|        Purpose        |                          Description                          | Supported MIME Types | Max Size |
-| --------------------- | ------------------------------------------------------------- | -------------------- | -------- |
-| `business-onboarding` | A file used to onboard Asset Programs.                        | CSV                  | 50KB     |
+|        Purpose        |                             Description                             | Supported MIME Types | Max Size |
+| --------------------- | ------------------------------------------------------------------- | -------------------- | -------- |
+| `business-onboarding` | A file used to onboard Businesses so that they can accept payments. | CSV                  | 50KB     |
 | `branding-logo`       | A logo used for any branding including [Tokens](http://localhost:4321/api/tokens) and [Businesses](http://localhost:4321/api/businesses). | JPEG, PNG            | 512KB    |
 
 ---


### PR DESCRIPTION
Fix description to remove reference to asset programs.

Test plan: Expect to see updated description on media uploads page.