### PR TITLE
add docs for get promotion api

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -287,6 +287,7 @@ exports[`the build should not break any links 1`] = `
   "/api/promotion-memberships#promotion-membership-model",
   "/api/promotions",
   "/api/promotions#create-promotion",
+  "/api/promotions#get-promotion",
   "/api/promotions#list-promotions-by-account",
   "/api/promotions#list-promotions-by-loyalty-program",
   "/api/promotions#promotion-condition-model",

--- a/src/content/api/_endpoints/promotions-get.js
+++ b/src/content/api/_endpoints/promotions-get.js
@@ -1,0 +1,46 @@
+export default {
+  method: 'GET',
+  path: '/api/promotions/8aoMfscvtuewsuJzmzBzAs',
+  request: {
+    headers: {
+      'X-Api-Key': '<TOKEN>',
+    },
+  },
+  response: {
+    id: '8aoMfscvtuewsuJzmzBzAs',
+    accountId: '57SyRRgZ1U8Kq2wKpCnSR5',
+    programId: 'WRhAxxWpTKb5U7pXyxQjjY',
+    name: 'Spend a Buck',
+    summary: 'Make a payment',
+    description: 'The amount of the payment must be greater than $1.',
+    mediaUploadId: '26yUWG6wFgmva8UaDiCTWq',
+    img: 'https://media-upload.centrapay.com/image.png?jhbdsfau67ewejshb=487hsdjhbdgs743',
+    startsAt: '2023-02-16T00:47:54.131Z',
+    endsAt: '2024-02-16T00:47:54.131Z',
+    rewards: [
+      {
+        assetType: 'centrapay.nzd.main',
+        amount: '500',
+      }
+    ],
+    eventType: 'payment',
+    target: {
+      type: 'count',
+      amount: 1
+    },
+    type: 'challenge',
+    conditions: [
+      {
+        field: 'amount',
+        value: '100',
+        operator: 'greater-than'
+      }
+    ],
+    supplyLimit: '10',
+    remainingSupply: '7',
+    createdAt: '2023-02-08T04:04:27.426Z',
+    createdBy: 'crn::user:1234',
+    updatedAt: '2023-02-08T04:04:27.426Z',
+    updatedBy: 'crn::user:1234',
+  }
+};

--- a/src/content/api/promotions.mdoc
+++ b/src/content/api/promotions.mdoc
@@ -215,6 +215,17 @@ Promotions are a mechanism to reward accounts for completing certain actions.
 ---
 
 {% endpoint
+  path="/api/promotions/{promotionId}"
+  filename="promotions-get"
+%}
+  ## Get Promotion {% badge type="experimental" /%}
+
+  Allows the user to get a Promotion
+{% /endpoint %}
+
+---
+
+{% endpoint
   path="/api/accountId/{id}/promotions"
   filename="promotions-list-by-accountId"
 %}


### PR DESCRIPTION
This adds docs for the get promotion api

Test Plan: Ensure the page displays properly

![image](https://github.com/user-attachments/assets/efbbeaf9-feda-4714-9f83-bfc26fe50952)
