### PR TITLE
add repeatable flag to create promotion docs

### DIFF
--- a/src/content/api/_endpoints/promotions-create.js
+++ b/src/content/api/_endpoints/promotions-create.js
@@ -32,7 +32,8 @@ export default {
         }
       ],
       description: 'The amount of the payment must be greater than $1.',
-      supplyLimit: '10'
+      supplyLimit: '10',
+      repeatable: true
     },
   },
   response: {
@@ -49,6 +50,9 @@ export default {
       {
         assetType: 'centrapay.nzd.main',
         amount: '500',
+      },
+      {
+        promotionId: '8aoMfscvtuewsuJzmzBzAs',
       }
     ],
     eventType: 'payment',
@@ -71,5 +75,6 @@ export default {
     createdBy: 'crn::user:1234',
     updatedAt: '2023-02-08T04:04:27.426Z',
     updatedBy: 'crn::user:1234',
+    repeatable: true
   },
 };

--- a/src/content/api/promotions.mdoc
+++ b/src/content/api/promotions.mdoc
@@ -201,7 +201,11 @@ Promotions are a mechanism to reward accounts for completing certain actions.
     {% /property %}
 
     {% property name="supplyLimit" type="string" %}
-    The maximum number of [Promotion Memberships](/api/promotion-memberships) that can be created.
+      The maximum number of [Promotion Memberships](/api/promotion-memberships) that can be created.
+    {% /property %}
+
+    {% property name="repeatable" type="boolean" %}
+      Flag indicating that the promotion will reward itself upon completion. This will mean that members can complete the promotion an unlimited number of times.
     {% /property %}
   {% /properties %}
 


### PR DESCRIPTION
This adds docs for the new repeatable flag available when creating promotions

Test Plan: Ensure the page displays as intended

![image](https://github.com/user-attachments/assets/5a06033b-0a48-4d48-9e95-26aaec0fa6ea)
