### PR TITLE
❌ Remove Skyzer from supported devices

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -349,7 +349,6 @@ exports[`the build should not break any links 1`] = `
   "/guides/compatible-devices#on-this-page-title",
   "/guides/compatible-devices#salespoint",
   "/guides/compatible-devices#sektor",
-  "/guides/compatible-devices#skyzer",
   "/guides/compatible-devices#smartpay",
   "/guides/compatible-devices#verifone",
   "/guides/compatible-devices#windcave",

--- a/src/content/guides/compatible-devices.mdoc
+++ b/src/content/guides/compatible-devices.mdoc
@@ -28,10 +28,6 @@ The Centrapay service is supported on a range of payment and point of sale devic
 - Pax IM30
 - Pax XA35
 
-## Skyzer
-- Desk 5000
-- Move 5000
-
 ## Smartpay
 - Pax S800
 - S900


### PR DESCRIPTION
We are having issues with Skyzer terminals and therefore do not want to currently document these devices as supported.

Test plan: Expect Skyzer removed from supported devices page.