### PR TITLE
update docs for create and get wallet

### DIFF
--- a/src/content/api/_endpoints/wallets-create.js
+++ b/src/content/api/_endpoints/wallets-create.js
@@ -1,6 +1,6 @@
 export default {
   method: 'POST',
-  path: '/api/wallets',
+  path: '/api/wallet-assets',
   request: {
     headers: {
       'X-Api-Key': '<TOKEN>',

--- a/src/content/api/_endpoints/wallets-list.js
+++ b/src/content/api/_endpoints/wallets-list.js
@@ -1,6 +1,6 @@
 export default {
   method: 'GET',
-  path: '/api/wallets',
+  path: '/api/wallet-assets',
   request: {
     headers: {
       'X-Api-Key': '<TOKEN>',

--- a/src/content/api/wallets.mdoc
+++ b/src/content/api/wallets.mdoc
@@ -125,7 +125,7 @@ A Settlement Wallet is a special type of Wallet that can only receive or refund 
 
 ---
 
-{% endpoint path="/api/wallets" filename="wallets-create" %}
+{% endpoint path="/api/wallet-assets" filename="wallets-create" %}
   ## Create a Wallet
 
   This endpoint allows you to create a Wallet.
@@ -154,7 +154,7 @@ A Settlement Wallet is a special type of Wallet that can only receive or refund 
 
 ---
 
-{% endpoint path="/api/wallets" filename="wallets-list" %}
+{% endpoint path="/api/wallet-assets" filename="wallets-list" %}
   ## List Wallets
 
   This endpoint allows you to list authorized Wallets.


### PR DESCRIPTION
Test Plan: 
- Ensure the docs show as `/wallet-assets` for the route to call

![image](https://github.com/user-attachments/assets/330c797f-f8f9-45b8-a606-044082cd3a2a)
