### PR TITLE
add docs for get applet api

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -32,6 +32,7 @@ exports[`the build should not break any links 1`] = `
   "/api/applets#applet-extensions",
   "/api/applets#applet-model",
   "/api/applets#create-applet",
+  "/api/applets#get-applet",
   "/api/applets#list-applets",
   "/api/applets#loyalty-extension-model",
   "/api/asset-activities",

--- a/src/content/api/_endpoints/applets-get.js
+++ b/src/content/api/_endpoints/applets-get.js
@@ -1,0 +1,28 @@
+export default {
+  method: 'GET',
+  path: '/api/applets/a_WRhAxxWpTKb5U7pXyxQjjY',
+  request: {
+    headers: {
+      'X-Api-Key': '<TOKEN>',
+      'Content-Type': 'application/json',
+    },
+  },
+  response: {
+    id: 'a_WRhAxxWpTKb5U7pXyxQjjY',
+    name: 'Centrapay Cafe',
+    mediaUploadId: '8aoMfscvtuewsuJzmzBzAs',
+    img: 'https://media-upload.centrapay.com/image.png?jhbdsfau67ewejshb=487hsdjhbdgs743',
+    accountId: 'Jaim1Cu1Q55uooxSens6yk',
+    createdAt: '2021-08-25T00:02:49.488Z',
+    createdBy: 'crn::user:b657195e-dc2f-11ea-8566-e7710d592c99',
+    extensions: [
+      {
+        type: 'loyalty',
+        loyaltyProgramId: 'L001',
+        getPromotionsUrl: 'service.payap.com/api/loyaltyPrograms/L001/promotions',
+        getPromotionMembershipsUrl: 'service.payap.com/api/loyaltyPrograms/L001/promotionMemberships',
+        getLoyaltyProgramUrl: 'service.payap.com/api/loyaltyPrograms/L001'
+      }
+    ]
+  }
+};

--- a/src/content/api/applets.mdoc
+++ b/src/content/api/applets.mdoc
@@ -134,3 +134,15 @@ An applet is a discoverable container of functions and features that users can a
 {% /endpoint %}
 
 ---
+
+{% endpoint
+  path="/api/applets/{id}"
+  filename="applets-get"
+%}
+  ## Get Applet {% badge type="experimental" /%}
+
+  Get an Applet based on it's ID
+
+{% /endpoint %}
+
+---


### PR DESCRIPTION
Adds docs for the new get applet API

Test Plan: 
- Ensure the docs show as expected

![image](https://github.com/user-attachments/assets/318aad4a-849e-4dec-9777-36eb818e49d8)
