### PR TITLE
fix grammar for get applet api docs

### DIFF
--- a/src/content/api/applets.mdoc
+++ b/src/content/api/applets.mdoc
@@ -141,7 +141,7 @@ An applet is a discoverable container of functions and features that users can a
 %}
   ## Get Applet {% badge type="experimental" /%}
 
-  Get an Applet based on it's ID
+  Get an Applet based on its ID
 
 {% /endpoint %}
 


### PR DESCRIPTION
Fixes the incorrect it's / its usage 