### PR TITLE
add connectionId to payment request docs

### DIFF
--- a/src/content/api/_endpoints/payment-requests-create.js
+++ b/src/content/api/_endpoints/payment-requests-create.js
@@ -31,6 +31,7 @@ export default {
           discount: '600'
         }
       ],
+      connectionId: 'cn_9asd9k19',
     },
   },
   response: {
@@ -102,5 +103,7 @@ export default {
         discount: '600'
       }
     ],
+    connectionId: 'cn_9asd9k19',
+    connectionStatus: 'active',
   }
 };

--- a/src/content/api/_endpoints/payment-requests-get-by-patron-code.js
+++ b/src/content/api/_endpoints/payment-requests-get-by-patron-code.js
@@ -33,6 +33,8 @@ export default {
     updatedAt: '2021-06-08T04:04:27.426Z',
     expiresAt: '2021-06-08T04:06:27.426Z',
     liveness: 'test',
-    expirySeconds: 120
+    expirySeconds: 120,
+    connectionId: 'cn_9asd9k19',
+    connectionStatus: 'active',
   }
 };

--- a/src/content/api/_endpoints/payment-requests-get-by-short-code.js
+++ b/src/content/api/_endpoints/payment-requests-get-by-short-code.js
@@ -33,6 +33,8 @@ export default {
     updatedAt: '2021-06-08T04:04:27.426Z',
     expiresAt: '2021-06-08T04:06:27.426Z',
     liveness: 'test',
-    expirySeconds: 120
+    expirySeconds: 120,
+    connectionId: 'cn_9asd9k19',
+    connectionStatus: 'active',
   }
 };

--- a/src/content/api/_endpoints/payment-requests-get.js
+++ b/src/content/api/_endpoints/payment-requests-get.js
@@ -75,6 +75,8 @@ export default {
     updatedAt: '2021-06-08T04:04:27.426Z',
     expiresAt: '2021-06-08T04:06:27.426Z',
     liveness: 'test',
-    expirySeconds: 120
+    expirySeconds: 120,
+    connectionId: 'cn_9asd9k19',
+    connectionStatus: 'active',
   }
 };

--- a/src/content/api/_endpoints/payment-requests-list-by-external-ref.js
+++ b/src/content/api/_endpoints/payment-requests-list-by-external-ref.js
@@ -45,7 +45,9 @@ export default {
         }
       ],
       status: 'new',
-      liveness: 'test'
+      liveness: 'test',
+      connectionId: 'cn_9asd9k19',
+      connectionStatus: 'active',
     }],
     pageKey: '12312312',
   }

--- a/src/content/api/payment-requests.mdoc
+++ b/src/content/api/payment-requests.mdoc
@@ -150,6 +150,12 @@ Centrapay Payment Requests are serviced via two sets of endpoints; the â€œnextâ€
   {% property name="basketAmount" type="bignumber" %}
     The total amount of the transaction including non Centrapay payment methods.
   {% /property %}
+  {% property name="connectionId" type="string" experimental=true %}
+    The identifier of the [Connection](/api/connections) associated with the payment request.
+  {% /property %}
+  {% property name="connectionStatus" type="string" experimental=true %}
+    The status of the [Connection](/api/connections) associated with the payment request.
+  {% /property %}
 {% /properties %}
 
 ---
@@ -535,6 +541,9 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
     {% property name="basketAmount" type="bignumber" %}
       The total amount of the transaction including non Centrapay payment methods. Required when `partialAllowed` is `true`.
     {% /property %}
+    {% property name="connectionId" type="string" %}
+      The identifier of the connection to be linked to the payment request.
+    {% /property %}
   {% /properties %}
 
   {% properties heading="Errors" %}
@@ -555,6 +564,15 @@ Payment Activities are created when a Payment Request has been `created`, `paid`
     {% /error %}
     {% error code="403" message="TOKEN_COLLECTION_NOT_FOUND" %}
       The token collection does not exist.
+    {% /error %}
+    {% error code="403" message="CONNECTION_NOT_FOUND" %}
+      The connection does not exist.
+    {% /error %}
+    {% error code="403" message="CONNECTION_MERCHANT_MISMATCH" %}
+      The connection is not for the same merchant as the payment request.
+    {% /error %}
+    {% error code="403" message="CONNECTION_CREATED_BY_MISMATCH" %}
+      The connection was not created by the same caller as the payment request.
     {% /error %}
   {% /properties %}
 


### PR DESCRIPTION
Adds the connectionId field to the create and get/list payment request docs

Test Plan: 
- Ensure the pages are all displayed correctly

![image](https://github.com/user-attachments/assets/07b34c76-a1c3-4170-adfe-90941f852f6f)
![image](https://github.com/user-attachments/assets/ea7dbbcc-5a0f-40e4-a4a2-0f8ef5506353)
