### PR TITLE
Fix smart pay guide link

### DIFF
--- a/src/content/guides/processing-centrapay-transactions.mdoc
+++ b/src/content/guides/processing-centrapay-transactions.mdoc
@@ -89,7 +89,7 @@ Currently, users can scan Centrapay QR codes through multiple methods, including
 ## More detailed terminal manuals
 For the manual of specific terminal models, please refer to:
 
-* [Smartpay](/terminalGuides/smartPay.pdf)
+* [Smartpay](/terminalGuides/smart-pay.pdf)
 * [Windcave](/terminalGuides/windcave.pdf)
 * [Verifone](/terminalGuides/verifone.pdf)
 


### PR DESCRIPTION
The smart pay guide wasn't working as the link was incorrect.

Testing Steps:
* Click smartpay guide link in the processing centrapay transactions page
* See that the pdf is displayed