### PR TITLE
Remove collapsable property button

### DIFF
--- a/src/components/Properties.astro
+++ b/src/components/Properties.astro
@@ -5,55 +5,11 @@ const { heading = 'Attributes' } = Astro.props;
 <div data-attributes class="my-6">
   <div class="not-prose flex items-center justify-between py-2">
     <h3 class="type-subtitle-1">{ heading }</h3>
-    <button data-expand-button class="type-overline text-content-tertiary hover:text-content-secondary">
-      Collapse all
-    </button>
   </div>
   <ul
-    data-attribute-list
     role="list"
     class="m-0 list-none divide-y divide-outline-transparent border-y border-outline-transparent p-0 pt-4"
   >
     <slot />
   </ul>
 </div>
-
-<script>
-  import getElement from '../utils/getElement';
-
-  for (const attributesSection of document.querySelectorAll('[data-attributes]')) {
-    const button = getElement('[data-expand-button]', HTMLButtonElement, attributesSection);
-    const attributeList = getElement('[data-attribute-list]', HTMLUListElement, attributesSection);
-    button.addEventListener('click', () => {
-      button.textContent = button.innerText === 'EXPAND ALL' ? 'COLLAPSE ALL' : 'EXPAND ALL';
-      const expandables = attributeList.querySelectorAll('[data-expandable-slot]');
-      for (const expandable of expandables) {
-        if (expandable.classList.contains('collapsed')) {
-          expandable.classList.remove('collapsed');
-          expandable.classList.add('expanded');
-        } else {
-          expandable.classList.remove('expanded');
-          expandable.classList.add('collapsed');
-        }
-      }
-    });
-  }
-</script>
-
-<style is:global>
-  .expanded {
-    @apply
-      pt-2
-      opacity-100
-      scale-y-100
-    ;
-  }
-
-  .collapsed {
-    @apply
-      h-0
-      opacity-0
-      scale-y-0
-    ;
-  }
-</style>


### PR DESCRIPTION
Remove collapsable property button in preparation of an upgrade to Tailwind v4. This button doesn't provide enough utility to be useful to documentation readers.

Future changes will deal with our vertical scroll
issues in an alternative way.

Test plan:
- Confirm "collapse" button is no longer present of our API docs