### PR TITLE
Remove desktop-gutters class

### DIFF
--- a/src/assets/css/tailwind.css
+++ b/src/assets/css/tailwind.css
@@ -3,4 +3,3 @@
 @import "tailwindcss/components";
 
 @import "tailwindcss/utilities";
-@import "./utilities";

--- a/src/assets/css/utilities/index.css
+++ b/src/assets/css/utilities/index.css
@@ -1,1 +1,0 @@
-@import "responsive";

--- a/src/assets/css/utilities/responsive.css
+++ b/src/assets/css/utilities/responsive.css
@@ -1,9 +1,0 @@
-@layer utilities {
-  .desktop-gutters {
-    @apply
-      max-w-6xl
-      mx-auto
-      w-full
-    ;
-  }
-}

--- a/src/components/Farmlands.astro
+++ b/src/components/Farmlands.astro
@@ -9,7 +9,7 @@ import VerifiedCheck from './icons/VerifiedCheck.astro';
   <header
     class="not-prose bg-[#174B33] bg-[url('/countryside.jpg')] bg-cover bg-bottom bg-blend-overlay"
   >
-    <div class="desktop-gutters space-y-6 px-8 py-16">
+    <div class="mx-auto w-full max-w-6xl space-y-6 px-8 py-16">
       <h1 class="type-display mb-8 mt-4 text-content-inverse-primary">
         <b>Farmlands</b>
       </h1>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -6,7 +6,7 @@ import GithubLogo from './icons/GithubLogo.astro';
 const year = new Date().getFullYear();
 ---
 <footer class="mt-auto bg-surface-tertiary">
-  <div class="desktop-gutters mx-auto px-6 py-8 md:flex md:items-center md:justify-between lg:px-8">
+  <div class="mx-auto w-full max-w-6xl px-6 py-8 md:flex md:items-center md:justify-between lg:px-8">
     <div class="flex space-x-6 md:order-2">
       <a
         href="https://x.com/centrapay"

--- a/src/layouts/ConnectionLayout.astro
+++ b/src/layouts/ConnectionLayout.astro
@@ -8,7 +8,7 @@ const { title, description, img, navigation } = Astro.props;
   <div>
     <slot name="header" />
     <div>
-      <div class="desktop-gutters relative mx-auto flex justify-center">
+      <div class="relative mx-auto flex w-full max-w-6xl justify-center">
         <div class="min-w-0 max-w-2xl flex-auto px-8 pb-16 pt-8 lg:max-w-none xl:pt-16">
           <article>
             <h2 class="type-headline-2 mb-12">

--- a/src/pages/api/[...id].astro
+++ b/src/pages/api/[...id].astro
@@ -19,7 +19,7 @@ const previewImg = entry.data.img || '/default-cover.jpg';
 const { title, description } = entry.data;
 ---
 <BaseLayout title={title} description={description} img={previewImg} navigation={navigation}>
-  <div class="desktop-gutters relative mx-auto flex justify-center">
+  <div class="relative mx-auto flex w-full max-w-6xl justify-center">
     <div class="min-w-0 flex-auto p-8">
       <article>
         <Prose>


### PR DESCRIPTION
Remove desktop-gutters class in favour of inline tailwind classes to simplify an upcoming tailwind css upgrade to v4.

Test plan:
- Confirm affected layouts have no visual regressions