### PR TITLE
Add paymentRequestId into the Transaction Attempt Model

### DIFF
--- a/src/content/guides/integrating-third-party-asset.mdoc
+++ b/src/content/guides/integrating-third-party-asset.mdoc
@@ -189,6 +189,7 @@ Centrapay will retry a transaction attempt immediately when an HTTP response sta
 | failureReason        | String                                 | optional   | Required if the status is failed. See possible failure reasons under each API below.                     |
 | refundable           | Boolean                                | optional   | Required if type is payment and status is successful. A flag indicating whether a payment is refundable. |
 | refundBefore         | [Timestamp](/api/data-types#timestamp) | optional   | The latest time at which a refund can be initiated.                                                      |
+| paymentRequestId     | String                                 | optional   | A unique identifier for the original Payment request.                                                    |
 | idempotencyKey       | String                                 | deprecated | A unique value that can be used to recognize subsequent retries of the same request.                     |
 
 ### Statuses
@@ -243,7 +244,8 @@ curl -X POST https://your.endpoint/pay \
       "country": "NZ",
       "street": "17 South Street"
     },
-		"idempotencyKey": "UttDGTHjr7DgKoKwWpTKb"
+    "paymentRequestId": "LTsofbYSldsp35psd",
+		"idempotencyKey": "UttDGTHjr7DgKoKwWpTKb",
 		"transactionId": "UttDGTHjr7DgKoKwWpTKb"
   }'
 ```
@@ -264,6 +266,7 @@ curl -X POST https://your.endpoint/pay \
     "country": "NZ",
     "street": "17 South Street"
   },
+  "paymentRequestId": "LTsofbYSldsp35psd",
   "transactionId": "UttDGTHjr7DgKoKwWpTKb",
   "type": "payment",
   "status": "successful",


### PR DESCRIPTION
Part of the coke flow

Coke want a paymentRequestId field on the Uplink API transaction attempt model.

[Notion](https://www.notion.so/centrapay/Add-payment-request-ID-to-Uplink-API-transaction-attempt-233a9ab17e8080d59a04f3b7252816db)

<img width="1733" height="1029" alt="Screenshot 2025-07-24 at 14 19 47" src="https://github.com/user-attachments/assets/dfffbb72-4c0a-41d4-a4ca-3ce4482bcf20" />
<img width="1737" height="1034" alt="Screenshot 2025-07-24 at 14 20 14" src="https://github.com/user-attachments/assets/bc4b840b-96c3-424b-aecd-56295fe41acb" />
<img width="1726" height="1022" alt="Screenshot 2025-07-24 at 14 20 19" src="https://github.com/user-attachments/assets/d541a809-849e-464f-acf5-9313a8e335a2" />
