### PR TITLE
Accordion component on devices page

### DIFF
--- a/markdoc.config.js
+++ b/markdoc.config.js
@@ -122,5 +122,11 @@ export default defineMarkdocConfig({
     mermaid: {
       render: component('./src/components/Mermaid.astro'),
     },
+    accordion: {
+      render: component('./src/components/Accordion.astro'),
+      attributes: {
+        title: { type: String, required: true },
+      },
+    },
   },
 });

--- a/src/components/Accordion.astro
+++ b/src/components/Accordion.astro
@@ -1,0 +1,41 @@
+---
+import Carat from "./icons/Carat.vue";
+const { title } = Astro.props;
+const contentHtml = (await Astro.slots.render('default'))?.trim();
+const hasContent = contentHtml && contentHtml.length > 0;
+---
+
+<div class="flex flex-col mb-4">
+  <div
+    class="flex justify-between items-center cursor-pointer"
+    onclick="toggleAccordion(this)"
+  >
+    <span class="type-headline-4 font-normal">
+      {title}
+    </span>
+    {hasContent && (
+      <span class="icon transition-transform duration-300">
+        <Carat class="w-4 h-4 transform rotate-0" />
+      </span>
+    )}
+  </div>
+
+  <div class="content max-h-0 overflow-hidden transition-all duration-300 ease-in-out mt-0.5 mb-4">
+    <div class="flex flex-col [&>*]:first:mt-0 [&>*]:mt-0.5" set:html={contentHtml} />
+  </div>
+</div>
+
+<script is:inline>
+  function toggleAccordion(el) {
+    const content = el.parentElement.querySelector('.content');
+    const icon = el.querySelector('.icon svg');
+
+    const isOpen = content.style.maxHeight && content.style.maxHeight !== '0px';
+    content.style.maxHeight = isOpen ? '0' : content.scrollHeight + 'px';
+    if (icon) {
+      icon.style.transform = isOpen ? 'rotate(0deg)' : 'rotate(90deg)';
+    }
+  }
+
+  window.toggleAccordion = toggleAccordion;
+</script>

--- a/src/content/guides/compatible-solutions.mdoc
+++ b/src/content/guides/compatible-solutions.mdoc
@@ -12,15 +12,17 @@ If you would like to discuss a new integration or support of Centrapay on a new 
 
 Centrapay is currently integrated with a wide range of payment and point-of-sale (POS) devices. If your device is not listed, it may not be supported at this time.
 
-### Invenco
+{% accordion title="Invenco" %}
 - G6-300
 - G6-400
 - G6-500
+{% /accordion %}
 
-### SalesPoint
+{% accordion title="SalesPoint" %}
 - Epay Convenience POS (ECP SalesPoint)
+{% /accordion %}
 
-### Sektor
+{% accordion title="Sektor" %}
 - Pax 6650
 - Pax A3700 Tablet
 - Pax A50
@@ -32,13 +34,15 @@ Centrapay is currently integrated with a wide range of payment and point-of-sale
 - Pax E600 Mini
 - Pax IM30
 - Pax XA35
+{% /accordion %}
 
-### Smartpay
+{% accordion title="Smartpay" %}
 - Pax S800
 - S900
 - Pax S920
+{% /accordion %}
 
-### Verifone
+{% accordion title="Verifone" %}
 - Android T650C
 - Android T650M
 - Android T650P
@@ -56,8 +60,9 @@ Centrapay is currently integrated with a wide range of payment and point-of-sale
 - V400
 - V400C
 - VX690
+{% /accordion %}
 
-### Windcave
+{% accordion title="Windcave" %}
 - CHU200M
 - CHU200MP
 - CHU200T
@@ -69,6 +74,9 @@ Centrapay is currently integrated with a wide range of payment and point-of-sale
 - LANE3000
 - MOVE5000
 - MTM300
+{% /accordion %}
+
+{% accordion title="Ontempo" /%}
 
 ## E-commerce Integrations
 


### PR DESCRIPTION
This adds a accordion component to hide the devices on the device page.

<img width="696" height="1030" alt="image" src="https://github.com/user-attachments/assets/fe027f17-b16f-445e-9ac4-ced595cf0290" />
