### PR TITLE
Fix Farmlands partner support guide formatting

### DIFF
--- a/src/content/guides/farmlands-card-partner-support.mdoc
+++ b/src/content/guides/farmlands-card-partner-support.mdoc
@@ -16,32 +16,25 @@ You can also use the Support window inside the Portal.
 
 ### Troubleshooting
 
-**What is the address for the portal?**
+**What is the address for the portal?**  
+<https://app.centrapay.com/business>
 
-https://app.centrapay.com/business
-
-**I am getting an invalid barcode message in the portal**
-
+**I am getting an invalid barcode message in the portal**  
 Double check you are entering the correct length barcode on the card. If you are using the scan feature, try to enter it manually instead.
 
-**What if the barcode will not scan or is obscured?**
+**What if the barcode will not scan or is obscured?**  
+The 9-digit Card number can be entered manually. This is printed on the back below the barcode and on the front of the card under the Cardholder's name. If neither is visible, please request another method of payment. Advise the Cardholder to contact Farmlands on [0800 200 600](tel:0800200600) to request a new Card.
 
-The 9-digit Card number can be entered manually. This is printed on the back below the barcode and on the front of the card under the Cardholder's name. If neither is visible, please request another method of payment. Advise the Cardholder to contact Farmlands on 0800 200 600 to request a new Card.
+**What should I do if the Authorisation is declined?**  
+Request an alternative form of payment from your customer. Refer the Cardholder to Farmlands on [0800 200 600](tel:0800200600) for further information.
 
-**What should I do if the Authorisation is declined?**
-
-Request an alternative form of payment from your customer. Refer the Cardholder to Farmlands on 0800 200 600 for further information.
-
-**How do I check if a transaction was authorised or where can I see the transaction history?**
-
+**How do I check if a transaction was authorised or where can I see the transaction history?**  
 Go to the Payments page on the Centrapay Business Portal, select the transaction related to the Farmlands Authorisation and check that the status is Authorised.
 
-**Is there a portal guide that covers additional Trouble Shooting FAQs and that can help with training?**
-
+**Is there a portal guide that covers additional Trouble Shooting FAQs and that can help with training?**  
 Yes. If you go to the portal and click on the dashboard there is a guides section or go to the [Farmlands Portal Guide](/guides/farmlands-portal)
 
 ## Support for POS Integrators
-
 1. If you require assistance with POS integration functionality contact Centrapay at support@centrapay.com or Farmlands at card.specialist@farmlands.co.nz
 2. If you require assistance with the POS integration contact your POS provider.
 
@@ -49,35 +42,21 @@ Yes. If you go to the portal and click on the dashboard there is a guides sectio
 
 ### P1 - Severe Business Disruption
 
-Centrapay Platform is unable to process transactions initiated by Card Partners
-
-**Target Response:** < 1 hour
-
-**Target Resolution:** 3 hours
+Centrapay Platform is unable to process transactions initiated by Card Partners  
+**Target Response:** < 1 hour  
+**Target Resolution:** 3 hours  
 
 ### P2 - Major Business Disruption
-
-Centrapay Platform unable to:
-
-- provide transaction data to the Customer
-- ingest Customer card updates (full or delta)
-
-**Target Response:** 4 hour
-
-**Target Resolution:** 16 hours
+Centrapay Platform unable to provide transaction data to the Customer or ingest Customer card updates (full or delta)  
+**Target Response:** 4 hour  
+**Target Resolution:** 16 hours  
 
 ### P3 - Minor Business Disruption
-
-Centrapay Platform is operational but suffering performance degradation
-
-**Target Response:** 8 hours
-
-**Target Resolution:** 32 hours
+Centrapay Platform is operational but suffering performance degradation  
+**Target Response:** 8 hours  
+**Target Resolution:** 32 hours  
 
 ### P4 - Adhoc requests as requested by Farmlands
-
-Adhoc requests as requested by Farmlands
-
-**Target Response:** 12 hours
-
+Adhoc requests as requested by Farmlands  
+**Target Response:** 12 hours  
 **Target Resolution:** N/A


### PR DESCRIPTION
After the removal of the disclosure the whitespace was a bit confusing. Especially in the trouble shooting section. This PR tidies up the whitespace a bit.
Original:
<img width="611" height="680" alt="image" src="https://github.com/user-attachments/assets/806eb302-24dd-4738-8645-a6b845efe72d" />

Updated:
<img width="681" height="622" alt="image" src="https://github.com/user-attachments/assets/5e9f2c25-a165-4e2a-961f-db13219a2803" />
