### PR TITLE
Remove 'test' from asset program

### DIFF
--- a/src/content/api/asset-programs.mdoc
+++ b/src/content/api/asset-programs.mdoc
@@ -124,10 +124,6 @@ An Asset Program is provided by an asset issuer as a mechanism that enables busi
   This endpoint allows you to list published [Asset Programs](#asset-program-model).
 
   {% properties %}
-    {% property name="test" type="boolean" %}
-      Filter by test or live Asset Programs. If not specified, returns live Asset Programs only.
-    {% /property %}
-
     {% property name="pageKey" type="string" %}
       The page key used in pagination to fetch the next page of results.
     {% /property %}


### PR DESCRIPTION
Removes 'test' param from endpoint as this is instead filtered by account liveness.