### PR TITLE
Add submenu back for api docs

### DIFF
--- a/src/components/AppShell.astro
+++ b/src/components/AppShell.astro
@@ -4,11 +4,12 @@ import DesktopNavigation from './DesktopNavigation.astro';
 const { path, navigation } = Astro.props;
 
 const navPath = path.endsWith('/') ? path.slice(0, -1) : path;
+const showHeadings = !navPath.startsWith('/guides');
 ---
 
 <div class="flex h-screen w-screen">
   <Header path={navPath} navigation={navigation} />
-  <DesktopNavigation path={navPath} navigation={navigation} />
+  <DesktopNavigation path={navPath} navigation={navigation} showHeadings={showHeadings} />
   <main class="flex min-h-full w-full flex-col pt-16 md:pl-64">
     <slot />
   </main>

--- a/src/components/DesktopNavigation.astro
+++ b/src/components/DesktopNavigation.astro
@@ -1,6 +1,6 @@
 ---
 import Navigation from './Navigation.vue';
-const { path, navigation } = Astro.props;
+const { path, navigation, showHeadings = true } = Astro.props;
 ---
 <div
   id="sidebar"
@@ -10,7 +10,7 @@ const { path, navigation } = Astro.props;
     <Navigation
       navigation={navigation}
       path={path}
-      showHeadings={false}
+      showHeadings={showHeadings}
       client:load
     />
   </div>


### PR DESCRIPTION
We had a regression when removing the submenu for the guides it also removed for the api docs. We need it for the api docs as there is no nav on the right side. This PR adds the submenu back.

Before 
<img width="279" height="407" alt="image" src="https://github.com/user-attachments/assets/1659084b-fe6a-4903-98b8-26086c085155" />

After
<img width="222" height="963" alt="image" src="https://github.com/user-attachments/assets/cc420503-a8ed-4696-858b-b8719aaa8dd1" />
