### PR TITLE
Organise Sales Channel Integrations sidebar into sub-sections

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -20,35 +20,76 @@
             :key="navigationChild.title"
             role="menuitem"
           >
-            <li
-              role="presentation"
-              class="group rounded-md hover:bg-gray-100"
-              :class="{ 'bg-gray-100': path === navigationChild.path}"
-            >
-              <a
-                role="menuitem"
-                class="block py-2 pl-4 text-xs text-gray-600"
-                :href="navigationChild.path"
-              >
+            <template v-if="navigationChild.children?.length && !navigationChild.path">
+              <li class="px-4 pb-1 pt-3 text-xs font-semibold text-gray-400">
                 {{ navigationChild.title }}
-              </a>
-            </li>
-            <div v-if="showHeadings && navigationChild.headings?.length && path === navigationChild.path">
+              </li>
+              <div
+                v-for="subChild in navigationChild.children"
+                :key="subChild.title"
+              >
+                <li
+                  role="presentation"
+                  class="group rounded-md hover:bg-gray-100"
+                  :class="{ 'bg-gray-100': path === subChild.path }"
+                >
+                  <a
+                    role="menuitem"
+                    class="block py-2 pl-6 text-xs text-gray-600"
+                    :href="subChild.path"
+                  >
+                    {{ subChild.title }}
+                  </a>
+                </li>
+                <div v-if="showHeadings && subChild.headings?.length && path === subChild.path">
+                  <li
+                    v-for="navigationGrandchild in subChild.headings"
+                    :key="navigationGrandchild.title"
+                    role="presentation"
+                    class="group rounded-md hover:bg-gray-50"
+                  >
+                    <a
+                      role="menuitem"
+                      class="block py-2 pl-8 text-xs text-gray-600"
+                      :href="`${subChild.path}#${navigationGrandchild.slug}`"
+                    >
+                      {{ navigationGrandchild.text }}
+                    </a>
+                  </li>
+                </div>
+              </div>
+            </template>
+            <template v-else>
               <li
-                v-for="navigationGrandchild in navigationChild.headings"
-                :key="navigationGrandchild.title"
                 role="presentation"
-                class="group rounded-md hover:bg-gray-50"
+                class="group rounded-md hover:bg-gray-100"
+                :class="{ 'bg-gray-100': path === navigationChild.path}"
               >
                 <a
                   role="menuitem"
-                  class="block py-2 pl-6 text-xs text-gray-600"
-                  :href="`${navigationChild.path}#${navigationGrandchild.slug}`"
+                  class="block py-2 pl-4 text-xs text-gray-600"
+                  :href="navigationChild.path"
                 >
-                  {{ navigationGrandchild.text }}
+                  {{ navigationChild.title }}
                 </a>
               </li>
-            </div>
+              <div v-if="showHeadings && navigationChild.headings?.length && path === navigationChild.path">
+                <li
+                  v-for="navigationGrandchild in navigationChild.headings"
+                  :key="navigationGrandchild.title"
+                  role="presentation"
+                  class="group rounded-md hover:bg-gray-50"
+                >
+                  <a
+                    role="menuitem"
+                    class="block py-2 pl-6 text-xs text-gray-600"
+                    :href="`${navigationChild.path}#${navigationGrandchild.slug}`"
+                  >
+                    {{ navigationGrandchild.text }}
+                  </a>
+                </li>
+              </div>
+            </template>
           </div>
         </div>
       </div>

--- a/src/content/guides/ecommerce-website.mdoc
+++ b/src/content/guides/ecommerce-website.mdoc
@@ -3,8 +3,8 @@ title: E-commerce
 description: How to process payments using Centrapay's e-commerce Platform.
 iframe: true
 nav:
-  path: Sales Channel Integrations
-  order: 5
+  path: Sales Channel Integrations/Integration Types
+  order: 3
 ---
 Centrapay enables businesses to process payments with connected Centrapay assets online. To process online payments, businesses need to integrate with one of our redirect or popup e-commerce payment flows.
 

--- a/src/content/guides/initiating-refunds.mdoc
+++ b/src/content/guides/initiating-refunds.mdoc
@@ -2,8 +2,8 @@
 title: Initiating Refunds
 description: How to issue refunds on the Centrapay payment platform.
 nav:
-  path: Sales Channel Integrations
-  order: 11
+  path: Sales Channel Integrations/Operations
+  order: 2
 ---
 
 Refunds are initiated by calling the [Refund Payment Request](/api/payment-requests#refund-a-payment-request) endpoint.

--- a/src/content/guides/line-items.mdoc
+++ b/src/content/guides/line-items.mdoc
@@ -2,8 +2,8 @@
 title: Line Items
 description: Line items are used to communicate the details of a purchase to a patron.
 nav:
-  path: Sales Channel Integrations
-  order: 12
+  path: Sales Channel Integrations/Extensions
+  order: 1
 ---
 [Line Items](/api/payment-requests#line-item-model) are used to communicate the details of a purchase to a patron.
 

--- a/src/content/guides/merchant-integration-barcode-flow.mdoc
+++ b/src/content/guides/merchant-integration-barcode-flow.mdoc
@@ -2,9 +2,9 @@
 title: Barcode Flow for Merchants
 description: How merchants can accept payments by scanning a barcode presented by the patron.
 nav:
-  path: Sales Channel Integrations
+  path: Sales Channel Integrations/Payment Flows
   title: Barcode Flow
-  order: 8
+  order: 3
 ---
 Connecting with patrons using our Barcode Flow requires the patron to present a Barcode and the merchant integration to scan it in order to [create a Payment Request](/api/payment-requests#create-a-payment-request).
 

--- a/src/content/guides/merchant-integration-error-handling.mdoc
+++ b/src/content/guides/merchant-integration-error-handling.mdoc
@@ -2,9 +2,9 @@
 title: Error Handling
 description: How to deal with inconsistencies in Payment Request statuses due to network issues or race conditions.
 nav:
-  path: Sales Channel Integrations
+  path: Sales Channel Integrations/Payment Flows
   title: Error Handling
-  order: 9
+  order: 4
 ---
 Below are our guidelines for dealing with inconsistencies in [Payment Request](/api/payment-requests) statuses due to network issues, race conditions, or [asset](/api/asset-types/) specific behaviours.
 

--- a/src/content/guides/merchant-integration-qr-code-flow.mdoc
+++ b/src/content/guides/merchant-integration-qr-code-flow.mdoc
@@ -2,9 +2,9 @@
 title: QR Code Flow for Merchants
 description: How merchants can accept payments by presenting a QR code to the patron.
 nav:
-  path: Sales Channel Integrations
+  path: Sales Channel Integrations/Payment Flows
   title: QR Code Flow
-  order: 7
+  order: 2
 ---
 Connecting with patrons using our QR Code Flow requires the merchant integration to create a [Payment Request](/api/payment-requests) and present a QR Code for the patron to scan.
 

--- a/src/content/guides/partial-payment-extension.mdoc
+++ b/src/content/guides/partial-payment-extension.mdoc
@@ -2,8 +2,8 @@
 title: Partial Payment
 description: A core feature of the Payment Request Protocol that allows integrators to accept a partial transaction through Centrapay.
 nav:
-  path: Sales Channel Integrations
-  order: 13
+  path: Sales Channel Integrations/Extensions
+  order: 2
 ---
 
 Partial Payment enables patrons to pay using other payment options alongside

--- a/src/content/guides/patron-not-present.mdoc
+++ b/src/content/guides/patron-not-present.mdoc
@@ -2,8 +2,8 @@
 title: Patron Not Present
 description: Centrapay’s Patron Not Present extension allows a merchant to complete a payment when the patron is not physically present at the time of payment.
 nav:
-  path: Sales Channel Integrations
-  order: 16
+  path: Sales Channel Integrations/Extensions
+  order: 5
 ---
 Centrapay’s Patron Not Present extension allows a merchant to complete a payment when the patron is not physically present at the time of payment (e.g. phone-based orders).
 

--- a/src/content/guides/payment-conditions.mdoc
+++ b/src/content/guides/payment-conditions.mdoc
@@ -2,8 +2,8 @@
 title: Payment Conditions
 description: Payment Conditions enable integrations to require conditional approval to accept specific Asset Types as payment.
 nav:
-  path: Sales Channel Integrations
-  order: 14
+  path: Sales Channel Integrations/Extensions
+  order: 3
 ---
 
 Some [Asset Types](/api/asset-types) such as tokens or closed-loop cards may require conditional operator approval. Merchant integrations are required to support [Payment Conditions](/api/payment-requests#payment-condition-model) for these asset types in order for them to be accepted for payment.

--- a/src/content/guides/payment-terminals.mdoc
+++ b/src/content/guides/payment-terminals.mdoc
@@ -2,8 +2,8 @@
 title: Payment Terminal
 description: How to integrate a payment terminal with Centrapay APIs.
 nav:
-  path: Sales Channel Integrations
-  order: 3
+  path: Sales Channel Integrations/Integration Types
+  order: 1
 ---
 
 Integrating a merchant terminal with Centrapay APIs requires creating, cancelling, voiding and refunding [Payment Requests](/api/payment-requests) on behalf of Merchants using a “merchant terminal” API key.

--- a/src/content/guides/point-of-sale.mdoc
+++ b/src/content/guides/point-of-sale.mdoc
@@ -2,8 +2,8 @@
 title: Point of Sale
 description: How to integrate a point of sale (POS) terminal with Centrapay APIs.
 nav:
-  path: Sales Channel Integrations
-  order: 4
+  path: Sales Channel Integrations/Integration Types
+  order: 2
 ---
 
 Integrating a point of sale (POS) terminal with Centrapay APIs allows merchants to accept payment via any Centrapay-enabled apps without installing additional POS hardware or software.

--- a/src/content/guides/requesting-payment.mdoc
+++ b/src/content/guides/requesting-payment.mdoc
@@ -2,8 +2,8 @@
 title: Requesting Payment
 description: How to request payment on the Centrapay payment platform.
 nav:
-  path: Sales Channel Integrations
-  order: 6
+  path: Sales Channel Integrations/Payment Flows
+  order: 1
 ---
 
 Centrapay’s payment protocol requires a merchant integration to connect with the patron in order to create a [Payment Request](/api/payment-requests); and poll it for payment confirmation.

--- a/src/content/guides/requesting-pre-auth.mdoc
+++ b/src/content/guides/requesting-pre-auth.mdoc
@@ -2,8 +2,8 @@
 title: Requesting Pre Auth
 description: Centrapay’s Pre Auth extension allows a patron to authorize payment up to a limit when the actual payment amount is not yet known.
 nav:
-  path: Sales Channel Integrations
-  order: 15
+  path: Sales Channel Integrations/Extensions
+  order: 4
 ---
 
 Centrapay’s Pre Auth extension allows a patron to authorize payment up to a limit when the actual payment amount is not yet known.

--- a/src/content/guides/transaction-reporting.mdoc
+++ b/src/content/guides/transaction-reporting.mdoc
@@ -2,8 +2,8 @@
 title: Transaction Reporting
 description: Guidelines on communicating the Asset Types used for payment to the user in any transaction reporting function on the merchant side.
 nav:
-  path: Sales Channel Integrations
-  order: 10
+  path: Sales Channel Integrations/Operations
+  order: 1
 ---
 
 Centrapay allows merchants to give their patrons choice over which digital assets to use for payment.

--- a/src/navigation/guideNavigation.js
+++ b/src/navigation/guideNavigation.js
@@ -6,7 +6,15 @@ const nav = [
   { title: 'Centrapay Experiences' },
   { title: 'Digital Assets' },
   { title: 'Partner Services' },
-  { title: 'Sales Channel Integrations' },
+  {
+    title: 'Sales Channel Integrations',
+    children: [
+      { title: 'Integration Types', order: 2 },
+      { title: 'Payment Flows', order: 3 },
+      { title: 'Operations', order: 4 },
+      { title: 'Extensions', order: 5 },
+    ],
+  },
   { title: 'App Integrations' },
   { title: 'Payap' },
   { title: 'Farmlands' },


### PR DESCRIPTION
Organise Sales Channel Integrations sidebar into sub-sections
- Extends Navigation.vue to render a third level of hierarchy — sub-section labels with pages indented beneath them
- Adds four sub-sections to guideNavigation.js: Integration Types, Payment Flows, Operations, Extensions
- Updates nav.path and order frontmatter on 14 guides accordingly
<img width="223" height="649" alt="image" src="https://github.com/user-attachments/assets/84326787-885c-4398-bd9a-19a4996fb8c2" />

**Test plan**
- All 14 guides appear under the correct sub-section
- No other sidebar sections affected