### PR TITLE
Fix mobile hamburger menu

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,13 +16,13 @@ const { path, navigation } = Astro.props;
           <span class="sr-only">Go to home page</span>
           <CentrapayLogo class="inline-block size-8 text-content-on-color" />
         </a>
-        <div class="ml-4 flex flex-row gap-2">
+        <div class="ml-4 hidden flex-row gap-2 md:flex">
           <a
             href="/"
             target="_self"
             class="rounded-lg bg-gray-100 px-3 py-2 text-sm font-medium leading-5 text-gray-600 ring-focus-ring hover:bg-gray-200 hover:text-content-primary focus:outline-hidden focus:ring-2 focus:ring-inset"
           >
-            Docs
+            Guides
           </a>
           <a
             href="/api/introduction"

--- a/src/components/MobileMenu.vue
+++ b/src/components/MobileMenu.vue
@@ -3,22 +3,18 @@
     v-slot="{ open }"
     class="static isolate z-50 md:hidden"
   >
-    <div class="py-5">
-      <div class="mx-auto max-w-7xl px-6 lg:px-8">
-        <PopoverButton class="flex items-center ring-focus-ring focus:outline-hidden focus:ring-2 focus:ring-inset">
-          <NavigationMenu
-            v-if="!open"
-            class="block size-6 text-content-tertiary"
-            aria-hidden="true"
-          />
-          <CloseOutline
-            v-else
-            class="block size-6 text-content-tertiary"
-            aria-hidden="true"
-          />
-        </PopoverButton>
-      </div>
-    </div>
+    <PopoverButton class="flex items-center p-2 ring-focus-ring focus:outline-hidden focus:ring-2 focus:ring-inset">
+      <NavigationMenu
+        v-if="!open"
+        class="block size-6 text-content-tertiary"
+        aria-hidden="true"
+      />
+      <CloseOutline
+        v-else
+        class="block size-6 text-content-tertiary"
+        aria-hidden="true"
+      />
+    </PopoverButton>
 
     <transition
       enter-active-class="transition ease-out duration-200"
@@ -30,6 +26,20 @@
     >
       <PopoverPanel class="absolute inset-x-0 inset-y-16 -z-10">
         <div class="relative max-h-[calc(100vh-64px)] w-full flex-1 overflow-y-scroll border-t border-gray-200 bg-surface-primary pb-4 pt-2">
+          <div class="flex flex-col gap-1 border-b border-gray-200 px-4 pb-4 pt-2">
+            <a
+              href="/"
+              class="rounded-lg bg-gray-100 px-3 py-2 text-sm font-medium text-gray-600 hover:bg-gray-200 hover:text-content-primary"
+            >Guides</a>
+            <a
+              href="/api/introduction"
+              class="rounded-lg bg-gray-100 px-3 py-2 text-sm font-medium text-gray-600 hover:bg-gray-200 hover:text-content-primary"
+            >API Reference</a>
+            <a
+              href="/guides/merchant-introduction"
+              class="rounded-lg bg-gray-100 px-3 py-2 text-sm font-medium text-gray-600 hover:bg-gray-200 hover:text-content-primary"
+            >Merchant Services</a>
+          </div>
           <Navigation
             :path="path"
             :navigation="navigation"


### PR DESCRIPTION
When making the changes to add the merchant services section the hamburger menu on mobile was pushed off the edge. This PR puts it back. It also moves the section selection for mobile into the hamburger menu as there isn't much real estate width wise on mobile.

<img width="435" height="860" alt="image" src="https://github.com/user-attachments/assets/e87b6541-a1ad-4494-8582-07315e00c212" />
<img width="440" height="873" alt="image" src="https://github.com/user-attachments/assets/2171131a-40f6-47c7-acd7-b84cea78495a" />

Testing Steps:
* Go to page on mobile see that the hamburger menu is there and click and see the merchant selection