### PR TITLE
Add payap onboarding flow guide

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -496,6 +496,7 @@ exports[`the build should not break any links 1`] = `
   "/guides/partial-payment-extension#partial-payment-flow",
   "/guides/partial-payment-extension#see-also",
   "/guides/patron-not-present",
+  "/guides/payap-onboarding-flow",
   "/guides/payap-third-party-asset-integration",
   "/guides/payap-third-party-asset-integration#asset-type-registration",
   "/guides/payap-third-party-asset-integration#connecting-an-account",

--- a/src/content/guides/payap-onboarding-flow.mdoc
+++ b/src/content/guides/payap-onboarding-flow.mdoc
@@ -1,0 +1,36 @@
+---
+title: Payap Onboarding Flow
+description: Overview of the merchant onboarding workflow for Payap.
+nav:
+  path: Partner Services
+  order: 2
+---
+
+The following diagram outlines the onboarding workflow for Payap, from signing up a merchant through to activation.
+
+```mermaid
+sequenceDiagram
+    participant SoO as Source of Onboarding
+    participant M as Merchant
+    participant C as Centrapay
+    participant SCP as Sales Channel Provider
+
+    SoO->>C: Sign up merchant
+    C->>M: Send invitation email
+    M->>C: Complete on-boarding process
+    Note over C: Perform checks on merchant
+
+    break Declined
+        C->>SoO: Return decline reason
+    end
+
+    C->>SCP: Send terminal information
+    SCP->>C: Loading response
+
+    break Not Loaded
+        C->>SoO: Return reason not loaded
+    end
+
+    Note over C: Activate merchant
+    C->>M: Send welcome email
+```


### PR DESCRIPTION
There are a few referrer partners that want to know the flow of for Payap onboarding. This adds a page to the docs site so that they can get a better understanding on their part.

<img width="1876" height="1041" alt="image" src="https://github.com/user-attachments/assets/3597afd3-dbc8-46ad-b86a-1de9b4232a62" />

Testing Steps:
* Open page and see that it renders correctly