### PR TITLE
Update testing payments page

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -413,7 +413,6 @@ exports[`the build should not break any links 1`] = `
   "/guides/creating-digital-tokens#token-collection",
   "/guides/creating-test-money",
   "/guides/creating-test-money#on-this-page-title",
-  "/guides/creating-test-money#via-api",
   "/guides/creating-test-money#via-centrapay-app",
   "/guides/ecommerce-website",
   "/guides/ecommerce-website#centrapay-checkout-sample",

--- a/src/content/guides/creating-test-money.mdoc
+++ b/src/content/guides/creating-test-money.mdoc
@@ -1,32 +1,15 @@
 ---
-title: Creating Test Money
+title: Testing Payments
 description: Use test assets to make testing integrations easier.
 nav:
   path: Digital Assets
   order: 1
 ---
 
-In order to make testing easier, most Centrapay assets have a “test” variant which can be issued at no cost. In the case of money, issuing the test variant (eg “centrapay.nzd.test”) requires linking a “test” bank account which, instead of going through the banking system, sends transaction notifications to the email address of the initiating user.
-
-The test bank account can be used to create a topup request. The 4-digit bank account verification code, which normally appears in your bank account statement, will be included in the emailed transaction notification.
-
-The test assets can be created via either the Centrapay API or the Centrapay app.
-
-> Test bank accounts count toward resource quotas.
-
-## Via API
-
-To create test dollars via the Centrapay API:
-
-1. Add email to Centrapay profile: If not already configured, set an email on your Centrapay user profile via the [update profile endpoint](/api/profiles/#update-profile).
-2. Create a test bank account: Create a bank account, using “00-“ as the bank account number prefix, via the [create bank account endpoint](/api/bank-accounts/#create-bank-account).
-3. Create a test topup: Use the test bank account id to topup up via the [topup endpoint](/api/funds-transfers/#create-a-top-up). The topup *must* be created with a Centrapay user (ie: authenticated with JWT, not an API key) in order for the transaction email notification to be delivered.
-4. Verify the bank account: Post the 4-digit code from the test transaction confirmation email, along with the test bank account id, to the [verify bank account endpoint](/api/bank-accounts/#verify-bank-account).
+The recommended way to test payment integrations is using the `centrapay.nzd.test` asset. If your integration works with the Centrapay app, it will work with any app on the Centrapay platform.
 
 ## Via Centrapay App
 
-To create test dollars via the Centrapay app:
-
-1. Enable Test Assets: Create a test payment request at [https://app.centrapay.com/test](https://app.centrapay.com/test) . Follow the link to pay the payment request (`https://app.centrapay.com/pay/{id}`) and, when prompted, enable test assets.
-2. Link Test Bank Account: Visit [https://app.centrapay.com/bank-accounts](https://app.centrapay.com/bank-accounts)  and link a bank account using “00-“ as the bank account number prefix.
-3. Topup and Verify: Topup via [https://app.centrapay.com/topup](https://app.centrapay.com/topup)  by choosing the test bank account. You will receive a test transaction confirmation email with a 4-digit code to “verify” the test bank account. After the bank account is verified, the topup amount will be released into your Centrapay account.
+1. **Enable test assets**: Navigate to [https://app.centrapay.com/config](https://app.centrapay.com/config). Under Features, toggle **Test Assets Enabled** on, then tap **Apply Changes**.
+2. **Top up**: Tap **Topup** in the bottom navigation. Select an amount and tap **Topup** — funds are added to your account instantly.
+3. **Pay**: Tap **Scan**, point the camera at a payment QR code, and complete the payment using your test balance.


### PR DESCRIPTION
The test money page was outdated. This PR updates the page to reflect the current method
<img width="884" height="627" alt="image" src="https://github.com/user-attachments/assets/8369a746-a30f-4917-97ec-64b3babc4ef8" />

Testing Steps:
* Go to testing payments page
* See that the changes are reflected