### PR TITLE
Add get patron code by namespace and external id to patron codes page

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -271,6 +271,7 @@ exports[`the build should not break any links 1`] = `
   "/api/patron-codes#create-patron-code",
   "/api/patron-codes#get-patron-code",
   "/api/patron-codes#get-patron-code-by-barcode",
+  "/api/patron-codes#get-patron-code-by-namespace-and-external-id",
   "/api/patron-codes#patron-code-model",
   "/api/payment-activities",
   "/api/payment-links",

--- a/src/content/api/_endpoints/patron-codes-get-by-externalId.js
+++ b/src/content/api/_endpoints/patron-codes-get-by-externalId.js
@@ -1,0 +1,18 @@
+export default {
+  method: 'GET',
+  path: '/api/patron-codes/namespace-test/external-id/3e9003bbff48d',
+  request: {
+    headers: {
+      'X-Api-Key': '<TOKEN>',
+    },
+  },
+  response: {
+    id: 'V17FByEP9gm1shSG6a1Zzx',
+    accountId: 'Jaim1Cu1Q55uooxSens6yk',
+    barcode: '9990001234567895',
+    createdAt: '2021-06-08T22:55:00.000Z',
+    expiresAt: '2021-06-08T23:00:00.000Z',
+    externalId: '3e9003bbff48d',
+    appName: 'centrapay'
+  }
+};

--- a/src/content/api/patron-codes.mdoc
+++ b/src/content/api/patron-codes.mdoc
@@ -38,6 +38,10 @@ A Patron Code is an alternative to presenting a QR code where that option isn’
   {% property name="testScenarioName" type="string" %}
     The [Test Scenario Name](#test-scenario-name) of the Patron Code.
   {% /property %}
+
+  {% property name="externalId" type="string" %}
+    The external Id of the Patron Code.
+  {% /property %}
 {% /properties %}
 
 ✩ Barcode is a 16 digit number. The first 6 digits are a Centrapay defined prefix, then a 9 digit
@@ -119,6 +123,23 @@ be used with Payment Requests that will have a liveness of 'test'. The [Asset Ty
       Luhn checksum digit doesn't pass.
     {% /error %}
 
+    {% error code="403" message="PATRON_CODE_INVALID" %}
+      Patron Code doesn't exist or it has expired.
+    {% /error %}
+  {% /properties %}
+{% /endpoint %}
+
+---
+
+{% endpoint
+  path="/api/patron-codes/{namespace}/external-id/{externalId}"
+  filename="patron-codes-get-by-externalId"
+%}
+  ## Get Patron Code By Namespace and External Id
+
+   This endpoint allows you to retrieve a Patron Code by namespace and external id.
+
+  {% properties heading="Errors" %}
     {% error code="403" message="PATRON_CODE_INVALID" %}
       Patron Code doesn't exist or it has expired.
     {% /error %}


### PR DESCRIPTION
This PR adds the get patron code by namespace and external id to the patron codes page.
Testing steps:
- Open Patron Codes page
- See that: 
  - Patron code model has externalId field; 
  - New section added for the new endpoint: Get Patron Code By Namespace and External Id