### PR TITLE
Fix merchant services search

### DIFF
--- a/src/plugins/flexsearch.js
+++ b/src/plugins/flexsearch.js
@@ -70,7 +70,9 @@ async function createFlexsearchIndexData() {
     .use(remarkHtml);
 
   for (const filepath of await glob.sync('src/content/**/*.{md,mdoc}')) {
-    const href = filepath.replace(/(src\/content)|\.(mdoc?)/g, '');
+    const href = filepath
+      .replace(/(src\/content)|\.(mdoc?)/g, '')
+      .replace(/^\/merchant-services\//, '/guides/');
     const { data: frontMatter, content } = grayMatter(await fs.readFile(filepath));
     const path = [...frontMatter.nav.path.split('/'), frontMatter.nav.title ?? frontMatter.title];
 


### PR DESCRIPTION
Currently there is a bug where the pages in the merchant services section are incorrectly referenced in the search as https://docs.centrapay.com/merchant-services/compatible-solutions instead of https://docs.centrapay.com/guides/compatible-solutions/ this PR fixes that bug

Testing Steps:
* Search compatible solutions
* Click link
* See that the page is correctly displayed