### PR TITLE
Add the in operator

### DIFF
--- a/src/content/api/promotions.mdoc
+++ b/src/content/api/promotions.mdoc
@@ -143,11 +143,11 @@ Promotions are a mechanism to reward accounts for completing certain actions.
   {% /property %}
 
   {% property name="value" type="string" %}
-    The value that the field must satisfy depending on the `operator`.
+    The value that the field must satisfy depending on the `operator`. Must be an array of strings when using the `in` operator.
   {% /property %}
 
   {% property name="operator" type="string" %}
-    The operator to use when looking at the value of the field. Can be `equals`, `not`, `greater-than`, `less-than`.
+    The operator to use when looking at the value of the field. Can be `equals`, `not`, `in`, `greater-than`, `less-than`.
   {% /property %}
 
   {% property name="type" type="string" %}


### PR DESCRIPTION
Adds an `in` operator for promotion conditions. When operator is `in`, value must be a string array.

For the [kari](https://github.com/centrapay/kari/pull/1463) change