### PR TITLE
Add asset id to patron code

### DIFF
--- a/src/content/api/_endpoints/patron-codes-create.js
+++ b/src/content/api/_endpoints/patron-codes-create.js
@@ -12,6 +12,7 @@ export default {
     barcode: '9990001234567895',
     createdAt: '2021-06-08T22:55:00.000Z',
     expiresAt: '2021-06-08T23:00:00.000Z',
-    appName: 'centrapay'
+    appName: 'centrapay',
+    assetId: 'WRhAxxWpTKb5U7pXyxQjjY'
   }
 };

--- a/src/content/api/_endpoints/patron-codes-get-by-barcode.js
+++ b/src/content/api/_endpoints/patron-codes-get-by-barcode.js
@@ -12,6 +12,7 @@ export default {
     barcode: '9990001234567895',
     createdAt: '2021-06-08T22:55:00.000Z',
     expiresAt: '2021-06-08T23:00:00.000Z',
-    appName: 'centrapay'
+    appName: 'centrapay',
+    assetId: 'WRhAxxWpTKb5U7pXyxQjjY'
   }
 };

--- a/src/content/api/_endpoints/patron-codes-get-by-externalId.js
+++ b/src/content/api/_endpoints/patron-codes-get-by-externalId.js
@@ -13,6 +13,7 @@ export default {
     createdAt: '2021-06-08T22:55:00.000Z',
     expiresAt: '2021-06-08T23:00:00.000Z',
     externalId: '3e9003bbff48d',
-    appName: 'centrapay'
+    appName: 'centrapay',
+    assetId: 'WRhAxxWpTKb5U7pXyxQjjY'
   }
 };

--- a/src/content/api/_endpoints/patron-codes-get.js
+++ b/src/content/api/_endpoints/patron-codes-get.js
@@ -12,6 +12,7 @@ export default {
     barcode: '9990001234567895',
     createdAt: '2021-06-08T22:55:00.000Z',
     expiresAt: '2021-06-08T23:00:00.000Z',
-    appName: 'centrapay'
+    appName: 'centrapay',
+    assetId: 'WRhAxxWpTKb5U7pXyxQjjY'
   }
 };

--- a/src/content/api/patron-codes.mdoc
+++ b/src/content/api/patron-codes.mdoc
@@ -23,6 +23,10 @@ A Patron Code is an alternative to presenting a QR code where that option isn’
     Date when the Patron Code was created.
   {% /property %}
 
+  {% property name="assetId" type="string" %}
+    Id of the related asset.
+  {% /property %}
+
   {% property name="expiresAt" type="timestamp" %}
     Date when the Patron Code will expire.
   {% /property %}


### PR DESCRIPTION
We have moved the `assetId` to the top level of the Patron Code we are now returning it on the API response this PR updates the docs to reflect this