### PR TITLE
fix the sidebar scroll

### DIFF
--- a/src/components/Navigation.vue
+++ b/src/components/Navigation.vue
@@ -37,6 +37,7 @@
                     role="menuitem"
                     class="block py-2 pl-6 text-xs text-gray-600"
                     :href="subChild.path"
+                    @click="saveScroll"
                   >
                     {{ subChild.title }}
                   </a>
@@ -69,6 +70,7 @@
                   role="menuitem"
                   class="block py-2 pl-4 text-xs text-gray-600"
                   :href="navigationChild.path"
+                  @click="saveScroll"
                 >
                   {{ navigationChild.title }}
                 </a>
@@ -98,9 +100,28 @@
 </template>
 
 <script setup>
+import { onMounted } from 'vue';
+
 const props = defineProps({
   path: { type: [String, undefined], required: false, default: undefined },
   navigation: { type: Object, required: true },
   showHeadings: { type: Boolean, required: false, default: true },
+});
+
+const saveScroll = () => {
+  const sidebar = document.querySelector('#sidebar-content');
+  if (sidebar) {
+    try { localStorage.setItem('sidebar-scroll', String(sidebar.scrollTop)); }
+    catch {}
+  }
+};
+
+onMounted(() => {
+  const sidebar = document.querySelector('#sidebar-content');
+  if (!sidebar) return;
+  try {
+    const saved = localStorage.getItem('sidebar-scroll');
+    if (saved !== null) sidebar.scrollTop = parseInt(saved, 10);
+  } catch {}
 });
 </script>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,4 +1,5 @@
 ---
+import { ViewTransitions } from 'astro:transitions';
 import AppShell from '../components/AppShell.astro';
 import IntercomButton from '../components/IntercomButton.vue';
 import Footer from '../components/Footer.astro';
@@ -42,6 +43,8 @@ const intercomAppId = import.meta.env.PUBLIC_INTERCOM_APP_ID;
     <meta property="og:image:width" content="1200">
     <meta property="og:image:height" content="630">
     <meta name="twitter:card" content="summary_large_image">
+
+    <ViewTransitions />
 
     <!-- Intercom widget -->
     <meta name="referrer" content="no-referrer-when-downgrade">


### PR DESCRIPTION
Save sidebar scroll position on link click and restore after Vue mounts to prevent jump
Add View Transitions to eliminate full-page flash between navigations

Testing steps:

- Go to Centrapay Docs
- Click any link in the sidebar
- The sidebar should stay at roughly the same position after the new page loads. Since clicking a new link collapses the previously active link's headings, there may be a small upward jump if the previously active link is positioned above the newly clicked link. This will be addressed in a follow-up PR.