### PR TITLE
Add login step to testing payments guide

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -414,8 +414,6 @@ exports[`the build should not break any links 1`] = `
   "/guides/creating-digital-tokens#redemption-conditions",
   "/guides/creating-digital-tokens#token-collection",
   "/guides/creating-test-money",
-  "/guides/creating-test-money#on-this-page-title",
-  "/guides/creating-test-money#via-centrapay-app",
   "/guides/ecommerce-website",
   "/guides/ecommerce-website#backend-server",
   "/guides/ecommerce-website#before-you-begin",

--- a/src/content/guides/creating-test-money.mdoc
+++ b/src/content/guides/creating-test-money.mdoc
@@ -8,8 +8,7 @@ nav:
 
 The recommended way to test payment integrations is using the `centrapay.nzd.test` asset. If your integration works with the Centrapay app, it will work with any app on the Centrapay platform.
 
-## Via Centrapay App
-
-1. **Enable test assets**: Navigate to [https://app.centrapay.com/config](https://app.centrapay.com/config). Under Features, toggle **Test Assets Enabled** on, then tap **Apply Changes**.
-2. **Top up**: Tap **Topup** in the bottom navigation. Select an amount and tap **Topup** — funds are added to your account instantly.
-3. **Pay**: Tap **Scan**, point the camera at a payment QR code, and complete the payment using your test balance.
+1. **Create an account**: Go to [https://app.centrapay.com](https://app.centrapay.com), create an account, and log in.
+2. **Enable test assets**: Navigate to [https://app.centrapay.com/config](https://app.centrapay.com/config). Under Features, toggle **Test Assets Enabled** on, then tap **Apply Changes**. You'll be redirected back to the wallet page, where a **Topup** option is now available.
+3. **Top up**: Tap **Topup** in the bottom navigation. Select an amount and tap **Topup** — funds are added to your account instantly.
+4. **Pay**: Tap **Scan**, point the camera at a payment QR code, and complete the payment using your test balance.


### PR DESCRIPTION
The guide was missing the step to create an account on app.centrpay.com


Testing Steps:
* Merge
* See the updated guide