### PR TITLE
Add merchant metadata endpoint to guides

### DIFF
--- a/src/__tests__/__snapshots__/links.integration.test.js.snap
+++ b/src/__tests__/__snapshots__/links.integration.test.js.snap
@@ -245,6 +245,7 @@ exports[`the build should not break any links 1`] = `
   "/api/merchants#merchant-search-result-model",
   "/api/merchants#product-model",
   "/api/merchants#search-merchants",
+  "/api/merchants#set-merchant-metadata",
   "/api/merchants#set-merchant-onboarding-status",
   "/api/merchants#settlement-config-model",
   "/api/merchants#update-merchant",

--- a/src/content/api/_endpoints/merchants-set-metadata.js
+++ b/src/content/api/_endpoints/merchants-set-metadata.js
@@ -1,0 +1,23 @@
+export default {
+  method: 'POST',
+  path: '/api/merchants/5ee0c486308f590260d9a07f/metadata',
+  request: {
+    headers: {
+      'X-Api-Key': '<TOKEN>',
+      'Content-Type': 'application/json',
+    },
+    payload: {
+      metadata: {
+        deviceId: 'device-001',
+      },
+    },
+  },
+  response: {
+    merchantId: 'MhocUmpxxmgdHjr7DgKoKw',
+    createdAt: '2021-09-12T01:11:22.491Z',
+    createdBy: 'crn:WIj211vFs9cNACwBb04vQw:api-key:MyApiKey',
+    metadata: {
+      deviceId: 'device-001',
+    },
+  },
+};

--- a/src/content/api/merchants.mdoc
+++ b/src/content/api/merchants.mdoc
@@ -71,6 +71,10 @@ which define the payment methods available for a Payment Request.
   {% property name="categoryCode" type="string" %}
     The category code assigned to the Merchant by Centrapay. Must be 4 digits.
   {% /property %}
+
+  {% property name="metadata" type="object" %}
+    Arbitrary key-value data associated with the Merchant. See [Set Merchant Metadata](#set-merchant-metadata).
+  {% /property %}
 {% /properties %}
 
 ### Onboarding Statuses
@@ -295,6 +299,25 @@ which define the payment methods available for a Payment Request.
 
     {% property name="onboardingStatusReason" type="string" %}
       The reason associated with the [Onboarding Status](#onboarding-statuses). Required if the onboardingStatus is `on-hold` or `deactivated`. See [Onboarding Status Reasons](#onboarding-status-reasons) for possible values.
+    {% /property %}
+  {% /properties %}
+{% /endpoint %}
+
+---
+
+{% endpoint
+  path="/api/merchants/{merchantId}/metadata"
+  filename="merchants-set-metadata"
+%}
+  ## Set Merchant Metadata
+
+  This endpoint allows you to set metadata on a Merchant. Metadata is merged with any existing
+  keys — only the keys provided in the request are affected. To remove a key, set its value to an
+  empty string.
+
+  {% properties %}
+    {% property name="metadata" type="object" required=true %}
+      A map of key-value pairs to attach to the Merchant. Keys must be alphanumeric with underscores or dashes (max 64 characters). Values must be strings (max 256 characters). A maximum of 10 keys is allowed.
     {% /property %}
   {% /properties %}
 {% /endpoint %}


### PR DESCRIPTION
Documents the new merchant metadata feature.
### Changes
- Add `merchants-set-metadata.js` endpoint example for `POST /api/merchants/{merchantId}/metadata`.
- Add the `metadata` property to the Merchant Model.
- Add a **Set Merchant Metadata** endpoint section documenting the merge/delete behavior (keys are merged; an empty-string value deletes a key) and the validation constraints (keys alphanumeric with underscores/dashes, max 64 chars; string values max 256 chars; max 10 keys).

### Test plan
- `yarn build && yarn integration` passes (link snapshot updated).
- `yarn lint` and `yarn test` pass.